### PR TITLE
Feat/be#69: AI 추천 응답에 matched 구조화 필드 추가

### DIFF
--- a/backend/module-ai/src/main/java/com/team6/module/ai/dto/response/GuideRecommendItem.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/dto/response/GuideRecommendItem.java
@@ -3,6 +3,8 @@ package com.team6.module.ai.dto.response;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.List;
+
 @Getter
 @Builder
 public class GuideRecommendItem {
@@ -10,4 +12,16 @@ public class GuideRecommendItem {
     private String guideName;
     private int score;
     private String reason;
+
+    private MatchedEvidence matched;
+
+    @Getter
+    @Builder
+    public static class MatchedEvidence {
+        private boolean region;
+        private boolean style;
+        private boolean budget;
+        private List<String> tags;
+        private List<String> languages;
+    }
 }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/engine/MatchingEngine.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/engine/MatchingEngine.java
@@ -49,6 +49,7 @@ public class MatchingEngine {
                         .guideName(sg.guide.getGuideName())
                         .score(sg.baseScore)
                         .reason(sg.reason)
+                        .matched(buildMatchedEvidence(preference, sg.guide))
                         .build())
                 .toList();
 
@@ -148,6 +149,57 @@ public class MatchingEngine {
 
     private boolean safeEquals(String a, String b) {
         return a != null && a.equalsIgnoreCase(b);
+    }
+
+    private GuideRecommendItem.MatchedEvidence buildMatchedEvidence(TravelerPreference pref, GuideAiProfile guide) {
+        boolean region = safeEquals(pref.getRegion(), guide.getRegion());
+        boolean style = safeEquals(pref.getTravelStyle(), guide.getGuideStyle());
+        boolean budget = safeEquals(pref.getBudgetLevel(), guide.getPriceLevel());
+
+        List<String> matchedTags = intersectNormalizedTags(pref.getActivityTags(), guide.getSpecialtyTags());
+        List<String> matchedLanguages = intersectNormalizedLanguages(pref.getPreferredLanguages(), guide.getLanguages());
+
+        return GuideRecommendItem.MatchedEvidence.builder()
+                .region(region)
+                .style(style)
+                .budget(budget)
+                .tags(matchedTags)
+                .languages(matchedLanguages)
+                .build();
+    }
+
+    private List<String> intersectNormalizedTags(List<String> a, List<String> b) {
+        if (a == null || b == null || a.isEmpty() || b.isEmpty()) {
+            return List.of();
+        }
+        Set<String> right = b.stream()
+                .map(KeywordNormalizer::normalizeTag)
+                .filter(s -> s != null && !s.isBlank())
+                .collect(Collectors.toSet());
+
+        return a.stream()
+                .map(KeywordNormalizer::normalizeTag)
+                .filter(s -> s != null && !s.isBlank())
+                .distinct()
+                .filter(right::contains)
+                .toList();
+    }
+
+    private List<String> intersectNormalizedLanguages(List<String> a, List<String> b) {
+        if (a == null || b == null || a.isEmpty() || b.isEmpty()) {
+            return List.of();
+        }
+        Set<String> right = b.stream()
+                .map(KeywordNormalizer::normalizeLanguage)
+                .filter(s -> s != null && !s.isBlank())
+                .collect(Collectors.toSet());
+
+        return a.stream()
+                .map(KeywordNormalizer::normalizeLanguage)
+                .filter(s -> s != null && !s.isBlank())
+                .distinct()
+                .filter(right::contains)
+                .toList();
     }
 
     private record ScoredGuide(GuideAiProfile guide, int baseScore, String reason) {

--- a/backend/module-ai/src/test/java/com/team6/module/ai/service/AiRecommendationServiceTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/service/AiRecommendationServiceTest.java
@@ -72,6 +72,8 @@ class AiRecommendationServiceTest {
         assertThat(response.getRecommendations()).isNotEmpty();
         assertThat(response.getRecommendations().get(0).getGuideId()).isEqualTo(1L);
         assertThat(response.getRecommendations().get(0).getReason()).contains("선호 지역");
+        assertThat(response.getRecommendations().get(0).getMatched()).isNotNull();
+        assertThat(response.getRecommendations().get(0).getMatched().isRegion()).isTrue();
     }
 
     @Test
@@ -101,6 +103,8 @@ class AiRecommendationServiceTest {
         assertThat(response.getRecommendations()).isNotEmpty();
         assertThat(response.getRecommendations().get(0).getScore()).isGreaterThan(0);
         assertThat(response.getRecommendations().get(0).getReason()).contains("관심 활동");
+        assertThat(response.getRecommendations().get(0).getMatched()).isNotNull();
+        assertThat(response.getRecommendations().get(0).getMatched().getTags()).contains("바다");
     }
 
     @Test


### PR DESCRIPTION
# 🔗 이슈 번호
- Closes #69
────────────────────────

주요 변경 사항

[1] AI 추천 응답에 matched(구조화 근거) 필드 추가
1.1) 기존 reason 문자열은 유지하면서, 프론트에서 뱃지/하이라이트로 바로 사용할 수 있는 구조화 필드를 함께 제공
1.2) 추가된 필드(GuideRecommendItem.matched)
→ region : 지역 일치 여부(boolean)
→ style : 스타일 일치 여부(boolean)
→ budget : 예산대 일치 여부(boolean)
→ tags : 일치한 활동 태그 목록(List)
→ languages : 일치한 언어 목록(List)

[2] matched 근거 계산 방식
2.1) KeywordNormalizer 기반으로 태그/언어를 정규화한 뒤 교집합을 계산하여 matched 목록 생성
2.2) 문자열 파싱 없이 “매칭된 근거”를 UI에서 안정적으로 사용 가능

[3] 테스트 보강 및 검증
3.1) 추천 결과에 matched 필드가 포함되는지 테스트로 검증
3.2) 동의어 매칭(예: 오션뷰 → 바다)이 matched.tags에도 반영되는지 검증
3.3) ./gradlew :module-ai:test 통과 확인

────────────────────────

주의 사항 / 질문

[1] 하위 호환성
1.1) reason 필드는 그대로 유지(기존 클라이언트 영향 최소화)
1.2) matched는 신규 필드로 추가 제공

────────────────────────

체크리스트

[1] 테스트
1.1) ./gradlew :module-ai:test 통과 확인

[2] 커밋 컨벤션
2.1) Feat/be#69 형식 준수

[3] 설정 파일 커밋 여부
3.1) 이번 PR에는 설정 파일 커밋 없음