### PR TITLE
Feat/be#30: guide domain entity 생성 (GuideProfile, GuideImage, GuideCa…

### DIFF
--- a/backend/module-domain/src/main/java/com/team6/domain/guide/entity/GuideCareer.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/entity/GuideCareer.java
@@ -1,0 +1,37 @@
+package com.team6.domain.guide.entity;
+
+import com.team6.module.common.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+/**
+ * 가이드 경력/자격 엔티티 (guide_careers 테이블)
+ */
+@Entity
+@Table(name = "guide_careers")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
+public class GuideCareer extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "career_id")
+    private Long careerId; // 경력 고유 ID (PK)
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "guide_id", nullable = false)
+    private GuideProfile guideProfile; // 가이드 프로필 (guide_profiles FK)
+
+    @Column(nullable = false, length = 100)
+    private String title; // 자격/경력명
+
+    @Column(columnDefinition = "TEXT")
+    private String description; // 자격/경력 설명
+
+    @Column(name = "acquired_at", nullable = false)
+    private LocalDate acquiredAt; // 자격 취득일
+}

--- a/backend/module-domain/src/main/java/com/team6/domain/guide/entity/GuideImage.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/entity/GuideImage.java
@@ -1,0 +1,33 @@
+package com.team6.domain.guide.entity;
+
+import com.team6.module.common.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * 가이드 이미지 엔티티 (guide_images 테이블)
+ */
+@Entity
+@Table(name = "guide_images")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
+public class GuideImage extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "image_id")
+    private Long imageId; // 이미지 고유 ID (PK)
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "guide_id", nullable = false)
+    private GuideProfile guideProfile; // 가이드 프로필 (guide_profiles FK)
+
+    @Column(name = "image_url", nullable = false, length = 500)
+    private String imageUrl; // 이미지 저장 URL
+
+    @Column(name = "sort_order", nullable = false)
+    @Builder.Default
+    private Integer sortOrder = 0; // 이미지 정렬 순서
+}

--- a/backend/module-domain/src/main/java/com/team6/domain/guide/entity/GuideProfile.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/entity/GuideProfile.java
@@ -1,0 +1,73 @@
+package com.team6.domain.guide.entity;
+
+import com.team6.module.common.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+/**
+ * 가이드 프로필 엔티티 (guide_profiles 테이블)
+ */
+@Entity
+@Table(name = "guide_profiles")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
+public class GuideProfile extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "guide_id")
+    private Long guideId; // 가이드 프로필 고유 ID (PK)
+
+    @Column(name = "user_id", nullable = false, unique = true)
+    private Long userId; // 회원 ID (JWT에서 추출, 엔티티 직접 참조 금지)
+
+    @Column(nullable = false, length = 50)
+    private String nickname; // 가이드 닉네임
+
+    @Column(name = "profile_image", length = 500)
+    private String profileImage; // 프로필 이미지 URL
+
+    @Column(columnDefinition = "TEXT")
+    private String bio; // 자기소개
+
+    @Column(nullable = false, length = 100)
+    private String region; // 활동 지역
+
+    @Column(length = 50)
+    private String language; // 구사 가능 언어
+
+    @Column(name = "price_per_hour", precision = 10, scale = 2)
+    private BigDecimal pricePerHour; // 시간당 가격
+
+    @Column(name = "average_rating", precision = 3, scale = 2)
+    @Builder.Default
+    private BigDecimal averageRating = BigDecimal.ZERO; // 평균 평점
+
+    @Column(name = "review_count", nullable = false)
+    @Builder.Default
+    private Integer reviewCount = 0; // 리뷰 수
+
+    @Column(name = "is_approved", nullable = false)
+    @Builder.Default
+    private Boolean isApproved = false; // 관리자 승인 여부
+
+    @Column(name = "is_active", nullable = false)
+    @Builder.Default
+    private Boolean isActive = true; // 활성화 여부
+
+    // 수정 가능한 필드 업데이트
+    public void update(String nickname, String profileImage, String bio,
+                       String region, String language, BigDecimal pricePerHour, Boolean isActive) {
+        this.nickname = nickname;
+        this.profileImage = profileImage;
+        this.bio = bio;
+        this.region = region;
+        this.language = language;
+        this.pricePerHour = pricePerHour;
+        this.isActive = isActive;
+    }
+}


### PR DESCRIPTION

# 🔗 이슈 번호
- Closes #30 


---

## 💡 주요 변경 사항
작업한 핵심 내용을 간단히 요약해 주세요.  

GuideProfile, GuideImage, GuideCareer 엔티티 생성
- ERD 기준 컬럼 반영
- BaseTimeEntity 상속
- GuideImage, GuideCareer ,GuideProfile 

---

## ⚠️ 주의 사항 / 질문


## ✅ 체크리스트
- [x] 빌드가 정상적으로 되는가?
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [x] .gitignore에 설정 파일이 잘 포함되었는가? (application-local.yml 등)