### PR TITLE
Feat/be#65: AI 추천 로직 고도화 v2

### DIFF
--- a/backend/module-ai/src/main/java/com/team6/module/ai/dto/request/GuideRecommendRequest.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/dto/request/GuideRecommendRequest.java
@@ -14,6 +14,9 @@ public class GuideRecommendRequest {
     private String companionType;
     private List<String> activityTags;
     private List<String> preferredLanguages;
+    private Integer headcount;
+    private Integer durationDays;
+    private List<String> excludedActivityTags;
     private Integer topN;
     private List<GuideCandidateDto> guideCandidates;
 

--- a/backend/module-ai/src/main/java/com/team6/module/ai/engine/ReasonGenerator.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/engine/ReasonGenerator.java
@@ -2,6 +2,7 @@ package com.team6.module.ai.engine;
 
 import com.team6.module.ai.model.GuideAiProfile;
 import com.team6.module.ai.model.TravelerPreference;
+import com.team6.module.ai.parser.KeywordNormalizer;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -28,8 +29,15 @@ public class ReasonGenerator {
         }
 
         if (pref.getPreferredLanguages() != null && guide.getLanguages() != null) {
+            Set<String> guideLang = guide.getLanguages().stream()
+                    .map(KeywordNormalizer::normalizeLanguage)
+                    .filter(s -> s != null && !s.isBlank())
+                    .collect(Collectors.toSet());
+
             Set<String> matchedLanguages = pref.getPreferredLanguages().stream()
-                    .filter(guide.getLanguages()::contains)
+                    .map(KeywordNormalizer::normalizeLanguage)
+                    .filter(s -> s != null && !s.isBlank())
+                    .filter(guideLang::contains)
                     .collect(Collectors.toSet());
             if (!matchedLanguages.isEmpty()) {
                 reasons.add("가능 언어(" + String.join("/", matchedLanguages) + ")");
@@ -37,8 +45,15 @@ public class ReasonGenerator {
         }
 
         if (pref.getActivityTags() != null && guide.getSpecialtyTags() != null) {
+            Set<String> guideTags = guide.getSpecialtyTags().stream()
+                    .map(KeywordNormalizer::normalizeTag)
+                    .filter(s -> s != null && !s.isBlank())
+                    .collect(Collectors.toSet());
+
             List<String> matched = pref.getActivityTags().stream()
-                    .filter(guide.getSpecialtyTags()::contains)
+                    .map(KeywordNormalizer::normalizeTag)
+                    .filter(s -> s != null && !s.isBlank())
+                    .filter(guideTags::contains)
                     .distinct()
                     .toList();
 
@@ -46,6 +61,13 @@ public class ReasonGenerator {
                 String head = matched.stream().limit(3).collect(Collectors.joining("/"));
                 reasons.add("관심 활동(" + head + (matched.size() > 3 ? " 외" : "") + ")");
             }
+        }
+
+        if (pref.getHeadcount() != null) {
+            reasons.add("인원 " + pref.getHeadcount() + "명");
+        }
+        if (pref.getDurationDays() != null) {
+            reasons.add("기간 " + pref.getDurationDays() + "일");
         }
 
         if (reasons.isEmpty()) {

--- a/backend/module-ai/src/main/java/com/team6/module/ai/model/TravelerPreference.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/model/TravelerPreference.java
@@ -14,4 +14,9 @@ public class TravelerPreference {
     private String companionType;
     private List<String> activityTags;
     private List<String> preferredLanguages;
+
+    // 파서 확장용(미사용 필드라도 MVP에 영향 없이 확장 가능)
+    private Integer headcount;
+    private Integer durationDays;
+    private List<String> excludedActivityTags;
 }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/parser/KeywordNormalizer.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/parser/KeywordNormalizer.java
@@ -1,0 +1,60 @@
+package com.team6.module.ai.parser;
+
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Prompt/프로필의 다양한 표현을 canonical 형태로 통일한다.
+ * (LLM 없이 룰 기반으로 매칭 정확도만 올리기 위한 유틸)
+ */
+public final class KeywordNormalizer {
+
+    private KeywordNormalizer() {
+    }
+
+    private static final Map<String, String> TAG_SYNONYMS = Map.ofEntries(
+            Map.entry("오션뷰", "바다"),
+            Map.entry("해변", "바다"),
+            Map.entry("바닷가", "바다"),
+            Map.entry("식도락", "맛집"),
+            Map.entry("먹방", "맛집"),
+            Map.entry("포토", "사진"),
+            Map.entry("인생샷", "사진"),
+            Map.entry("전시", "전시"),
+            Map.entry("미술관", "전시"),
+            Map.entry("박물관", "전시"),
+            Map.entry("전통시장", "시장"),
+            Map.entry("로컬시장", "시장")
+    );
+
+    public static String normalizeTag(String tag) {
+        if (tag == null) {
+            return null;
+        }
+        String trimmed = tag.trim();
+        if (trimmed.isEmpty()) {
+            return null;
+        }
+        String canonical = TAG_SYNONYMS.get(trimmed);
+        return canonical != null ? canonical : trimmed;
+    }
+
+    public static String normalizeLanguage(String lang) {
+        if (lang == null) {
+            return null;
+        }
+        String trimmed = lang.trim();
+        if (trimmed.isEmpty()) {
+            return null;
+        }
+        String lower = trimmed.toLowerCase(Locale.ROOT);
+        return switch (lower) {
+            case "eng", "english", "en", "영어" -> "영어";
+            case "jp", "japanese", "ja", "일본어" -> "일본어";
+            case "cn", "chinese", "zh", "중국어" -> "중국어";
+            case "kr", "korean", "ko", "한국어" -> "한국어";
+            default -> trimmed;
+        };
+    }
+}
+

--- a/backend/module-ai/src/main/java/com/team6/module/ai/parser/PromptParser.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/parser/PromptParser.java
@@ -15,6 +15,9 @@ import java.util.regex.Pattern;
 public class PromptParser {
 
     private static final Pattern BUDGET_WON = Pattern.compile("(\\d{1,3}(?:,\\d{3})+|\\d+)\\s*(원|만원)");
+    private static final Pattern HEADCOUNT = Pattern.compile("(\\d+)\\s*(명|인)");
+    private static final Pattern DURATION_NIGHTS_DAYS = Pattern.compile("(\\d+)\\s*박\\s*(\\d+)\\s*일");
+    private static final Pattern DURATION_DAYS = Pattern.compile("(\\d+)\\s*일");
 
     public GuideRecommendRequest parse(
             String prompt,
@@ -28,7 +31,10 @@ public class PromptParser {
         String budgetLevel = extractBudgetLevel(normalizedPrompt);
         String companionType = extractCompanionType(normalizedPrompt);
         List<String> activityTags = extractActivityTags(normalizedPrompt);
+        List<String> excludedActivityTags = extractExcludedActivityTags(normalizedPrompt);
         List<String> preferredLanguages = extractLanguages(normalizedPrompt);
+        Integer headcount = extractHeadcount(normalizedPrompt);
+        Integer durationDays = extractDurationDays(normalizedPrompt);
 
         return GuideRecommendRequest.builder()
                 .region(region)
@@ -37,6 +43,9 @@ public class PromptParser {
                 .companionType(companionType)
                 .activityTags(activityTags)
                 .preferredLanguages(preferredLanguages)
+                .headcount(headcount)
+                .durationDays(durationDays)
+                .excludedActivityTags(excludedActivityTags)
                 .topN(topN)
                 .guideCandidates(guideCandidates)
                 .build();
@@ -103,8 +112,20 @@ public class PromptParser {
         if (containsAny(prompt, "바다", "해변", "오션뷰")) tags.add("바다");
         if (containsAny(prompt, "박물관", "미술관", "전시")) tags.add("전시");
         if (containsAny(prompt, "시장", "전통시장", "로컬시장")) tags.add("시장");
+        if (containsAny(prompt, "술집", "클럽", "바")) tags.add("술집");
 
         return new ArrayList<>(tags);
+    }
+
+    private List<String> extractExcludedActivityTags(String prompt) {
+        // 간단 룰: "<키워드> ... (빼고|제외|말고)" 형태를 포함하면 제외 태그로 등록
+        Set<String> excluded = new LinkedHashSet<>();
+        if (containsAny(prompt, "빼고", "제외", "말고")) {
+            if (containsAny(prompt, "술집", "클럽", "바") && containsAny(prompt, "빼고", "제외", "말고")) excluded.add("술집");
+            if (containsAny(prompt, "등산", "트레킹") && containsAny(prompt, "빼고", "제외", "말고")) excluded.add("등산");
+            if (containsAny(prompt, "쇼핑") && containsAny(prompt, "빼고", "제외", "말고")) excluded.add("쇼핑");
+        }
+        return new ArrayList<>(excluded);
     }
 
     private List<String> extractLanguages(String prompt) {
@@ -146,5 +167,38 @@ public class PromptParser {
         } catch (NumberFormatException e) {
             return null;
         }
+    }
+
+    private Integer extractHeadcount(String prompt) {
+        Matcher m = HEADCOUNT.matcher(prompt);
+        if (!m.find()) {
+            return null;
+        }
+        try {
+            int n = Integer.parseInt(m.group(1));
+            return (n <= 0 || n > 20) ? null : n;
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private Integer extractDurationDays(String prompt) {
+        Matcher m = DURATION_NIGHTS_DAYS.matcher(prompt);
+        if (m.find()) {
+            try {
+                int days = Integer.parseInt(m.group(2));
+                return (days <= 0 || days > 30) ? null : days;
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        Matcher d = DURATION_DAYS.matcher(prompt);
+        if (d.find()) {
+            try {
+                int days = Integer.parseInt(d.group(1));
+                return (days <= 0 || days > 30) ? null : days;
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        return null;
     }
 }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/policy/ActivityMatchPolicy.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/policy/ActivityMatchPolicy.java
@@ -2,7 +2,11 @@ package com.team6.module.ai.policy;
 
 import com.team6.module.ai.model.GuideAiProfile;
 import com.team6.module.ai.model.TravelerPreference;
+import com.team6.module.ai.parser.KeywordNormalizer;
 import org.springframework.stereotype.Component;
+
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Component
 public class ActivityMatchPolicy {
@@ -12,8 +16,18 @@ public class ActivityMatchPolicy {
             return 0;
         }
 
-        long matchedCount = pref.getActivityTags().stream()
-                .filter(guide.getSpecialtyTags()::contains)
+        Set<String> prefTags = pref.getActivityTags().stream()
+                .map(KeywordNormalizer::normalizeTag)
+                .filter(s -> s != null && !s.isBlank())
+                .collect(Collectors.toSet());
+
+        Set<String> guideTags = guide.getSpecialtyTags().stream()
+                .map(KeywordNormalizer::normalizeTag)
+                .filter(s -> s != null && !s.isBlank())
+                .collect(Collectors.toSet());
+
+        long matchedCount = prefTags.stream()
+                .filter(guideTags::contains)
                 .count();
 
         return (int) matchedCount * ScoreWeight.ACTIVITY;

--- a/backend/module-ai/src/main/java/com/team6/module/ai/policy/LanguageMatchPolicy.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/policy/LanguageMatchPolicy.java
@@ -2,7 +2,11 @@ package com.team6.module.ai.policy;
 
 import com.team6.module.ai.model.GuideAiProfile;
 import com.team6.module.ai.model.TravelerPreference;
+import com.team6.module.ai.parser.KeywordNormalizer;
 import org.springframework.stereotype.Component;
+
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Component
 public class LanguageMatchPolicy {
@@ -12,8 +16,17 @@ public class LanguageMatchPolicy {
             return 0;
         }
 
-        boolean matched = pref.getPreferredLanguages().stream()
-                .anyMatch(lang -> guide.getLanguages().contains(lang));
+        Set<String> prefLang = pref.getPreferredLanguages().stream()
+                .map(KeywordNormalizer::normalizeLanguage)
+                .filter(s -> s != null && !s.isBlank())
+                .collect(Collectors.toSet());
+
+        Set<String> guideLang = guide.getLanguages().stream()
+                .map(KeywordNormalizer::normalizeLanguage)
+                .filter(s -> s != null && !s.isBlank())
+                .collect(Collectors.toSet());
+
+        boolean matched = prefLang.stream().anyMatch(guideLang::contains);
 
         return matched ? ScoreWeight.LANGUAGE : 0;
     }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationMapper.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationMapper.java
@@ -5,6 +5,8 @@ import com.team6.module.ai.model.GuideAiProfile;
 import com.team6.module.ai.model.TravelerPreference;
 
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class AiRecommendationMapper {
 
@@ -12,13 +14,23 @@ public class AiRecommendationMapper {
     }
 
     public static TravelerPreference toPreference(GuideRecommendRequest request) {
+        List<String> excluded = request.getExcludedActivityTags() == null ? List.of() : request.getExcludedActivityTags();
+        Set<String> excludedSet = excluded.stream().collect(Collectors.toSet());
+        List<String> activityTags = request.getActivityTags() == null ? List.of() : request.getActivityTags();
+        List<String> filteredTags = activityTags.stream()
+                .filter(t -> !excludedSet.contains(t))
+                .toList();
+
         return TravelerPreference.builder()
                 .region(request.getRegion())
                 .travelStyle(request.getTravelStyle())
                 .budgetLevel(request.getBudgetLevel())
                 .companionType(request.getCompanionType())
-                .activityTags(request.getActivityTags())
+                .activityTags(filteredTags)
                 .preferredLanguages(request.getPreferredLanguages())
+                .headcount(request.getHeadcount())
+                .durationDays(request.getDurationDays())
+                .excludedActivityTags(excluded)
                 .build();
     }
 

--- a/backend/module-ai/src/test/java/com/team6/module/ai/parser/PromptParserTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/parser/PromptParserTest.java
@@ -34,4 +34,17 @@ class PromptParserTest {
         assertThat(request.getBudgetLevel()).isEqualTo("중간");
         assertThat(request.getActivityTags()).contains("카페");
     }
+
+    @Test
+    void parse_should_extract_headcount_and_duration_and_exclusions() {
+        String prompt = "제주 2박3일로 4명 여행인데 술집은 빼고 바다(오션뷰)랑 맛집 위주로 추천해줘";
+
+        GuideRecommendRequest request = promptParser.parse(prompt, 3, List.of());
+
+        assertThat(request.getRegion()).isEqualTo("제주");
+        assertThat(request.getHeadcount()).isEqualTo(4);
+        assertThat(request.getDurationDays()).isEqualTo(3);
+        assertThat(request.getExcludedActivityTags()).contains("술집");
+        assertThat(request.getActivityTags()).contains("바다", "맛집");
+    }
 }

--- a/backend/module-ai/src/test/java/com/team6/module/ai/service/AiRecommendationServiceTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/service/AiRecommendationServiceTest.java
@@ -75,6 +75,35 @@ class AiRecommendationServiceTest {
     }
 
     @Test
+    void recommend_should_apply_synonym_matching_for_activity_tags() {
+        AiRecommendationService aiRecommendationService = createService();
+
+        GuideRecommendRequest request = GuideRecommendRequest.builder()
+                .region("제주")
+                .travelStyle("감성")
+                .budgetLevel("중간")
+                .activityTags(List.of("오션뷰")) // synonym -> 바다
+                .topN(1)
+                .guideCandidates(List.of(
+                        GuideRecommendRequest.GuideCandidateDto.builder()
+                                .guideId(1L)
+                                .guideName("A가이드")
+                                .region("제주")
+                                .guideStyle("감성")
+                                .priceLevel("중간")
+                                .specialtyTags(List.of("바다"))
+                                .languages(List.of("한국어"))
+                                .build()
+                ))
+                .build();
+
+        GuideRecommendResponse response = aiRecommendationService.recommend(request);
+        assertThat(response.getRecommendations()).isNotEmpty();
+        assertThat(response.getRecommendations().get(0).getScore()).isGreaterThan(0);
+        assertThat(response.getRecommendations().get(0).getReason()).contains("관심 활동");
+    }
+
+    @Test
     void recommend_should_return_empty_when_no_candidates() {
         AiRecommendationService aiRecommendationService = createService();
 


### PR DESCRIPTION
- 동의어/표현 정규화로 태그·언어 매칭 정확도 개선
- 프롬프트에서 인원/기간/제외어를 추출해 요청/선호 데이터에 반영
- reason을 구체화하고 정책 매칭 로직을 정규화 기반으로 개선
- module-ai 테스트 케이스 보강 및 :module-ai:test 통과

# 🔗 이슈 번호
- Closes #65
────────────────────────

주요 변경 사항

[1] 동의어/정규화 레이어 추가로 매칭 정확도 개선
1.1) 태그 동의어 정규화(표현 통일)
→ 예: 오션뷰/해변/바닷가 → 바다, 식도락/먹방 → 맛집, 인생샷/포토 → 사진 등
1.2) 언어 표현 정규화
→ 예: eng/en/english → 영어, jp/ja/japanese → 일본어, cn/zh/chinese → 중국어 등
1.3) 정책 매칭(Activity/Language)에서 정규화된 값 기준으로 비교하도록 개선

[2] 프롬프트 파싱 확장(룰 기반)
2.1) 인원(headcount) 추출
→ 예: “4명/4인” 형태 인식
2.2) 기간(durationDays) 추출
→ 예: “2박3일”, “3일” 형태 인식
2.3) 제외어(excludedActivityTags) 추출
→ 예: “술집은 빼고/제외/말고” 같은 표현을 제외 태그로 반영
2.4) 신규 필드는 optional로 추가하여 기존 요청/응답 호환 유지

[3] reason(추천 사유) 구체화
3.1) 언어/활동 태그 매칭도 정규화 기반으로 reason에 반영
3.2) 인원/기간 정보가 있는 경우 reason에 함께 표기
3.3) 구분자 가독성 개선(요약형)

[4] 테스트 보강 및 검증
4.1) 파서 테스트에 인원/기간/제외어 케이스 추가
4.2) 동의어 매칭(오션뷰 → 바다) 점수/사유 반영 테스트 추가
4.3) ./gradlew :module-ai:test 통과 확인

────────────────────────

주의 사항 / 질문

[1] 제외어 처리 범위(MVP 룰)
1.1) 현재는 “술집/등산/쇼핑” 등 일부 키워드에 대해 제외어를 적용
1.2) 추후 제외 대상 태그는 요구사항에 맞춰 확장 가능

────────────────────────

체크리스트

[1] 테스트
1.1) ./gradlew :module-ai:test 통과 확인

[2] 커밋 컨벤션
2.1) Feat/be#65 형식 준수

[3] 설정 파일 커밋 여부
3.1) 이번 PR에는 설정 파일 커밋 없음