### PR TITLE
Feat/be#32: 매칭 요청 도메인 및 상태 흐름 설계

### DIFF
--- a/backend/api-server/src/main/java/com/team6/apiserver/constant/MatchStatus.java
+++ b/backend/api-server/src/main/java/com/team6/apiserver/constant/MatchStatus.java
@@ -1,0 +1,9 @@
+package com.team6.apiserver.constant;
+
+public enum MatchStatus {
+    REQUESTED,        // 게스트가 가이드에게 매칭 요청 보냄
+    GUIDE_ACCEPTED,   // 가이드가 요청 수락
+    GUIDE_REJECTED,   // 가이드가 요청 거절
+    GUEST_CONFIRMED,  // 게스트가 최종 수락
+    GUEST_REJECTED    // 게스트가 최종 거절
+}

--- a/backend/api-server/src/main/java/com/team6/apiserver/controller/AiController.java
+++ b/backend/api-server/src/main/java/com/team6/apiserver/controller/AiController.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/ai")
+@RequestMapping("/ai")
 public class AiController {
 
     private final PromptRecommendationService promptRecommendationService;

--- a/backend/api-server/src/main/java/com/team6/apiserver/entity/MatchRequest.java
+++ b/backend/api-server/src/main/java/com/team6/apiserver/entity/MatchRequest.java
@@ -1,0 +1,53 @@
+package com.team6.apiserver.entity;
+
+import com.team6.apiserver.constant.MatchStatus;
+import com.team6.module.common.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "match_requests")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class MatchRequest extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "match_request_id")
+    private Long id;
+
+    @Column(name = "guest_id", nullable = false)
+    private Long guestId;
+
+    @Column(name = "guide_id", nullable = false)
+    private Long guideId;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String prompt;
+
+    @Column(name = "ai_summary", columnDefinition = "TEXT")
+    private String aiSummary;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    @Builder.Default
+    private MatchStatus status = MatchStatus.REQUESTED;
+
+    public void guideAccept() {
+        this.status = MatchStatus.GUIDE_ACCEPTED;
+    }
+
+    public void guideReject() {
+        this.status = MatchStatus.GUIDE_REJECTED;
+    }
+
+    public void guestConfirm() {
+        this.status = MatchStatus.GUEST_CONFIRMED;
+    }
+
+    public void guestReject() {
+        this.status = MatchStatus.GUEST_REJECTED;
+    }
+}


### PR DESCRIPTION
# 🔗 이슈 번호

* Closes #32

---

## 💡 주요 변경 사항

* MatchRequest 엔티티 추가
* MatchStatus enum 정의
* 매칭 요청 상태 흐름 설계 (REQUESTED → GUIDE_ACCEPTED/REJECTED → GUEST_CONFIRMED/REJECTED)
* 게스트-가이드 매칭 요청을 위한 기본 도메인 구조 구성

---

## ⚙️ 설계 의도

* 추천 결과를 실제 매칭 요청으로 연결하기 위한 최소 도메인 모델 구성
* GuideProfile, Member 등 외부 도메인과의 결합을 최소화하기 위해 ID 기반 참조 방식 적용
* 상태 전환 메서드를 통해 이후 비즈니스 로직 확장 가능하도록 설계

---

## ⚠️ 주의 사항

* 현재는 매칭 요청 생성 API 및 비즈니스 로직은 포함되지 않음 (다음 이슈에서 구현 예정)
* aiSummary 필드는 향후 가이드가 확인할 AI 여행 컨셉 요약 정보를 저장하기 위한 용도

---

## ✅ 체크리스트

* [x] 빌드가 정상적으로 되는가?
* [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
* [x] 도메인 책임 분리가 적절한가?
