### PR TITLE
matching Entity => id 기반 스키마 sync

### DIFF
--- a/backend/api-server/src/main/resources/application.yml
+++ b/backend/api-server/src/main/resources/application.yml
@@ -20,3 +20,22 @@ server:
   servlet:
     context-path: /api
 
+---
+spring:
+  config:
+    activate:
+      on-profile: local
+  jpa:
+    hibernate:
+      ddl-auto: validate
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prod
+  jpa:
+    hibernate:
+      # 운영에서는 스키마 변경 없이 검증만 수행
+      ddl-auto: validate
+

--- a/backend/module-domain/src/main/java/com/team6/domain/guide/entity/GuideCareer.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/entity/GuideCareer.java
@@ -19,8 +19,7 @@ public class GuideCareer extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "career_id")
-    private Long careerId; // 경력 고유 ID (PK)
+    private Long id; // 경력 고유 ID (PK)
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "guide_id", nullable = false)

--- a/backend/module-domain/src/main/java/com/team6/domain/guide/entity/GuideImage.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/entity/GuideImage.java
@@ -17,8 +17,7 @@ public class GuideImage extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "image_id")
-    private Long imageId; // 이미지 고유 ID (PK)
+    private Long id; // 이미지 고유 ID (PK)
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "guide_id", nullable = false)
@@ -30,4 +29,8 @@ public class GuideImage extends BaseTimeEntity {
     @Column(name = "sort_order", nullable = false)
     @Builder.Default
     private Integer sortOrder = 0; // 이미지 정렬 순서
+
+    @Column(name = "is_main", nullable = false)
+    @Builder.Default
+    private Boolean isMain = false; // 대표 이미지 여부
 }

--- a/backend/module-domain/src/main/java/com/team6/domain/guide/entity/GuideProfile.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/entity/GuideProfile.java
@@ -19,11 +19,10 @@ public class GuideProfile extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "guide_id")
-    private Long guideId; // 가이드 프로필 고유 ID (PK)
+    private Long id; // 가이드 프로필 고유 ID (PK)
 
-    @Column(name = "user_id", nullable = false, unique = true)
-    private Long userId; // 회원 ID (JWT에서 추출, 엔티티 직접 참조 금지)
+    @Column(name = "member_id", nullable = false, unique = true)
+    private Long memberId; // 회원 ID (JWT에서 추출, 엔티티 직접 참조 금지)
 
     @Column(nullable = false, length = 50)
     private String nickname; // 가이드 닉네임
@@ -37,7 +36,7 @@ public class GuideProfile extends BaseTimeEntity {
     @Column(nullable = false, length = 100)
     private String region; // 활동 지역
 
-    @Column(length = 50)
+    @Column(length = 100)
     private String language; // 구사 가능 언어
 
     @Column(name = "price_per_hour", precision = 10, scale = 2)
@@ -58,6 +57,12 @@ public class GuideProfile extends BaseTimeEntity {
     @Column(name = "is_active", nullable = false)
     @Builder.Default
     private Boolean isActive = true; // 활성화 여부
+
+    @Column(name = "residence_years")
+    private Integer residenceYears; // 거주 연수
+
+    @Column(name = "local_story", columnDefinition = "TEXT")
+    private String localStory; // 로컬 스토리 소개
 
     // 수정 가능한 필드 업데이트
     public void update(String nickname, String profileImage, String bio,

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/dto/response/MatchRequestActionResponse.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/dto/response/MatchRequestActionResponse.java
@@ -13,7 +13,7 @@ public class MatchRequestActionResponse {
 
     public static MatchRequestActionResponse from(MatchRequest entity) {
         return MatchRequestActionResponse.builder()
-                .requestId(entity.getRequestId())
+                .requestId(entity.getId())
                 .status(entity.getStatus().name())
                 .build();
     }

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/dto/response/MatchRequestCreateResponse.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/dto/response/MatchRequestCreateResponse.java
@@ -23,7 +23,7 @@ public class MatchRequestCreateResponse {
 
     public static MatchRequestCreateResponse from(MatchRequest entity) {
         return MatchRequestCreateResponse.builder()
-                .requestId(entity.getRequestId())
+                .requestId(entity.getId())
                 .guestId(entity.getGuestId())
                 .guideId(entity.getGuideId())
                 .destination(entity.getDestination())

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/dto/response/PaymentResponseDto.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/dto/response/PaymentResponseDto.java
@@ -21,8 +21,8 @@ public class PaymentResponseDto {
     // Entity → DTO 변환
     public static PaymentResponseDto from(Payment payment) {
         return PaymentResponseDto.builder()
-                .paymentId(payment.getPaymentId())
-                .requestId(payment.getMatchRequest().getRequestId())
+                .paymentId(payment.getId())
+                .requestId(payment.getMatchRequest().getId())
                 .amount(payment.getAmount())
                 .paymentType(payment.getPaymentType())
                 .status(payment.getStatus())

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/dto/response/RefundResponseDto.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/dto/response/RefundResponseDto.java
@@ -20,8 +20,8 @@ public class RefundResponseDto {
     // Entity → DTO 변환
     public static RefundResponseDto from(Refund refund) {
         return RefundResponseDto.builder()
-                .refundId(refund.getRefundId())
-                .paymentId(refund.getPayment().getPaymentId())
+                .refundId(refund.getId())
+                .paymentId(refund.getPayment().getId())
                 .refundType(refund.getRefundType())
                 .status(refund.getStatus())
                 .processedAt(refund.getProcessedAt())

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/dto/response/TourExtensionResponseDto.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/dto/response/TourExtensionResponseDto.java
@@ -21,8 +21,8 @@ public class TourExtensionResponseDto {
     // Entity → DTO 변환
     public static TourExtensionResponseDto from(TourExtension extension) {
         return TourExtensionResponseDto.builder()
-                .extensionId(extension.getExtensionId())
-                .requestId(extension.getMatchRequest().getRequestId())
+                .extensionId(extension.getId())
+                .requestId(extension.getMatchRequest().getId())
                 .extendedDate(extension.getExtendedDate())
                 .extendedPrice(extension.getExtendedPrice())
                 .status(extension.getStatus())

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/entity/MatchRequest.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/entity/MatchRequest.java
@@ -3,32 +3,44 @@ package com.team6.domain.matching.entity;
 import com.team6.domain.matching.entity.enums.MatchRequestStatus;
 import com.team6.domain.matching.exception.MatchingErrorCode;
 import com.team6.domain.matching.exception.MatchingException;
+import com.team6.module.common.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.annotations.Check;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "match_request")
+@Table(
+        name = "match_request",
+        indexes = {
+                @Index(name = "idx_match_guest", columnList = "guest_id"),
+                @Index(name = "idx_match_guide", columnList = "guide_id")
+        }
+)
+@Check(constraints = "status IN ('PENDING','ACCEPTED','PAID','IN_PROGRESS','COMPLETED','CANCELLED','REJECTED')")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 @AllArgsConstructor
 @Slf4j
-public class MatchRequest {
+@AttributeOverrides({
+        @AttributeOverride(name = "createdAt", column = @Column(name = "created_at", nullable = false, updatable = false, columnDefinition = "DATETIME(6)")),
+        @AttributeOverride(name = "updatedAt", column = @Column(name = "updated_at", nullable = false, columnDefinition = "DATETIME(6)"))
+})
+public class MatchRequest extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long requestId;
+    private Long id;
 
     // TODO: Member 엔티티 완성 후 @ManyToOne으로 교체
-    @Column(nullable = false)
+    @Column(name = "guest_id", nullable = false)
     private Long guestId;
 
     // TODO: GuideProfile 엔티티 완성 후 @ManyToOne으로 교체
-    @Column(nullable = false)
+    @Column(name = "guide_id", nullable = false)
     private Long guideId;
 
     @Column(nullable = false)
@@ -37,24 +49,21 @@ public class MatchRequest {
     @Column(columnDefinition = "TEXT")
     private String concept;             // 여행 컨셉 (AI 분석 원본)
 
+    @Column(name = "desired_date", nullable = false)
     private LocalDate desiredDate;      // 희망 여행 날짜
 
+    @Column(name = "desired_budget")
     private Integer desiredBudget;      // 희망 예산(원)
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 30)
     private MatchRequestStatus status;  // 매칭 상태
 
-    @Column(length = 10)
+    @Column(name = "cancelled_by", length = 20)
     private String cancelledBy;         // GUEST or GUIDE
 
-    @Column(columnDefinition = "TEXT")
+    @Column(name = "cancel_reason", columnDefinition = "TEXT")
     private String cancelReason;        // 취소 사유
-
-    @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
-    private LocalDateTime updatedAt;
     /**
      * 매칭 요청 생성용 정적 팩토리 메서드
      *
@@ -84,18 +93,9 @@ public class MatchRequest {
 
     @PrePersist
     protected void onCreate() {
-        this.createdAt = LocalDateTime.now();
-        this.updatedAt = LocalDateTime.now();
-
-        // 최초 생성 시 status가 별도로 지정되지 않았다면 기본값을 PENDING으로 설정
         if (this.status == null) {
             this.status = MatchRequestStatus.PENDING;
         }
-    }
-
-    @PreUpdate
-    protected void onUpdate() {
-        this.updatedAt = LocalDateTime.now();
     }
     /**
      * 가이드가 요청을 거절할 때 사용하는 상태 변경 메서드
@@ -111,27 +111,22 @@ public class MatchRequest {
     }
 
     /**
-     * 가이드가 요청을 수락하고 제안 단계로 넘길 때 사용하는 상태 변경 메서드
-     *
-     * 현재 도메인 상태 설계상 "가이드 수락"을 별도 상태로 두지 않고
-     * 가이드가 실제 제안을 시작하는 시점을 PROPOSED로 본다.
-     *
-     * 따라서 PENDING 상태에서만 PROPOSED로 변경 가능하다.
+     * 가이드가 제안을 수락할 때 사용하는 상태 변경 메서드
+     * SQL 스키마에 PROPOSED 상태가 없으므로 ACCEPTED로 전이한다.
      */
     public void propose() {
         if (this.status != MatchRequestStatus.PENDING) {
             throw new MatchingException(MatchingErrorCode.MATCH_REQUEST_INVALID_STATUS);
         }
-        this.status = MatchRequestStatus.PROPOSED;
+        this.status = MatchRequestStatus.ACCEPTED;
     }
 
     /**
-     * 게스트가 가이드의 제안을 최종 수락할 때 사용하는 상태 변경 메서드
-     *
-     * PROPOSED 상태에서만 ACCEPTED로 변경 가능하다.
+     * 게스트가 제안을 최종 확인할 때 사용하는 메서드
+     * 현재 상태 모델에서는 ACCEPTED 상태를 유지한다.
      */
     public void accept() {
-        if (this.status != MatchRequestStatus.PROPOSED) {
+        if (this.status != MatchRequestStatus.ACCEPTED) {
             throw new MatchingException(MatchingErrorCode.MATCH_REQUEST_INVALID_STATUS);
         }
         this.status = MatchRequestStatus.ACCEPTED;

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/entity/Payment.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/entity/Payment.java
@@ -2,62 +2,72 @@ package com.team6.domain.matching.entity;
 
 
 import com.team6.domain.matching.entity.enums.PaymentStatus;
+import com.team6.module.common.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.Check;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "payment")
+@Table(
+        name = "payment",
+        indexes = {
+                @Index(name = "idx_payment_payer", columnList = "payer_id")
+        },
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_payment_unique", columnNames = {"match_request_id", "payment_type"})
+        }
+)
+@Check(constraints = "status IN ('PENDING','COMPLETED','REFUNDED','FAILED','CANCELLED') AND payment_type IN ('CHAT','ACCOMPANY','EXTENSION')")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 @AllArgsConstructor
-public class Payment {
+@AttributeOverrides({
+        @AttributeOverride(name = "createdAt", column = @Column(name = "created_at", nullable = false, updatable = false, columnDefinition = "DATETIME(6)")),
+        @AttributeOverride(name = "updatedAt", column = @Column(name = "updated_at", nullable = false, columnDefinition = "DATETIME(6)"))
+})
+public class Payment extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long paymentId;
+    private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "request_id", nullable = false)
+    @JoinColumn(name = "match_request_id", nullable = false)
     private MatchRequest matchRequest;  // MATCH_REQUEST FK
 
     // TODO: Member 엔티티 완성 후 @ManyToOne으로 교체
-    @Column(nullable = false)
+    @Column(name = "payer_id", nullable = false)
     private Long payerId;               // 게스트 MEMBER FK
 
     @Column(nullable = false)
     private Integer amount;             // 결제 금액(원)
 
-    @Column(nullable = false, length = 20)
+    @Column(name = "payment_type", nullable = false, length = 20)
     private String paymentType;         // CHAT / ACCOMPANY / EXTENSION
 
-    @Column(nullable = false, unique = true, length = 100)
+    @Column(name = "pg_order_no", nullable = false, unique = true, length = 100)
     private String pgOrderNo;           // PG 주문번호
 
-    @Column(length = 100)
+    @Column(name = "pg_transaction_id", length = 100)
     private String pgTransactionId;     // PG 거래 ID
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     private PaymentStatus status;       // 결제 상태
 
-    private LocalDateTime cancelledAt;  // 취소 처리 일시
-
-    @Column(columnDefinition = "TEXT")
-    private String cancelReason;        // 취소 사유
-
+    @Column(name = "paid_at", columnDefinition = "DATETIME(6)")
     private LocalDateTime paidAt;       // 결제 완료일시
 
+    @Column(name = "refund_deadline", columnDefinition = "DATETIME(6)")
     private LocalDateTime refundDeadline; // 환불 마감(paidAt+2h)
-
-    @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;
 
     @PrePersist
     protected void onCreate() {
-        this.createdAt = LocalDateTime.now();
-        this.status = PaymentStatus.PENDING;
+        if (this.status == null) {
+            this.status = PaymentStatus.PENDING;
+        }
     }
 
     // 결제 완료 처리 — 환불 마감 자동 계산
@@ -69,10 +79,8 @@ public class Payment {
     }
 
     // 취소 처리
-    public void cancel(String reason) {
+    public void cancel() {
         this.status = PaymentStatus.CANCELLED;
-        this.cancelledAt = LocalDateTime.now();
-        this.cancelReason = reason;
     }
 
     // 환불 완료 처리

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/entity/Refund.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/entity/Refund.java
@@ -2,28 +2,35 @@ package com.team6.domain.matching.entity;
 
 import com.team6.domain.matching.entity.enums.RefundStatus;
 import com.team6.domain.matching.entity.enums.RefundType;
+import com.team6.module.common.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.Check;
 import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "refund")
+@Check(constraints = "status IN ('PENDING','APPROVED','REJECTED') AND refund_type IN ('AUTO','MANUAL','CANCEL_GUEST','CANCEL_GUIDE')")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 @AllArgsConstructor
-public class Refund {
+@AttributeOverrides({
+        @AttributeOverride(name = "createdAt", column = @Column(name = "created_at", nullable = false, updatable = false, columnDefinition = "DATETIME(6)")),
+        @AttributeOverride(name = "updatedAt", column = @Column(name = "updated_at", nullable = false, columnDefinition = "DATETIME(6)"))
+})
+public class Refund extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long refundId;
+    private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "payment_id", nullable = false)
     private Payment payment;            // PAYMENT FK
 
     // TODO: Member 엔티티 완성 후 @ManyToOne으로 교체
-    @Column(nullable = false)
+    @Column(name = "requester_id", nullable = false)
     private Long requesterId;           // 게스트 MEMBER FK
 
     @Enumerated(EnumType.STRING)
@@ -43,16 +50,20 @@ public class Refund {
     @Column(nullable = false, length = 20)
     private RefundStatus status;        // 환불 처리 상태
 
+    @Column(name = "processed_at", columnDefinition = "DATETIME(6)")
     private LocalDateTime processedAt;  // 처리 완료일
-
-    @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;
 
     @PrePersist
     protected void onCreate() {
-        this.createdAt = LocalDateTime.now();
-        this.status = RefundStatus.PENDING;
-        this.aiProcessed = false;
+        if (this.status == null) {
+            this.status = RefundStatus.PENDING;
+        }
+        if (this.aiProcessed == null) {
+            this.aiProcessed = false;
+        }
+        if (this.refundType == null) {
+            this.refundType = RefundType.MANUAL;
+        }
     }
 
     // 환불 승인

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/entity/TourExtension.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/entity/TourExtension.java
@@ -1,49 +1,56 @@
 package com.team6.domain.matching.entity;
 
 import com.team6.domain.matching.entity.enums.TourExtensionStatus;
+import com.team6.module.common.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.Check;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "tour_extension")
+@Check(constraints = "status IN ('REQUESTED','GUIDE_APPROVED','PAID','REJECTED','AUTO_CANCELLED')")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 @AllArgsConstructor
-public class TourExtension {
+@AttributeOverrides({
+        @AttributeOverride(name = "createdAt", column = @Column(name = "created_at", nullable = false, updatable = false, columnDefinition = "DATETIME(6)")),
+        @AttributeOverride(name = "updatedAt", column = @Column(name = "updated_at", nullable = false, columnDefinition = "DATETIME(6)"))
+})
+public class TourExtension extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long extensionId;
+    private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "request_id", nullable = false)
+    @JoinColumn(name = "match_request_id", nullable = false)
     private MatchRequest matchRequest;  // MATCH_REQUEST FK
 
     // TODO: Member 엔티티 완성 후 @ManyToOne으로 교체
-    @Column(nullable = false)
+    @Column(name = "guest_id", nullable = false)
     private Long guestId;               // 게스트 MEMBER FK
 
-    @Column(nullable = false)
+    @Column(name = "extended_date", nullable = false)
     private LocalDate extendedDate;     // 연장 날짜
 
+    @Column(name = "extended_price")
     private Integer extendedPrice;      // 연장 요금(원)
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 30)
     private TourExtensionStatus status; // 연장 신청 상태
 
-    @Column(nullable = false, updatable = false)
+    @Column(name = "requested_at", nullable = false, updatable = false, columnDefinition = "DATETIME(6)")
     private LocalDateTime requestedAt;  // 신청일시
 
+    @Column(name = "guide_approved_at", columnDefinition = "DATETIME(6)")
     private LocalDateTime guideApprovedAt; // 가이드 승인 일시
 
-    @Column(nullable = false)
+    @Column(name = "deadline_at", nullable = false, columnDefinition = "DATETIME(6)")
     private LocalDateTime deadlineAt;   // 선택 마감 당일 23:59:59
-
-    private LocalDateTime autoCancelledAt; // 자동 미연장 처리 일시
 
     @PrePersist
     protected void onCreate() {
@@ -61,7 +68,6 @@ public class TourExtension {
     // 자동 취소 (23:59:59 초과)
     public void autoCancel() {
         this.status = TourExtensionStatus.AUTO_CANCELLED;
-        this.autoCancelledAt = LocalDateTime.now();
     }
 
     // 연장 결제 완료

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/entity/enums/MatchRequestStatus.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/entity/enums/MatchRequestStatus.java
@@ -3,7 +3,6 @@ package com.team6.domain.matching.entity.enums;
 // MatchRequestStatus.java
 public enum MatchRequestStatus {
     PENDING,      // 요청 생성됨, 가이드 응답 대기
-    PROPOSED,     // 가이드가 제안서 전송함
     ACCEPTED,     // 게스트가 제안서 수락함
     PAID,         // 결제 완료, 투어 확정
     IN_PROGRESS,  // 투어 진행 중

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/repository/PaymentRepository.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/repository/PaymentRepository.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
     // 매칭 요청 ID로 결제 목록 조회
-    List<Payment> findByMatchRequest_RequestId(Long requestId);
+    List<Payment> findByMatchRequest_Id(Long requestId);
 
     // 게스트 ID로 결제 내역 조회
     List<Payment> findByPayerId(Long payerId);

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/repository/RefundRepository.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/repository/RefundRepository.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 public interface RefundRepository extends JpaRepository<Refund, Long> {
 
     // 결제 ID로 환불 조회 (중복 신청 방지용)
-    Optional<Refund> findByPayment_PaymentId(Long paymentId);
+    Optional<Refund> findByPayment_Id(Long paymentId);
 
     // 신청자 ID로 환불 내역 조회
     List<Refund> findByRequesterId(Long requesterId);

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/repository/TourExtensionRepository.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/repository/TourExtensionRepository.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 public interface TourExtensionRepository extends JpaRepository<TourExtension, Long> {
 
     // 매칭 요청 ID로 연장 신청 조회
-    Optional<TourExtension> findByMatchRequest_RequestId(Long requestId);
+    Optional<TourExtension> findByMatchRequest_Id(Long requestId);
 
     // 게스트 ID로 연장 신청 목록 조회
     List<TourExtension> findByGuestId(Long guestId);


### PR DESCRIPTION
# 🔗 이슈 번호
- Closes #50 

---

## 💡 주요 변경 사항
- matching/guide 도메인의 엔티티 스키마를 최신 DB 규약(id PK 통일) 기준으로 정렬했습니다.
- payment.match_request_id, uq_payment_unique, 상태 체크 제약 등 핵심 제약조건이 엔티티/JPA 생성 결과에 반영되도록 수정했습니다.
- 로컬에서 JPA 스키마 재생성 후 정상 기동 확인했으며, 이후 ddl-auto=validate로 고정 가능한 상태입니다.

---

## ⚠️ 주의 사항 / 질문
- 이번 변경은 matching 외에 guide 엔티티 PK 규칙도 함께 포함됩니다(리뷰 시 범위 확인 부탁드립니다).
- 팀 공용 DB에서는 ddl-auto=create를 사용하지 않고 validate 유지가 필요합니다.

---

## ✅ 체크리스트
- [x] 빌드가 정상적으로 되는가?
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [x] .gitignore에 설정 파일이 잘 포함되었는가? (application-local.yml 등)