### PR TITLE
Feat/be#17: 예약·결제 Repository 4개 생성

### DIFF
--- a/backend/module-domain/src/main/java/com/team6/domain/matching/repository/MatchRequestRepository.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/repository/MatchRequestRepository.java
@@ -1,0 +1,21 @@
+package com.team6.domain.matching.repository;
+
+import com.team6.domain.matching.entity.MatchRequest;
+import com.team6.domain.matching.entity.enums.MatchRequestStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface MatchRequestRepository extends JpaRepository<MatchRequest, Long> {
+
+    // 게스트 ID로 전체 매칭 요청 조회
+    List<MatchRequest> findByGuestId(Long guestId);
+
+    // 가이드 ID로 전체 매칭 요청 조회
+    List<MatchRequest> findByGuideId(Long guideId);
+
+    // 게스트 ID + 상태로 조회 (진행중인 투어 확인용)
+    List<MatchRequest> findByGuestIdAndStatus(Long guestId, MatchRequestStatus status);
+
+    // 가이드 ID + 상태로 조회
+    List<MatchRequest> findByGuideIdAndStatus(Long guideId, MatchRequestStatus status);
+}

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/repository/PaymentRepository.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/repository/PaymentRepository.java
@@ -1,0 +1,22 @@
+package com.team6.domain.matching.repository;
+
+import com.team6.domain.matching.entity.Payment;
+import com.team6.domain.matching.entity.enums.PaymentStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+import java.util.Optional;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+
+    // 매칭 요청 ID로 결제 목록 조회
+    List<Payment> findByMatchRequest_RequestId(Long requestId);
+
+    // 게스트 ID로 결제 내역 조회
+    List<Payment> findByPayerId(Long payerId);
+
+    // PG 주문번호로 단건 조회 (결제 검증용)
+    Optional<Payment> findByPgOrderNo(String pgOrderNo);
+
+    // 게스트 ID + 상태로 조회
+    List<Payment> findByPayerIdAndStatus(Long payerId, PaymentStatus status);
+}

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/repository/RefundRepository.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/repository/RefundRepository.java
@@ -1,0 +1,19 @@
+package com.team6.domain.matching.repository;
+
+import com.team6.domain.matching.entity.Refund;
+import com.team6.domain.matching.entity.enums.RefundStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+import java.util.Optional;
+
+public interface RefundRepository extends JpaRepository<Refund, Long> {
+
+    // 결제 ID로 환불 조회 (중복 신청 방지용)
+    Optional<Refund> findByPayment_PaymentId(Long paymentId);
+
+    // 신청자 ID로 환불 내역 조회
+    List<Refund> findByRequesterId(Long requesterId);
+
+    // 상태별 환불 목록 조회 (관리자용)
+    List<Refund> findByStatus(RefundStatus status);
+}

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/repository/TourExtensionRepository.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/repository/TourExtensionRepository.java
@@ -1,0 +1,23 @@
+package com.team6.domain.matching.repository;
+
+import com.team6.domain.matching.entity.TourExtension;
+import com.team6.domain.matching.entity.enums.TourExtensionStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface TourExtensionRepository extends JpaRepository<TourExtension, Long> {
+
+    // 매칭 요청 ID로 연장 신청 조회
+    Optional<TourExtension> findByMatchRequest_RequestId(Long requestId);
+
+    // 게스트 ID로 연장 신청 목록 조회
+    List<TourExtension> findByGuestId(Long guestId);
+
+    // 자동 취소 스케줄러용 - 마감 지났는데 아직 REQUESTED 상태인 것들
+    List<TourExtension> findByStatusAndDeadlineAtBefore(
+            TourExtensionStatus status,
+            LocalDateTime now
+    );
+}


### PR DESCRIPTION
# 🔗 이슈 번호
- Closes #17 

---

## 💡 주요 변경 사항
- MatchRequest, Payment, Refund, TourExtension Repository 4개 생성
- JPA 네이밍 쿼리로 주요 조회 메서드 구현
  - findByGuestId, findByGuideId (매칭 요청 조회)
  - findByPgOrderNo (PG 주문번호로 결제 단건 조회)
  - findByPayment_PaymentId (중복 환불 신청 방지)
  - findByStatusAndDeadlineAtBefore (F05-03 자동 취소 스케줄러용)

---

## ⚠️ 주의 사항 / 질문
- findByMatchRequest_RequestId 처럼 연관 엔티티 탐색 시
  언더스코어(_) 네이밍 규칙 사용했는데 팀 컨벤션과 맞는지 확인 부탁드립니다
- 복잡한 조회(결제 내역 목록 등)는 추후 MyBatis Mapper로 별도 구현 예정

---

## ✅ 체크리스트
- [x] 빌드가 정상적으로 되는가?
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [x] .gitignore에 설정 파일이 잘 포함되었는가? (application-local.yml 등)