### PR TITLE
Feat/be#63: AI 추천 파서·사유 생성 고도화

### DIFF
--- a/backend/module-ai/src/main/java/com/team6/module/ai/engine/ReasonGenerator.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/engine/ReasonGenerator.java
@@ -6,6 +6,8 @@ import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Component
 public class ReasonGenerator {
@@ -21,13 +23,28 @@ public class ReasonGenerator {
             reasons.add("여행 스타일이 유사");
         }
 
-        if (pref.getActivityTags() != null && guide.getSpecialtyTags() != null) {
-            long matched = pref.getActivityTags().stream()
-                    .filter(guide.getSpecialtyTags()::contains)
-                    .count();
+        if (safeEquals(pref.getBudgetLevel(), guide.getPriceLevel())) {
+            reasons.add("예산대가 비슷");
+        }
 
-            if (matched > 0) {
-                reasons.add("관심 활동 태그가 " + matched + "개 일치");
+        if (pref.getPreferredLanguages() != null && guide.getLanguages() != null) {
+            Set<String> matchedLanguages = pref.getPreferredLanguages().stream()
+                    .filter(guide.getLanguages()::contains)
+                    .collect(Collectors.toSet());
+            if (!matchedLanguages.isEmpty()) {
+                reasons.add("가능 언어(" + String.join("/", matchedLanguages) + ")");
+            }
+        }
+
+        if (pref.getActivityTags() != null && guide.getSpecialtyTags() != null) {
+            List<String> matched = pref.getActivityTags().stream()
+                    .filter(guide.getSpecialtyTags()::contains)
+                    .distinct()
+                    .toList();
+
+            if (!matched.isEmpty()) {
+                String head = matched.stream().limit(3).collect(Collectors.joining("/"));
+                reasons.add("관심 활동(" + head + (matched.size() > 3 ? " 외" : "") + ")");
             }
         }
 
@@ -35,7 +52,7 @@ public class ReasonGenerator {
             reasons.add("전체 선호도 기준으로 적합");
         }
 
-        return String.join(", ", reasons);
+        return String.join(" · ", reasons);
     }
 
     private boolean safeEquals(String a, String b) {

--- a/backend/module-ai/src/main/java/com/team6/module/ai/parser/PromptParser.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/parser/PromptParser.java
@@ -4,11 +4,17 @@ import com.team6.module.ai.dto.request.GuideRecommendRequest;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Component
 public class PromptParser {
+
+    private static final Pattern BUDGET_WON = Pattern.compile("(\\d{1,3}(?:,\\d{3})+|\\d+)\\s*(원|만원)");
 
     public GuideRecommendRequest parse(
             String prompt,
@@ -40,7 +46,9 @@ public class PromptParser {
         if (prompt == null) {
             return "";
         }
-        return prompt.trim().toLowerCase(Locale.ROOT);
+        return prompt.trim()
+                .replaceAll("\\s+", " ")
+                .toLowerCase(Locale.ROOT);
     }
 
     private String extractRegion(String prompt) {
@@ -53,14 +61,21 @@ public class PromptParser {
     }
 
     private String extractTravelStyle(String prompt) {
-        if (containsAny(prompt, "감성", "감성적인")) return "감성";
-        if (containsAny(prompt, "액티비티", "활동적인", "신나게", "역동적인")) return "액티비티";
-        if (containsAny(prompt, "조용", "힐링", "편안", "여유")) return "힐링";
-        if (containsAny(prompt, "로컬", "현지", "동네 느낌")) return "로컬";
+        if (containsAny(prompt, "감성", "감성적인", "감성샷")) return "감성";
+        if (containsAny(prompt, "액티비티", "활동적인", "신나게", "역동적인", "익스트림")) return "액티비티";
+        if (containsAny(prompt, "조용", "힐링", "편안", "여유", "쉬고")) return "힐링";
+        if (containsAny(prompt, "로컬", "현지", "동네", "시장", "골목")) return "로컬";
         return null;
     }
 
     private String extractBudgetLevel(String prompt) {
+        Integer budget = extractBudgetAmount(prompt);
+        if (budget != null) {
+            if (budget <= 100_000) return "낮음";
+            if (budget <= 300_000) return "중간";
+            return "높음";
+        }
+
         if (containsAny(prompt, "저렴", "가성비", "싸게", "예산 적게")) return "낮음";
         if (containsAny(prompt, "적당", "무난", "보통", "중간")) return "중간";
         if (containsAny(prompt, "럭셔리", "고급", "비싸도", "프리미엄")) return "높음";
@@ -69,14 +84,14 @@ public class PromptParser {
 
     private String extractCompanionType(String prompt) {
         if (containsAny(prompt, "혼자", "혼행", "1인")) return "혼자";
-        if (containsAny(prompt, "친구", "친구랑")) return "친구";
-        if (containsAny(prompt, "가족", "부모님", "엄마", "아빠")) return "가족";
-        if (containsAny(prompt, "연인", "커플", "여자친구", "남자친구")) return "연인";
+        if (containsAny(prompt, "친구", "친구랑", "우정", "동창")) return "친구";
+        if (containsAny(prompt, "가족", "부모님", "엄마", "아빠", "아이", "애기")) return "가족";
+        if (containsAny(prompt, "연인", "커플", "데이트", "여자친구", "남자친구")) return "연인";
         return null;
     }
 
     private List<String> extractActivityTags(String prompt) {
-        List<String> tags = new ArrayList<>();
+        Set<String> tags = new LinkedHashSet<>();
 
         if (containsAny(prompt, "카페")) tags.add("카페");
         if (containsAny(prompt, "야경", "밤거리")) tags.add("야경");
@@ -86,19 +101,21 @@ public class PromptParser {
         if (containsAny(prompt, "사진", "포토", "인생샷")) tags.add("사진");
         if (containsAny(prompt, "쇼핑")) tags.add("쇼핑");
         if (containsAny(prompt, "바다", "해변", "오션뷰")) tags.add("바다");
+        if (containsAny(prompt, "박물관", "미술관", "전시")) tags.add("전시");
+        if (containsAny(prompt, "시장", "전통시장", "로컬시장")) tags.add("시장");
 
-        return tags;
+        return new ArrayList<>(tags);
     }
 
     private List<String> extractLanguages(String prompt) {
-        List<String> languages = new ArrayList<>();
+        Set<String> languages = new LinkedHashSet<>();
 
         if (containsAny(prompt, "한국어")) languages.add("한국어");
-        if (containsAny(prompt, "영어", "english")) languages.add("영어");
-        if (containsAny(prompt, "일본어", "japanese")) languages.add("일본어");
-        if (containsAny(prompt, "중국어", "chinese")) languages.add("중국어");
+        if (containsAny(prompt, "영어", "english", "eng")) languages.add("영어");
+        if (containsAny(prompt, "일본어", "japanese", "jp")) languages.add("일본어");
+        if (containsAny(prompt, "중국어", "chinese", "cn")) languages.add("중국어");
 
-        return languages;
+        return new ArrayList<>(languages);
     }
 
     private boolean containsAny(String prompt, String... keywords) {
@@ -108,5 +125,26 @@ public class PromptParser {
             }
         }
         return false;
+    }
+
+    private Integer extractBudgetAmount(String prompt) {
+        Matcher m = BUDGET_WON.matcher(prompt);
+        if (!m.find()) {
+            return null;
+        }
+        String number = m.group(1).replace(",", "");
+        String unit = m.group(2);
+        try {
+            long value = Long.parseLong(number);
+            if ("만원".equals(unit)) {
+                value *= 10_000L;
+            }
+            if (value <= 0L || value > Integer.MAX_VALUE) {
+                return null;
+            }
+            return (int) value;
+        } catch (NumberFormatException e) {
+            return null;
+        }
     }
 }

--- a/backend/module-ai/src/test/java/com/team6/module/ai/parser/PromptParserTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/parser/PromptParserTest.java
@@ -15,12 +15,23 @@ class PromptParserTest {
     void parse_should_extract_keywords_from_prompt() {
         String prompt = "부산에서 혼자 감성 카페 여행하고 싶고 영어 가능한 가이드면 좋겠어요";
 
-        GuideRecommendRequest request = promptParser.parse(prompt, List.of());
+        GuideRecommendRequest request = promptParser.parse(prompt, 3, List.of());
 
         assertThat(request.getRegion()).isEqualTo("부산");
         assertThat(request.getCompanionType()).isEqualTo("혼자");
         assertThat(request.getTravelStyle()).isEqualTo("감성");
         assertThat(request.getActivityTags()).contains("카페");
         assertThat(request.getPreferredLanguages()).contains("영어");
+    }
+
+    @Test
+    void parse_should_extract_budget_level_from_amount() {
+        String prompt = "제주 여행 20만원 정도 생각 중이고 감성 카페 가고 싶어요";
+
+        GuideRecommendRequest request = promptParser.parse(prompt, 3, List.of());
+
+        assertThat(request.getRegion()).isEqualTo("제주");
+        assertThat(request.getBudgetLevel()).isEqualTo("중간");
+        assertThat(request.getActivityTags()).contains("카페");
     }
 }

--- a/backend/module-ai/src/test/java/com/team6/module/ai/service/AiRecommendationServiceTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/service/AiRecommendationServiceTest.java
@@ -71,6 +71,7 @@ class AiRecommendationServiceTest {
         assertThat(response).isNotNull();
         assertThat(response.getRecommendations()).isNotEmpty();
         assertThat(response.getRecommendations().get(0).getGuideId()).isEqualTo(1L);
+        assertThat(response.getRecommendations().get(0).getReason()).contains("선호 지역");
     }
 
     @Test


### PR DESCRIPTION
관련 이슈

Closes #63
────────────────────────

주요 변경 사항

[1] PromptParser 고도화 (키워드/정규화/예산 인식)
1.1) 프롬프트 공백 정규화(다중 공백 → 단일 공백)로 파싱 안정화
1.2) 스타일/동행/활동/언어 키워드 인식 범위 확장
1.3) 예산 “금액” 입력 감지
→ 예: 20만원, 200,000원 형태를 인식해 budgetLevel(낮음/중간/높음) 자동 분류
1.4) 활동 태그/언어는 중복 없이 추출(순서 유지)

[2] 추천 사유(reason) 가독성 개선
2.1) 기존 지역/스타일 중심 reason에서 예산/언어/활동 매칭까지 포함
2.2) 구분자 개선
→ , 기반 나열 → · 기반 요약 문장 형태로 개선
2.3) 활동 태그는 상위 3개까지만 노출(+그 이상은 “외” 표기)

[3] 테스트 보강
3.1) 파서 테스트에 예산 금액 케이스 추가
3.2) 추천 서비스 테스트에 reason 내용 포함 여부 검증 추가

────────────────────────

주의 사항 / 질문

[1] 예산 분류 기준(룰 기반)
1.1) 금액이 인식되는 경우 기준
→ 10만원 이하: 낮음 / 30만원 이하: 중간 / 그 이상: 높음
1.2) 금액이 인식되지 않으면 기존 키워드(저렴/적당/럭셔리 등) 기반으로 분류

────────────────────────

체크리스트

[1] 테스트
1.1) ./gradlew :module-ai:test 통과 확인

[2] 커밋 컨벤션
2.1) Feat/be#63 형식 준수

[3] 설정 파일 커밋 여부
3.1) 이번 PR에는 설정 파일 커밋 없음