### PR TITLE
Feat/be#18: 예약·결제 Dto 6개 생성

### DIFF
--- a/backend/module-domain/src/main/java/com/team6/domain/matching/dto/CancelRequestDto.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/dto/CancelRequestDto.java
@@ -1,0 +1,12 @@
+package com.team6.domain.matching.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CancelRequestDto {
+
+    private Long requestId;     // 매칭 요청 ID
+    private String cancelReason; // 취소 사유
+}

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/dto/PaymentResponseDto.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/dto/PaymentResponseDto.java
@@ -1,0 +1,33 @@
+package com.team6.domain.matching.dto;
+
+import com.team6.domain.matching.entity.Payment;
+import com.team6.domain.matching.entity.enums.PaymentStatus;
+import lombok.Builder;
+import lombok.Getter;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class PaymentResponseDto {
+
+    private Long paymentId;              // 결제 ID
+    private Long requestId;              // 매칭 요청 ID
+    private Integer amount;              // 결제 금액
+    private String paymentType;          // CHAT/ACCOMPANY/EXTENSION
+    private PaymentStatus status;        // 결제 상태
+    private LocalDateTime paidAt;        // 결제 완료일시
+    private LocalDateTime refundDeadline; // 환불 마감일시
+
+    // Entity → DTO 변환
+    public static PaymentResponseDto from(Payment payment) {
+        return PaymentResponseDto.builder()
+                .paymentId(payment.getPaymentId())
+                .requestId(payment.getMatchRequest().getRequestId())
+                .amount(payment.getAmount())
+                .paymentType(payment.getPaymentType())
+                .status(payment.getStatus())
+                .paidAt(payment.getPaidAt())
+                .refundDeadline(payment.getRefundDeadline())
+                .build();
+    }
+}

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/dto/RefundRequestDto.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/dto/RefundRequestDto.java
@@ -1,0 +1,13 @@
+package com.team6.domain.matching.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RefundRequestDto {
+
+    private Long paymentId;      // 결제 ID
+    private String reason;       // 환불 사유
+    private String evidenceUrl;  // 증빙 자료 URL (선택)
+}

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/dto/RefundResponseDto.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/dto/RefundResponseDto.java
@@ -1,0 +1,30 @@
+package com.team6.domain.matching.dto;
+
+import com.team6.domain.matching.entity.Refund;
+import com.team6.domain.matching.entity.enums.RefundStatus;
+import com.team6.domain.matching.entity.enums.RefundType;
+import lombok.Builder;
+import lombok.Getter;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class RefundResponseDto {
+
+    private Long refundId;           // 환불 ID
+    private Long paymentId;          // 결제 ID
+    private RefundType refundType;   // 환불 유형
+    private RefundStatus status;     // 환불 상태
+    private LocalDateTime processedAt; // 처리 완료일시
+
+    // Entity → DTO 변환
+    public static RefundResponseDto from(Refund refund) {
+        return RefundResponseDto.builder()
+                .refundId(refund.getRefundId())
+                .paymentId(refund.getPayment().getPaymentId())
+                .refundType(refund.getRefundType())
+                .status(refund.getStatus())
+                .processedAt(refund.getProcessedAt())
+                .build();
+    }
+}

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/dto/TourExtensionRequestDto.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/dto/TourExtensionRequestDto.java
@@ -1,0 +1,13 @@
+package com.team6.domain.matching.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+public class TourExtensionRequestDto {
+
+    private Long requestId;          // 매칭 요청 ID
+    private LocalDate extendedDate;  // 연장 날짜
+}

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/dto/TourExtensionResponseDto.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/dto/TourExtensionResponseDto.java
@@ -1,0 +1,32 @@
+package com.team6.domain.matching.dto;
+
+import com.team6.domain.matching.entity.TourExtension;
+import com.team6.domain.matching.entity.enums.TourExtensionStatus;
+import lombok.Builder;
+import lombok.Getter;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class TourExtensionResponseDto {
+
+    private Long extensionId;            // 연장 신청 ID
+    private Long requestId;              // 매칭 요청 ID
+    private LocalDate extendedDate;      // 연장 날짜
+    private Integer extendedPrice;       // 연장 요금
+    private TourExtensionStatus status;  // 연장 상태
+    private LocalDateTime deadlineAt;    // 선택 마감일시
+
+    // Entity → DTO 변환
+    public static TourExtensionResponseDto from(TourExtension extension) {
+        return TourExtensionResponseDto.builder()
+                .extensionId(extension.getExtensionId())
+                .requestId(extension.getMatchRequest().getRequestId())
+                .extendedDate(extension.getExtendedDate())
+                .extendedPrice(extension.getExtendedPrice())
+                .status(extension.getStatus())
+                .deadlineAt(extension.getDeadlineAt())
+                .build();
+    }
+}


### PR DESCRIPTION
# 🔗 이슈 번호
- Closes #18 

---

## 💡 주요 변경 사항
- F05 기능별 Request/Response DTO 6개 생성
  - Request: CancelRequestDto, RefundRequestDto, TourExtensionRequestDto
  - Response: PaymentResponseDto, RefundResponseDto, TourExtensionResponseDto
- Response DTO에 Entity → DTO 변환 메서드 from() 포함
  - Service에서 Entity를 바로 DTO로 변환 가능

---

## ⚠️ 주의 사항 / 질문
- Request DTO 검증 어노테이션(@NotNull 등)은 Controller 작성 시 추가 예정

---

## ✅ 체크리스트
- [x] 빌드가 정상적으로 되는가?
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [x] .gitignore에 설정 파일이 잘 포함되었는가? (application-local.yml 등)