### PR TITLE
Feat/be#28: 외부 가이드 데이터 연동 구조 및 추천 흐름 개선

### DIFF
--- a/backend/api-server/src/main/java/com/team6/apiserver/controller/AiController.java
+++ b/backend/api-server/src/main/java/com/team6/apiserver/controller/AiController.java
@@ -1,10 +1,14 @@
 package com.team6.apiserver.controller;
 
 import com.team6.apiserver.dto.request.PromptRecommendApiRequest;
+import com.team6.apiserver.service.GuideCandidateProvider;
+import com.team6.module.ai.dto.request.GuideRecommendRequest;
 import com.team6.module.ai.dto.response.GuideRecommendResponse;
 import com.team6.module.ai.service.PromptRecommendationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -12,12 +16,16 @@ import org.springframework.web.bind.annotation.*;
 public class AiController {
 
     private final PromptRecommendationService promptRecommendationService;
+    private final GuideCandidateProvider guideCandidateProvider;
 
     @PostMapping("/recommend")
     public GuideRecommendResponse recommend(@RequestBody PromptRecommendApiRequest request) {
+        List<GuideRecommendRequest.GuideCandidateDto> candidates =
+                guideCandidateProvider.getCandidates(request.getGuideCandidates());
+
         return promptRecommendationService.recommendByPrompt(
                 request.getPrompt(),
-                request.getGuideCandidates()
+                candidates
         );
     }
 }

--- a/backend/api-server/src/main/java/com/team6/apiserver/service/GuideCandidateProvider.java
+++ b/backend/api-server/src/main/java/com/team6/apiserver/service/GuideCandidateProvider.java
@@ -1,0 +1,11 @@
+package com.team6.apiserver.service;
+
+import com.team6.module.ai.dto.request.GuideRecommendRequest;
+
+import java.util.List;
+
+public interface GuideCandidateProvider {
+    List<GuideRecommendRequest.GuideCandidateDto> getCandidates(
+            List<GuideRecommendRequest.GuideCandidateDto> candidates
+    );
+}

--- a/backend/api-server/src/main/java/com/team6/apiserver/service/RequestGuideCandidateProvider.java
+++ b/backend/api-server/src/main/java/com/team6/apiserver/service/RequestGuideCandidateProvider.java
@@ -1,0 +1,17 @@
+package com.team6.apiserver.service;
+
+import com.team6.module.ai.dto.request.GuideRecommendRequest;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class RequestGuideCandidateProvider implements GuideCandidateProvider {
+
+    @Override
+    public List<GuideRecommendRequest.GuideCandidateDto> getCandidates(
+            List<GuideRecommendRequest.GuideCandidateDto> candidates
+    ) {
+        return candidates == null ? List.of() : candidates;
+    }
+}


### PR DESCRIPTION
# 🔗 이슈 번호

* Closes #28

---

## 💡 주요 변경 사항

* 외부 가이드 데이터 연동을 고려한 추천 흐름 정리
* guideCandidates 기반 추천 구조 유지
* GuideCandidateProvider 추가를 통한 후보 데이터 주입 구조 분리
* PromptRecommendationService와 API 흐름 연결 개선

---

## ⚠️ 주의 사항 / 질문

* 가이드 프로필 시스템은 별도 담당 영역이므로 DB 엔티티/레포지토리 직접 구현은 제외
* 현재는 외부 입력 또는 request 기반으로 guideCandidates를 받는 구조
* 추후 가이드 프로필 시스템 API 연동 시 provider 교체 예정

---

## ✅ 체크리스트

* [x] 빌드가 정상적으로 되는가?
* [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
* [x] .gitignore에 설정 파일이 잘 포함되었는가?
