### PR TITLE
Feat/be#24 : 사용자 프롬프트 기반 가이드 추천 기능 구현 (PromptParser + RecommendationService)

### DIFF
--- a/backend/module-ai/src/main/java/com/team6/module/ai/parser/PromptParser.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/parser/PromptParser.java
@@ -1,0 +1,111 @@
+package com.team6.module.ai.parser;
+
+import com.team6.module.ai.dto.request.GuideRecommendRequest;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+@Component
+public class PromptParser {
+
+    public GuideRecommendRequest parse(
+            String prompt,
+            List<GuideRecommendRequest.GuideCandidateDto> guideCandidates
+    ) {
+        String normalizedPrompt = normalize(prompt);
+
+        String region = extractRegion(normalizedPrompt);
+        String travelStyle = extractTravelStyle(normalizedPrompt);
+        String budgetLevel = extractBudgetLevel(normalizedPrompt);
+        String companionType = extractCompanionType(normalizedPrompt);
+        List<String> activityTags = extractActivityTags(normalizedPrompt);
+        List<String> preferredLanguages = extractLanguages(normalizedPrompt);
+
+        return GuideRecommendRequest.builder()
+                .region(region)
+                .travelStyle(travelStyle)
+                .budgetLevel(budgetLevel)
+                .companionType(companionType)
+                .activityTags(activityTags)
+                .preferredLanguages(preferredLanguages)
+                .topN(3)
+                .guideCandidates(guideCandidates)
+                .build();
+    }
+
+    private String normalize(String prompt) {
+        if (prompt == null) {
+            return "";
+        }
+        return prompt.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private String extractRegion(String prompt) {
+        if (containsAny(prompt, "부산")) return "부산";
+        if (containsAny(prompt, "서울")) return "서울";
+        if (containsAny(prompt, "제주", "제주도")) return "제주";
+        if (containsAny(prompt, "강릉")) return "강릉";
+        if (containsAny(prompt, "경주")) return "경주";
+        return null;
+    }
+
+    private String extractTravelStyle(String prompt) {
+        if (containsAny(prompt, "감성", "감성적인")) return "감성";
+        if (containsAny(prompt, "액티비티", "활동적인", "신나게", "역동적인")) return "액티비티";
+        if (containsAny(prompt, "조용", "힐링", "편안", "여유")) return "힐링";
+        if (containsAny(prompt, "로컬", "현지", "동네 느낌")) return "로컬";
+        return null;
+    }
+
+    private String extractBudgetLevel(String prompt) {
+        if (containsAny(prompt, "저렴", "가성비", "싸게", "예산 적게")) return "낮음";
+        if (containsAny(prompt, "적당", "무난", "보통", "중간")) return "중간";
+        if (containsAny(prompt, "럭셔리", "고급", "비싸도", "프리미엄")) return "높음";
+        return null;
+    }
+
+    private String extractCompanionType(String prompt) {
+        if (containsAny(prompt, "혼자", "혼행", "1인")) return "혼자";
+        if (containsAny(prompt, "친구", "친구랑")) return "친구";
+        if (containsAny(prompt, "가족", "부모님", "엄마", "아빠")) return "가족";
+        if (containsAny(prompt, "연인", "커플", "여자친구", "남자친구")) return "연인";
+        return null;
+    }
+
+    private List<String> extractActivityTags(String prompt) {
+        List<String> tags = new ArrayList<>();
+
+        if (containsAny(prompt, "카페")) tags.add("카페");
+        if (containsAny(prompt, "야경", "밤거리")) tags.add("야경");
+        if (containsAny(prompt, "맛집", "먹방", "음식", "식도락")) tags.add("맛집");
+        if (containsAny(prompt, "산책", "걷기", "걷고")) tags.add("산책");
+        if (containsAny(prompt, "등산", "트레킹")) tags.add("등산");
+        if (containsAny(prompt, "사진", "포토", "인생샷")) tags.add("사진");
+        if (containsAny(prompt, "쇼핑")) tags.add("쇼핑");
+        if (containsAny(prompt, "바다", "해변", "오션뷰")) tags.add("바다");
+
+        return tags;
+    }
+
+    private List<String> extractLanguages(String prompt) {
+        List<String> languages = new ArrayList<>();
+
+        if (containsAny(prompt, "한국어")) languages.add("한국어");
+        if (containsAny(prompt, "영어", "english")) languages.add("영어");
+        if (containsAny(prompt, "일본어", "japanese")) languages.add("일본어");
+        if (containsAny(prompt, "중국어", "chinese")) languages.add("중국어");
+
+        return languages;
+    }
+
+    private boolean containsAny(String prompt, String... keywords) {
+        for (String keyword : keywords) {
+            if (prompt.contains(keyword.toLowerCase(Locale.ROOT))) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
@@ -1,0 +1,25 @@
+package com.team6.module.ai.service;
+
+import com.team6.module.ai.dto.request.GuideRecommendRequest;
+import com.team6.module.ai.dto.response.GuideRecommendResponse;
+import com.team6.module.ai.parser.PromptParser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PromptRecommendationService {
+
+    private final PromptParser promptParser;
+    private final AiRecommendationService aiRecommendationService;
+
+    public GuideRecommendResponse recommendByPrompt(
+            String prompt,
+            List<GuideRecommendRequest.GuideCandidateDto> guideCandidates
+    ) {
+        GuideRecommendRequest request = promptParser.parse(prompt, guideCandidates);
+        return aiRecommendationService.recommend(request);
+    }
+}

--- a/backend/module-ai/src/test/java/com/team6/module/ai/parser/PromptParserTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/parser/PromptParserTest.java
@@ -1,0 +1,26 @@
+package com.team6.module.ai.parser;
+
+import com.team6.module.ai.dto.request.GuideRecommendRequest;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PromptParserTest {
+
+    private final PromptParser promptParser = new PromptParser();
+
+    @Test
+    void parse_should_extract_keywords_from_prompt() {
+        String prompt = "부산에서 혼자 감성 카페 여행하고 싶고 영어 가능한 가이드면 좋겠어요";
+
+        GuideRecommendRequest request = promptParser.parse(prompt, List.of());
+
+        assertThat(request.getRegion()).isEqualTo("부산");
+        assertThat(request.getCompanionType()).isEqualTo("혼자");
+        assertThat(request.getTravelStyle()).isEqualTo("감성");
+        assertThat(request.getActivityTags()).contains("카페");
+        assertThat(request.getPreferredLanguages()).contains("영어");
+    }
+}


### PR DESCRIPTION
# 🔗 이슈 번호

* Closes #24

---

## 💡 주요 변경 사항

* PromptParser 추가

  * 사용자 자연어 프롬프트에서 지역, 여행 스타일, 예산, 동행 유형, 활동 태그, 언어 등 키워드 기반 추출
* PromptRecommendationService 추가

  * 프롬프트 → GuideRecommendRequest 변환 후 기존 추천 엔진과 연동
* 기존 AiRecommendationService와 통합하여 프롬프트 기반 추천 흐름 완성

---

## ⚙️ 상세 구현 내용

* 키워드 기반 파싱 방식 적용 (contains 기반)
* 추천 로직은 기존 MatchingEngine + ScoreCalculator 재사용
* topN 기준 추천 결과 제한 유지

---

## 🧪 테스트

* PromptParserTest

  * 프롬프트 입력 → 조건 추출 검증
* AiRecommendationServiceTest

  * 추천 결과 정렬 검증
  * 후보 없음 예외 처리
  * topN 제한 테스트

---

## ⚠️ 주의 사항 / 개선 포인트

* 현재 프롬프트 해석은 키워드 기반으로 단순 구현
* 복잡한 자연어 해석은 한계 존재
* 향후 LLM 기반 또는 NLP 개선 가능

---

## ✅ 체크리스트

* [x] 빌드가 정상적으로 되는가?
* [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
* [x] .gitignore에 설정 파일이 잘 포함되었는가?
