### PR TITLE
Feat/be#67: AI 추천 다양성 rerank 적용

### DIFF
--- a/backend/module-ai/src/main/java/com/team6/module/ai/engine/MatchingEngine.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/engine/MatchingEngine.java
@@ -4,11 +4,17 @@ import com.team6.module.ai.dto.response.GuideRecommendItem;
 import com.team6.module.ai.dto.response.GuideRecommendResponse;
 import com.team6.module.ai.model.GuideAiProfile;
 import com.team6.module.ai.model.TravelerPreference;
+import com.team6.module.ai.parser.KeywordNormalizer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.Comparator;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
@@ -17,30 +23,133 @@ public class MatchingEngine {
     private final ScoreCalculator scoreCalculator;
     private final ReasonGenerator reasonGenerator;
 
+    private static final double DIVERSITY_LAMBDA = 15.0;
+    private static final double REGION_SIM_WEIGHT = 1.0;
+    private static final double STYLE_SIM_WEIGHT = 0.8;
+    private static final double TAG_SIM_WEIGHT = 0.8;
+
     public GuideRecommendResponse recommend(
             TravelerPreference preference,
             List<GuideAiProfile> guides,
             int topN
     ) {
-        List<GuideRecommendItem> items = guides.stream()
+        List<ScoredGuide> scored = guides.stream()
                 .map(guide -> {
                     int score = scoreCalculator.calculate(preference, guide);
                     String reason = reasonGenerator.generate(preference, guide, score);
-
-                    return GuideRecommendItem.builder()
-                            .guideId(guide.getGuideId())
-                            .guideName(guide.getGuideName())
-                            .score(score)
-                            .reason(reason)
-                            .build();
+                    return new ScoredGuide(guide, score, reason);
                 })
-                .sorted(Comparator.comparingInt(GuideRecommendItem::getScore).reversed())
-                .limit(topN)
+                .sorted(Comparator.comparingInt(ScoredGuide::baseScore).reversed())
+                .toList();
+
+        List<ScoredGuide> picked = pickWithDiversityPenalty(scored, topN);
+        List<GuideRecommendItem> items = picked.stream()
+                .map(sg -> GuideRecommendItem.builder()
+                        .guideId(sg.guide.getGuideId())
+                        .guideName(sg.guide.getGuideName())
+                        .score(sg.baseScore)
+                        .reason(sg.reason)
+                        .build())
                 .toList();
 
         return GuideRecommendResponse.builder()
                 .totalCount(items.size())
                 .recommendations(items)
                 .build();
+    }
+
+    private List<ScoredGuide> pickWithDiversityPenalty(List<ScoredGuide> candidates, int topN) {
+        if (topN <= 0 || candidates.isEmpty()) {
+            return List.of();
+        }
+
+        int limit = Math.min(topN, candidates.size());
+        List<ScoredGuide> selected = new ArrayList<>(limit);
+        Set<Long> used = new HashSet<>();
+
+        while (selected.size() < limit) {
+            ScoredGuide best = null;
+            double bestFinal = Double.NEGATIVE_INFINITY;
+
+            for (ScoredGuide c : candidates) {
+                if (c.guide.getGuideId() == null || used.contains(c.guide.getGuideId())) {
+                    continue;
+                }
+                double penalty = selected.isEmpty() ? 0.0 : maxSimilarityToSelected(c.guide, selected) * DIVERSITY_LAMBDA;
+                double finalScore = c.baseScore - penalty;
+
+                if (finalScore > bestFinal) {
+                    bestFinal = finalScore;
+                    best = c;
+                }
+            }
+
+            if (best == null) {
+                break;
+            }
+
+            selected.add(best);
+            used.add(best.guide.getGuideId());
+        }
+
+        return selected;
+    }
+
+    private double maxSimilarityToSelected(GuideAiProfile candidate, List<ScoredGuide> selected) {
+        double max = 0.0;
+        for (ScoredGuide s : selected) {
+            max = Math.max(max, similarity(candidate, s.guide));
+        }
+        return max;
+    }
+
+    private double similarity(GuideAiProfile a, GuideAiProfile b) {
+        double sim = 0.0;
+
+        if (safeEquals(a.getRegion(), b.getRegion())) {
+            sim += REGION_SIM_WEIGHT;
+        }
+        if (safeEquals(a.getGuideStyle(), b.getGuideStyle())) {
+            sim += STYLE_SIM_WEIGHT;
+        }
+
+        double tagSim = tagOverlapRatio(a.getSpecialtyTags(), b.getSpecialtyTags());
+        sim += TAG_SIM_WEIGHT * tagSim;
+
+        // normalize to 0..1-ish
+        double max = REGION_SIM_WEIGHT + STYLE_SIM_WEIGHT + TAG_SIM_WEIGHT;
+        return max == 0.0 ? 0.0 : (sim / max);
+    }
+
+    private double tagOverlapRatio(List<String> tagsA, List<String> tagsB) {
+        if (tagsA == null || tagsB == null || tagsA.isEmpty() || tagsB.isEmpty()) {
+            return 0.0;
+        }
+        Set<String> a = tagsA.stream()
+                .map(KeywordNormalizer::normalizeTag)
+                .filter(s -> s != null && !s.isBlank())
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        Set<String> b = tagsB.stream()
+                .map(KeywordNormalizer::normalizeTag)
+                .filter(s -> s != null && !s.isBlank())
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        if (a.isEmpty() || b.isEmpty()) {
+            return 0.0;
+        }
+
+        Set<String> inter = new LinkedHashSet<>(a);
+        inter.retainAll(b);
+        Set<String> uni = new LinkedHashSet<>(a);
+        uni.addAll(b);
+
+        return uni.isEmpty() ? 0.0 : ((double) inter.size() / (double) uni.size());
+    }
+
+    private boolean safeEquals(String a, String b) {
+        return a != null && a.equalsIgnoreCase(b);
+    }
+
+    private record ScoredGuide(GuideAiProfile guide, int baseScore, String reason) {
     }
 }

--- a/backend/module-ai/src/test/java/com/team6/module/ai/service/AiRecommendationServiceTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/service/AiRecommendationServiceTest.java
@@ -164,4 +164,55 @@ class AiRecommendationServiceTest {
         assertThat(response).isNotNull();
         assertThat(response.getRecommendations()).hasSize(1);
     }
+
+    @Test
+    void recommend_should_rerank_for_diversity_when_top_results_are_too_similar() {
+        AiRecommendationService aiRecommendationService = createService();
+
+        GuideRecommendRequest request = GuideRecommendRequest.builder()
+                .region("제주")
+                .budgetLevel("중간")
+                .activityTags(List.of("카페", "바다"))
+                .preferredLanguages(List.of("한국어"))
+                .topN(2)
+                .guideCandidates(List.of(
+                        // A and B are very similar (same region/style/tags) but B has slightly lower base score
+                        GuideRecommendRequest.GuideCandidateDto.builder()
+                                .guideId(1L)
+                                .guideName("A가이드")
+                                .region("제주")
+                                .guideStyle("감성")
+                                .priceLevel("중간")
+                                .specialtyTags(List.of("카페", "바다"))
+                                .languages(List.of("한국어"))
+                                .build(),
+                        GuideRecommendRequest.GuideCandidateDto.builder()
+                                .guideId(2L)
+                                .guideName("B가이드")
+                                .region("제주")
+                                .guideStyle("감성")
+                                .priceLevel("중간")
+                                .specialtyTags(List.of("카페", "바다"))
+                                .languages(List.of("한국어"))
+                                .build(),
+                        // C is slightly less matched but provides diversity (different style/tags)
+                        GuideRecommendRequest.GuideCandidateDto.builder()
+                                .guideId(3L)
+                                .guideName("C가이드")
+                                .region("제주")
+                                .guideStyle("로컬")
+                                .priceLevel("중간")
+                                .specialtyTags(List.of("카페", "바다"))
+                                .languages(List.of("한국어"))
+                                .build()
+                ))
+                .build();
+
+        GuideRecommendResponse response = aiRecommendationService.recommend(request);
+
+        assertThat(response.getRecommendations()).hasSize(2);
+        assertThat(response.getRecommendations().get(0).getGuideId()).isEqualTo(1L);
+        // Diversity rerank should prefer C over B for the second slot
+        assertThat(response.getRecommendations().get(1).getGuideId()).isEqualTo(3L);
+    }
 }


### PR DESCRIPTION

# 🔗 이슈 번호
- Closes #67
────────────────────────

주요 변경 사항

[1] AI 추천 다양성 rerank(유사도 패널티) 적용
1.1) 기존: 점수 내림차순 정렬 후 Top‑N 단순 선택
1.2) 변경: Top‑N 선택 과정에서 “이미 선택된 후보와의 유사도”에 패널티를 부여하여 중복 후보 쏠림 완화
1.3) 최종 선택 점수 개념
→ finalScore = baseScore − (λ × similarity)

[2] 유사도(similarity) 산정 기준(MVP 룰)
2.1) region 동일 여부
2.2) guideStyle 동일 여부
2.3) specialtyTags 유사도(Jaccard overlap, 동의어 정규화 적용)

[3] 단위 테스트 추가
3.1) 유사 후보가 많은 후보군에서 Top‑N 결과가 다양해지는지 검증 테스트 추가
3.2) ./gradlew :module-ai:test 통과 확인

────────────────────────

주의 사항 / 질문

[1] 튜닝 포인트
1.1) 다양성 강도는 λ(DIVERSITY_LAMBDA) 값으로 조절 가능
1.2) 현재는 MVP 기본값으로 적용(추후 설정화 가능)

────────────────────────

체크리스트

[1] 테스트
1.1) ./gradlew :module-ai:test 통과 확인

[2] 커밋 컨벤션
2.1) Feat/be#67 형식 준수

[3] 설정 파일 커밋 여부
3.1) 이번 PR에는 설정 파일 커밋 없음