### PR TITLE
Feat/be#61: match_request concept_summary 자동 생성

### DIFF
--- a/backend/module-domain/src/main/java/com/team6/domain/matching/dto/request/MatchRequestCreateRequest.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/dto/request/MatchRequestCreateRequest.java
@@ -19,6 +19,12 @@ public class MatchRequestCreateRequest {
 
     private String concept;
 
+    /**
+     * AI가 정리한 컨셉 요약 (선택).
+     * 프론트에서 전달하지 않으면 서버에서 destination/concept 등을 기반으로 생성한다.
+     */
+    private String conceptSummary;
+
     private LocalDate desiredDate;
 
     private Integer desiredBudget;

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/entity/MatchRequest.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/entity/MatchRequest.java
@@ -87,6 +87,7 @@ public class MatchRequest extends BaseTimeEntity {
             Long guideId,
             String destination,
             String concept,
+            String conceptSummary,
             LocalDate desiredDate,
             Integer desiredBudget
     ) {
@@ -95,6 +96,7 @@ public class MatchRequest extends BaseTimeEntity {
                 .guideId(guideId)
                 .destination(destination)
                 .concept(concept)
+                .conceptSummary(conceptSummary)
                 .desiredDate(desiredDate)
                 .desiredBudget(desiredBudget)
                 .build();

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/service/MatchRequestService.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/service/MatchRequestService.java
@@ -14,7 +14,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.text.NumberFormat;
 import java.util.List;
+import java.util.Locale;
 
 @Slf4j
 @Service
@@ -28,16 +30,18 @@ public class MatchRequestService {
     public MatchRequestCreateResponse createMatchRequest(Long guestId, MatchRequestCreateRequest request) {
         validateCreateRequest(guestId, request);
 
+        String conceptSummary = resolveConceptSummary(request);
         MatchRequest matchRequest = MatchRequest.create(
                 guestId,
                 request.getGuideId(),
                 request.getDestination(),
                 request.getConcept(),
+                conceptSummary,
                 request.getDesiredDate(),
                 request.getDesiredBudget()
         );
 
-        log.info("[MatchRequest] 매칭 요청 생성 — guestId={}, guideId={}", guestId, request.getGuideId());
+        log.info("[F03-04] 매칭 요청 생성 — guestId={}, guideId={}", guestId, request.getGuideId());
         return MatchRequestCreateResponse.from(matchRequestRepository.save(matchRequest));
     }
 
@@ -140,5 +144,57 @@ public class MatchRequestService {
         if (guestId.equals(request.getGuideId())) {
             throw new MatchingException(MatchingErrorCode.GUEST_GUIDE_SAME);
         }
+    }
+
+    private String resolveConceptSummary(MatchRequestCreateRequest request) {
+        if (request.getConceptSummary() != null && !request.getConceptSummary().isBlank()) {
+            return request.getConceptSummary().trim();
+        }
+
+        String destination = safeTrim(request.getDestination());
+        String concept = safeTrim(request.getConcept());
+        String date = request.getDesiredDate() == null ? null : request.getDesiredDate().toString();
+        String budget = formatBudget(request.getDesiredBudget());
+
+        StringBuilder sb = new StringBuilder();
+        if (destination != null) {
+            sb.append('[').append(destination).append("] ");
+        }
+        if (date != null) {
+            sb.append(date);
+        }
+        if (budget != null) {
+            if (sb.length() > 0) sb.append(", ");
+            sb.append("예산 ").append(budget);
+        }
+        if (concept != null) {
+            if (sb.length() > 0) sb.append(" · ");
+            sb.append("컨셉: ").append(concept);
+        }
+
+        String summary = sb.toString().trim();
+        if (summary.isBlank()) {
+            return null;
+        }
+        return summary.length() > 500 ? summary.substring(0, 500) : summary;
+    }
+
+    private String safeTrim(String value) {
+        if (value == null) {
+            return null;
+        }
+        String t = value.trim();
+        return t.isBlank() ? null : t;
+    }
+
+    private String formatBudget(Integer desiredBudget) {
+        if (desiredBudget == null) {
+            return null;
+        }
+        if (desiredBudget < 0) {
+            throw new MatchingException(MatchingErrorCode.INVALID_REQUEST);
+        }
+        NumberFormat nf = NumberFormat.getNumberInstance(Locale.KOREA);
+        return nf.format(desiredBudget) + "원";
     }
 }


### PR DESCRIPTION
관련 이슈

Closes #61
────────────────────────

주요 변경 사항

[1] 매칭 요청 생성 시 concept_summary 자동 생성
1.1) conceptSummary 미입력(null/blank)인 경우 서버에서 요약 자동 생성
1.2) 요약 생성 기준
→ destination / desiredDate / desiredBudget / concept 값을 조합해 1~2문장 템플릿 요약 생성
1.3) 생성된 요약을 match_request.concept_summary에 저장

[2] 호환성(프론트 연동)
2.1) 프론트가 conceptSummary를 전달하면 해당 값을 우선 사용
2.2) 기존 요청 필드(destination/concept/예산/날짜)만으로도 동작 유지

────────────────────────

실행/스모크 테스트 결과 (local)
[1] 서버 기동
1.1) local 프로필에서 ddl-auto: validate 상태로 :api-server:bootRun 정상 기동 확인 (context-path: /api)

[2] API 스모크 테스트 (curl)
2.1) conceptSummary 미입력 시 자동 생성 확인
→ POST /api/matching/requests 요청에서 conceptSummary를 보내지 않아도 응답에 conceptSummary가 자동 생성되어 포함됨

2.2) conceptSummary 직접 입력 시 우선 저장 확인
→ POST /api/matching/requests 요청에 conceptSummary를 포함하면, 응답의 conceptSummary가 해당 값으로 저장/반영됨

2.3) 예산 음수 방어 확인
→ desiredBudget = -1 요청 시 400 응답 확인 ({"status":400,"message":"잘못된 요청입니다"})

────────────────────────

주의 사항 / 질문

[1] 데이터 정책
1.1) concept_summary는 nullable 유지 (생성 가능한 정보가 없으면 null 저장)
1.2) 예산이 음수로 들어오면 INVALID_REQUEST로 처리 (금액 음수 저장 방지 룰 준수)

────────────────────────

체크리스트

[1] 빌드
1.1) ./gradlew :module-domain:compileJava 확인 완료
1.2) ./gradlew :api-server:compileJava 확인 완료

[2] 커밋 컨벤션
2.1) Feat/be#61 형식 준수

[3] 설정 파일 커밋 여부
3.1) 이번 PR에는 설정 파일 커밋 없음