### PR TITLE
Feat/be#14: 예약·결제 Entity 4개 생성

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,25 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel>
-      <module name="backend" target="17" />
-      <module name="backend.api-server" target="17" />
-      <module name="backend.api-server.main" target="17" />
-      <module name="backend.api-server.test" target="17" />
-      <module name="backend.main" target="17" />
-      <module name="backend.module-ai" target="17" />
-      <module name="backend.module-ai.main" target="17" />
-      <module name="backend.module-ai.test" target="17" />
-      <module name="backend.module-chat" target="17" />
-      <module name="backend.module-chat.main" target="17" />
-      <module name="backend.module-chat.test" target="17" />
-      <module name="backend.module-common" target="17" />
-      <module name="backend.module-common.main" target="17" />
-      <module name="backend.module-common.test" target="17" />
-      <module name="backend.module-domain" target="17" />
-      <module name="backend.module-domain.main" target="17" />
-      <module name="backend.module-domain.test" target="17" />
-      <module name="backend.test" target="17" />
-    </bytecodeTargetLevel>
+    <annotationProcessing>
+      <profile name="Gradle Imported" enabled="true">
+        <outputRelativeToContentRoot value="true" />
+        <processorPath useClasspath="false">
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.38/57f8f5e02e92a30fd21b80cbd426a4172b5f8e29/lombok-1.18.38.jar" />
+        </processorPath>
+        <module name="backend.module-ai.main" />
+        <module name="backend.module-common.main" />
+        <module name="backend.api-server.main" />
+        <module name="backend.module-chat.main" />
+        <module name="backend.module-domain.main" />
+      </profile>
+    </annotationProcessing>
+  </component>
+  <component name="JavacSettings">
+    <option name="ADDITIONAL_OPTIONS_OVERRIDE">
+      <module name="backend" options="-parameters" />
+      <module name="backend.api-server" options="-parameters" />
+      <module name="backend.api-server.main" options="-parameters" />
+      <module name="backend.api-server.test" options="-parameters" />
+      <module name="backend.main" options="-parameters" />
+      <module name="backend.module-ai" options="-parameters" />
+      <module name="backend.module-ai.main" options="-parameters" />
+      <module name="backend.module-ai.test" options="-parameters" />
+      <module name="backend.module-chat" options="-parameters" />
+      <module name="backend.module-chat.main" options="-parameters" />
+      <module name="backend.module-chat.test" options="-parameters" />
+      <module name="backend.module-common" options="-parameters" />
+      <module name="backend.module-common.main" options="-parameters" />
+      <module name="backend.module-common.test" options="-parameters" />
+      <module name="backend.module-domain" options="-parameters" />
+      <module name="backend.module-domain.main" options="-parameters" />
+      <module name="backend.module-domain.test" options="-parameters" />
+      <module name="backend.test" options="-parameters" />
+    </option>
   </component>
 </project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -4,6 +4,7 @@
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/LocalGuest.iml" filepath="$PROJECT_DIR$/.idea/LocalGuest.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/api-server/backend.api-server.main.iml" filepath="$PROJECT_DIR$/.idea/modules/api-server/backend.api-server.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/module-ai/backend.module-ai.main.iml" filepath="$PROJECT_DIR$/.idea/modules/module-ai/backend.module-ai.main.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/module-chat/backend.module-chat.main.iml" filepath="$PROJECT_DIR$/.idea/modules/module-chat/backend.module-chat.main.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/module-common/backend.module-common.main.iml" filepath="$PROJECT_DIR$/.idea/modules/module-common/backend.module-common.main.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/module-domain/backend.module-domain.main.iml" filepath="$PROJECT_DIR$/.idea/modules/module-domain/backend.module-domain.main.iml" />

--- a/.idea/modules/module-ai/backend.module-ai.main.iml
+++ b/.idea/modules/module-ai/backend.module-ai.main.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="AdditionalModuleElements">
+    <content url="file://$MODULE_DIR$/../../../backend/module-ai/build/generated/sources/annotationProcessor/java/main">
+      <sourceFolder url="file://$MODULE_DIR$/../../../backend/module-ai/build/generated/sources/annotationProcessor/java/main" isTestSource="false" generated="true" />
+    </content>
+  </component>
+</module>

--- a/.idea/modules/module-chat/backend.module-chat.main.iml
+++ b/.idea/modules/module-chat/backend.module-chat.main.iml
@@ -4,8 +4,5 @@
     <content url="file://$MODULE_DIR$/../../../backend/module-chat/build/generated/sources/annotationProcessor/java/main">
       <sourceFolder url="file://$MODULE_DIR$/../../../backend/module-chat/build/generated/sources/annotationProcessor/java/main" isTestSource="false" generated="true" />
     </content>
-    <content url="file://$MODULE_DIR$/../../../backend/module-chat/src/main" dumb="true">
-      <sourceFolder url="file://$MODULE_DIR$/../../../backend/module-chat/src/main/resources" type="java-resource" />
-    </content>
   </component>
 </module>

--- a/backend/HELP.md
+++ b/backend/HELP.md
@@ -13,4 +13,3 @@ For further reference, please consider the following sections:
 These additional references should also help you:
 
 * [Gradle Build Scans – insights for your project's build](https://scans.gradle.com#gradle)
-

--- a/backend/api-server/src/main/resources/application.yml
+++ b/backend/api-server/src/main/resources/application.yml
@@ -17,5 +17,6 @@ spring:
       - optional:classpath:/application-chat-prod.yml
 
 server:
+  port: 8080
   servlet:
     context-path: /api

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/entity/MatchRequest.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/entity/MatchRequest.java
@@ -1,0 +1,79 @@
+package com.team6.domain.matching.entity;
+
+import com.team6.domain.matching.entity.enums.MatchRequestStatus;
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "match_request")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
+public class MatchRequest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long requestId;
+
+    // TODO: Member 엔티티 완성 후 @ManyToOne으로 교체
+    @Column(nullable = false)
+    private Long guestId;
+
+    // TODO: GuideProfile 엔티티 완성 후 @ManyToOne으로 교체
+    @Column(nullable = false)
+    private Long guideId;
+
+    @Column(nullable = false)
+    private String destination;         // 여행 목적지
+
+    @Column(columnDefinition = "TEXT")
+    private String concept;             // 여행 컨셉 (AI 분석 원본)
+
+    private LocalDate desiredDate;      // 희망 여행 날짜
+
+    private Integer desiredBudget;      // 희망 예산(원)
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private MatchRequestStatus status;  // 매칭 상태
+
+    @Column(length = 10)
+    private String cancelledBy;         // GUEST or GUIDE
+
+    @Column(columnDefinition = "TEXT")
+    private String cancelReason;        // 취소 사유
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+        this.status = MatchRequestStatus.PENDING;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    // 게스트 취소 처리
+    public void cancelByGuest(String reason) {
+        this.status = MatchRequestStatus.CANCELLED;
+        this.cancelledBy = "GUEST";
+        this.cancelReason = reason;
+    }
+
+    // 가이드 취소 처리
+    public void cancelByGuide(String reason) {
+        this.status = MatchRequestStatus.CANCELLED;
+        this.cancelledBy = "GUIDE";
+        this.cancelReason = reason;
+    }
+}

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/entity/Payment.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/entity/Payment.java
@@ -1,0 +1,82 @@
+package com.team6.domain.matching.entity;
+
+
+import com.team6.domain.matching.entity.enums.PaymentStatus;
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "payment")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
+public class Payment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long paymentId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "request_id", nullable = false)
+    private MatchRequest matchRequest;  // MATCH_REQUEST FK
+
+    // TODO: Member 엔티티 완성 후 @ManyToOne으로 교체
+    @Column(nullable = false)
+    private Long payerId;               // 게스트 MEMBER FK
+
+    @Column(nullable = false)
+    private Integer amount;             // 결제 금액(원)
+
+    @Column(nullable = false, length = 20)
+    private String paymentType;         // CHAT / ACCOMPANY / EXTENSION
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String pgOrderNo;           // PG 주문번호
+
+    @Column(length = 100)
+    private String pgTransactionId;     // PG 거래 ID
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private PaymentStatus status;       // 결제 상태
+
+    private LocalDateTime cancelledAt;  // 취소 처리 일시
+
+    @Column(columnDefinition = "TEXT")
+    private String cancelReason;        // 취소 사유
+
+    private LocalDateTime paidAt;       // 결제 완료일시
+
+    private LocalDateTime refundDeadline; // 환불 마감(paidAt+2h)
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.status = PaymentStatus.PENDING;
+    }
+
+    // 결제 완료 처리 — 환불 마감 자동 계산
+    public void complete(String pgTransactionId) {
+        this.status = PaymentStatus.COMPLETED;
+        this.pgTransactionId = pgTransactionId;
+        this.paidAt = LocalDateTime.now();
+        this.refundDeadline = this.paidAt.plusHours(2); // 환불 마감 = 결제 완료 + 2시간
+    }
+
+    // 취소 처리
+    public void cancel(String reason) {
+        this.status = PaymentStatus.CANCELLED;
+        this.cancelledAt = LocalDateTime.now();
+        this.cancelReason = reason;
+    }
+
+    // 환불 완료 처리
+    public void refund() {
+        this.status = PaymentStatus.REFUNDED;
+    }
+}

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/entity/Refund.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/entity/Refund.java
@@ -1,0 +1,69 @@
+package com.team6.domain.matching.entity;
+
+import com.team6.domain.matching.entity.enums.RefundStatus;
+import com.team6.domain.matching.entity.enums.RefundType;
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "refund")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
+public class Refund {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long refundId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "payment_id", nullable = false)
+    private Payment payment;            // PAYMENT FK
+
+    // TODO: Member 엔티티 완성 후 @ManyToOne으로 교체
+    @Column(nullable = false)
+    private Long requesterId;           // 게스트 MEMBER FK
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private RefundType refundType;      // 환불 발생 원인
+
+    @Column(columnDefinition = "TEXT")
+    private String reason;              // 환불 사유
+
+    @Column(length = 500)
+    private String evidenceUrl;         // 증빙 자료 URL
+
+    @Column(nullable = false)
+    private Boolean aiProcessed;        // AI 처리 반영 여부
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private RefundStatus status;        // 환불 처리 상태
+
+    private LocalDateTime processedAt;  // 처리 완료일
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.status = RefundStatus.PENDING;
+        this.aiProcessed = false;
+    }
+
+    // 환불 승인
+    public void approve() {
+        this.status = RefundStatus.APPROVED;
+        this.processedAt = LocalDateTime.now();
+    }
+
+    // 환불 거절
+    public void reject() {
+        this.status = RefundStatus.REJECTED;
+        this.processedAt = LocalDateTime.now();
+    }
+}

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/entity/TourExtension.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/entity/TourExtension.java
@@ -1,0 +1,71 @@
+package com.team6.domain.matching.entity;
+
+import com.team6.domain.matching.entity.enums.TourExtensionStatus;
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "tour_extension")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
+public class TourExtension {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long extensionId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "request_id", nullable = false)
+    private MatchRequest matchRequest;  // MATCH_REQUEST FK
+
+    // TODO: Member 엔티티 완성 후 @ManyToOne으로 교체
+    @Column(nullable = false)
+    private Long guestId;               // 게스트 MEMBER FK
+
+    @Column(nullable = false)
+    private LocalDate extendedDate;     // 연장 날짜
+
+    private Integer extendedPrice;      // 연장 요금(원)
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private TourExtensionStatus status; // 연장 신청 상태
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime requestedAt;  // 신청일시
+
+    private LocalDateTime guideApprovedAt; // 가이드 승인 일시
+
+    @Column(nullable = false)
+    private LocalDateTime deadlineAt;   // 선택 마감 당일 23:59:59
+
+    private LocalDateTime autoCancelledAt; // 자동 미연장 처리 일시
+
+    @PrePersist
+    protected void onCreate() {
+        this.requestedAt = LocalDateTime.now();
+        this.status = TourExtensionStatus.REQUESTED;
+    }
+
+    // 가이드 승인
+    public void approveByGuide(Integer price) {
+        this.status = TourExtensionStatus.GUIDE_APPROVED;
+        this.guideApprovedAt = LocalDateTime.now();
+        this.extendedPrice = price;
+    }
+
+    // 자동 취소 (23:59:59 초과)
+    public void autoCancel() {
+        this.status = TourExtensionStatus.AUTO_CANCELLED;
+        this.autoCancelledAt = LocalDateTime.now();
+    }
+
+    // 연장 결제 완료
+    public void completePay() {
+        this.status = TourExtensionStatus.PAID;
+    }
+}


### PR DESCRIPTION
# 🔗 이슈 번호
- Closes #14 

---

## 💡 주요 변경 사항
- MatchRequest, Payment, Refund, TourExtension Entity 4개 생성
- 각 Entity에 비즈니스 로직 메서드 포함
  - MatchRequest: cancelByGuest(), cancelByGuide()
  - Payment: complete(), cancel(), refund()
  - Refund: approve(), reject()
  - TourExtension: approveByGuide(), autoCancel(), completePay()
- @PrePersist로 createdAt, status 초기값 자동 설정
- Member/GuideProfile FK는 Long 타입으로 임시 선언 (TODO 주석 표시)

---

## ⚠️ 주의 사항 / 질문
- Member, GuideProfile 엔티티 완성 후 Long 타입 FK를 @ManyToOne으로 교체 필요
  - MatchRequest.guestId, guideId
  - Payment.payerId
  - Refund.requesterId
  - TourExtension.guestId
- ddl-auto: update로 앱 실행 시 테이블 자동 생성되는 방식으로 schema.sql 미작성

---

## ✅ 체크리스트
- [x ] 빌드가 정상적으로 되는가?
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [x] .gitignore에 설정 파일이 잘 포함되었는가? (application-local.yml 등)