### PR TITLE
Feat/be#26: 추천 API controller 및 요청 흐름 구현

### DIFF
--- a/backend/api-server/src/main/java/com/team6/apiserver/controller/AiController.java
+++ b/backend/api-server/src/main/java/com/team6/apiserver/controller/AiController.java
@@ -1,0 +1,23 @@
+package com.team6.apiserver.controller;
+
+import com.team6.apiserver.dto.request.PromptRecommendApiRequest;
+import com.team6.module.ai.dto.response.GuideRecommendResponse;
+import com.team6.module.ai.service.PromptRecommendationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/ai")
+public class AiController {
+
+    private final PromptRecommendationService promptRecommendationService;
+
+    @PostMapping("/recommend")
+    public GuideRecommendResponse recommend(@RequestBody PromptRecommendApiRequest request) {
+        return promptRecommendationService.recommendByPrompt(
+                request.getPrompt(),
+                request.getGuideCandidates()
+        );
+    }
+}

--- a/backend/api-server/src/main/java/com/team6/apiserver/dto/request/PromptRecommendApiRequest.java
+++ b/backend/api-server/src/main/java/com/team6/apiserver/dto/request/PromptRecommendApiRequest.java
@@ -1,0 +1,14 @@
+package com.team6.apiserver.dto.request;
+
+import com.team6.module.ai.dto.request.GuideRecommendRequest;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class PromptRecommendApiRequest {
+    private String prompt;
+    private List<GuideRecommendRequest.GuideCandidateDto> guideCandidates;
+}


### PR DESCRIPTION
# 🔗 이슈 번호

* Closes #26

---

## 💡 주요 변경 사항

* api-server에 추천 API 엔드포인트 추가
* 프롬프트 기반 추천 요청 DTO 추가
* PromptRecommendationService와 api-server 연동
* 프론트/외부 요청 → 프롬프트 파싱 → 추천 결과 반환 흐름 연결

---

## ⚠️ 주의 사항 / 질문

* 현재 요청 구조에서 guideCandidates를 함께 받는 형태로 구현
* 추후 가이드 후보 데이터를 DB 또는 별도 서비스에서 조회하는 방식으로 변경 가능

---

## ✅ 체크리스트

* [x] 빌드가 정상적으로 되는가?
* [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
* [x] .gitignore에 설정 파일이 잘 포함되었는가?
