### PR TITLE
Feat/be#75: AI 추천 품질 강화(파서·사유·fallback·로그)

### DIFF
--- a/backend/module-ai/src/main/java/com/team6/module/ai/dto/response/GuideRecommendResponse.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/dto/response/GuideRecommendResponse.java
@@ -10,6 +10,7 @@ import java.util.List;
 public class GuideRecommendResponse {
     private String conceptSummary;
     private Keywords keywords;
+    private String notice;
     private int totalCount;
     private List<GuideRecommendItem> recommendations;
 

--- a/backend/module-ai/src/main/java/com/team6/module/ai/engine/ReasonGenerator.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/engine/ReasonGenerator.java
@@ -6,6 +6,7 @@ import com.team6.module.ai.parser.KeywordNormalizer;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -14,7 +15,8 @@ import java.util.stream.Collectors;
 public class ReasonGenerator {
 
     public String generate(TravelerPreference pref, GuideAiProfile guide, int score) {
-        List<String> reasons = new ArrayList<>();
+        // "핵심 근거" 위주로 2~3개만 노출 (중복 제거)
+        LinkedHashSet<String> reasons = new LinkedHashSet<>();
 
         if (safeEquals(pref.getRegion(), guide.getRegion())) {
             reasons.add("선호 지역이 일치");
@@ -22,10 +24,6 @@ public class ReasonGenerator {
 
         if (safeEquals(pref.getTravelStyle(), guide.getGuideStyle())) {
             reasons.add("여행 스타일이 유사");
-        }
-
-        if (safeEquals(pref.getBudgetLevel(), guide.getPriceLevel())) {
-            reasons.add("예산대가 비슷");
         }
 
         if (pref.getPreferredLanguages() != null && guide.getLanguages() != null) {
@@ -63,18 +61,19 @@ public class ReasonGenerator {
             }
         }
 
-        if (pref.getHeadcount() != null) {
-            reasons.add("인원 " + pref.getHeadcount() + "명");
-        }
-        if (pref.getDurationDays() != null) {
-            reasons.add("기간 " + pref.getDurationDays() + "일");
+        if (safeEquals(pref.getBudgetLevel(), guide.getPriceLevel())) {
+            reasons.add("예산대가 비슷");
         }
 
         if (reasons.isEmpty()) {
             reasons.add("전체 선호도 기준으로 적합");
         }
 
-        return String.join(" · ", reasons);
+        List<String> top = new ArrayList<>(reasons);
+        if (top.size() > 3) {
+            top = top.subList(0, 3);
+        }
+        return String.join(" · ", top);
     }
 
     private boolean safeEquals(String a, String b) {

--- a/backend/module-ai/src/main/java/com/team6/module/ai/parser/PromptParser.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/parser/PromptParser.java
@@ -15,9 +15,11 @@ import java.util.regex.Pattern;
 public class PromptParser {
 
     private static final Pattern BUDGET_WON = Pattern.compile("(\\d{1,3}(?:,\\d{3})+|\\d+)\\s*(원|만원)");
+    private static final Pattern BUDGET_MANWON_BAND = Pattern.compile("(\\d+)\\s*만원\\s*대");
     private static final Pattern HEADCOUNT = Pattern.compile("(\\d+)\\s*(명|인)");
     private static final Pattern DURATION_NIGHTS_DAYS = Pattern.compile("(\\d+)\\s*박\\s*(\\d+)\\s*일");
     private static final Pattern DURATION_DAYS = Pattern.compile("(\\d+)\\s*일");
+    private static final Pattern DURATION_WEEKS = Pattern.compile("(\\d+)\\s*주");
 
     public GuideRecommendRequest parse(
             String prompt,
@@ -85,9 +87,18 @@ public class PromptParser {
             return "높음";
         }
 
+        Integer band = extractBudgetBand(prompt);
+        if (band != null) {
+            // ex) "10만원대" -> 대략 10~19만원 구간으로 간주
+            int approx = band * 10_000;
+            if (approx <= 100_000) return "낮음";
+            if (approx <= 300_000) return "중간";
+            return "높음";
+        }
+
         if (containsAny(prompt, "저렴", "가성비", "싸게", "예산 적게")) return "낮음";
         if (containsAny(prompt, "적당", "무난", "보통", "중간")) return "중간";
-        if (containsAny(prompt, "럭셔리", "고급", "비싸도", "프리미엄")) return "높음";
+        if (containsAny(prompt, "럭셔리", "고급", "비싸도", "프리미엄", "플렉스")) return "높음";
         return null;
     }
 
@@ -95,6 +106,7 @@ public class PromptParser {
         if (containsAny(prompt, "혼자", "혼행", "1인")) return "혼자";
         if (containsAny(prompt, "친구", "친구랑", "우정", "동창")) return "친구";
         if (containsAny(prompt, "가족", "부모님", "엄마", "아빠", "아이", "애기")) return "가족";
+        if (containsAny(prompt, "반려견", "강아지", "댕댕이", "반려동물")) return "반려견";
         if (containsAny(prompt, "연인", "커플", "데이트", "여자친구", "남자친구")) return "연인";
         return null;
     }
@@ -118,12 +130,12 @@ public class PromptParser {
     }
 
     private List<String> extractExcludedActivityTags(String prompt) {
-        // 간단 룰: "<키워드> ... (빼고|제외|말고)" 형태를 포함하면 제외 태그로 등록
+        // 간단 룰: 제외 의도 + 태그 키워드가 같이 등장하면 제외 태그로 등록
         Set<String> excluded = new LinkedHashSet<>();
-        if (containsAny(prompt, "빼고", "제외", "말고")) {
-            if (containsAny(prompt, "술집", "클럽", "바") && containsAny(prompt, "빼고", "제외", "말고")) excluded.add("술집");
-            if (containsAny(prompt, "등산", "트레킹") && containsAny(prompt, "빼고", "제외", "말고")) excluded.add("등산");
-            if (containsAny(prompt, "쇼핑") && containsAny(prompt, "빼고", "제외", "말고")) excluded.add("쇼핑");
+        if (containsAny(prompt, "빼고", "제외", "말고", "싫어", "안 가", "안가", "원치 않아", "원치않아")) {
+            if (containsAny(prompt, "술집", "클럽", "바")) excluded.add("술집");
+            if (containsAny(prompt, "등산", "트레킹")) excluded.add("등산");
+            if (containsAny(prompt, "쇼핑")) excluded.add("쇼핑");
         }
         return new ArrayList<>(excluded);
     }
@@ -183,10 +195,26 @@ public class PromptParser {
     }
 
     private Integer extractDurationDays(String prompt) {
+        if (containsAny(prompt, "당일치기", "당일")) {
+            return 1;
+        }
+        if (containsAny(prompt, "주말")) {
+            return 2;
+        }
+
         Matcher m = DURATION_NIGHTS_DAYS.matcher(prompt);
         if (m.find()) {
             try {
                 int days = Integer.parseInt(m.group(2));
+                return (days <= 0 || days > 30) ? null : days;
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        Matcher w = DURATION_WEEKS.matcher(prompt);
+        if (w.find()) {
+            try {
+                int weeks = Integer.parseInt(w.group(1));
+                int days = weeks * 7;
                 return (days <= 0 || days > 30) ? null : days;
             } catch (NumberFormatException ignored) {
             }
@@ -200,5 +228,18 @@ public class PromptParser {
             }
         }
         return null;
+    }
+
+    private Integer extractBudgetBand(String prompt) {
+        Matcher m = BUDGET_MANWON_BAND.matcher(prompt);
+        if (!m.find()) {
+            return null;
+        }
+        try {
+            int n = Integer.parseInt(m.group(1));
+            return (n <= 0 || n > 10_000) ? null : n;
+        } catch (NumberFormatException e) {
+            return null;
+        }
     }
 }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
@@ -5,25 +5,48 @@ import com.team6.module.ai.dto.response.GuideRecommendResponse;
 import com.team6.module.ai.parser.PromptParser;
 import com.team6.module.ai.support.ConceptSummaryGenerator;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Objects;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class PromptRecommendationService {
 
     private final PromptParser promptParser;
     private final AiRecommendationService aiRecommendationService;
 
+    private static final int DEFAULT_TOP_N = 3;
+    private static final int LOW_SIGNAL_SCORE_THRESHOLD = 15;
+
     public GuideRecommendResponse recommendByPrompt(
             String prompt,
             Integer topN,
             List<GuideRecommendRequest.GuideCandidateDto> guideCandidates
     ) {
-        Integer resolvedTopN = (topN == null || topN <= 0) ? 3 : topN;
+        Integer resolvedTopN = (topN == null || topN <= 0) ? DEFAULT_TOP_N : topN;
         GuideRecommendRequest request = promptParser.parse(prompt, resolvedTopN, guideCandidates);
+
         GuideRecommendResponse base = aiRecommendationService.recommend(request);
+        FallbackDecision decision = decideFallback(request, base);
+        GuideRecommendResponse finalBase = base;
+
+        if (decision.shouldFallback) {
+            GuideRecommendRequest relaxed = relax(request, decision.stage);
+            GuideRecommendResponse retried = aiRecommendationService.recommend(relaxed);
+
+            if (retried != null && retried.getTotalCount() > 0 && topScore(retried) >= LOW_SIGNAL_SCORE_THRESHOLD) {
+                finalBase = retried;
+            }
+        }
+
+        String notice = decision.notice;
+
+        logRecommendation(prompt, request, guideCandidates, base, finalBase, decision);
 
         return GuideRecommendResponse.builder()
                 .conceptSummary(ConceptSummaryGenerator.generate(request))
@@ -38,8 +61,158 @@ public class PromptRecommendationService {
                         .excludedActivityTags(request.getExcludedActivityTags())
                         .preferredLanguages(request.getPreferredLanguages())
                         .build())
-                .totalCount(base.getTotalCount())
-                .recommendations(base.getRecommendations())
+                .notice(notice)
+                .totalCount(finalBase.getTotalCount())
+                .recommendations(finalBase.getRecommendations())
                 .build();
+    }
+
+    private static int topScore(GuideRecommendResponse resp) {
+        if (resp == null || resp.getRecommendations() == null || resp.getRecommendations().isEmpty()) {
+            return 0;
+        }
+        return resp.getRecommendations().get(0).getScore();
+    }
+
+    private FallbackDecision decideFallback(GuideRecommendRequest request, GuideRecommendResponse base) {
+        int candidateCount = request.getGuideCandidates() == null ? 0 : request.getGuideCandidates().size();
+        if (candidateCount == 0) {
+            return new FallbackDecision(false, RelaxStage.NONE, "가이드 후보가 없어 추천이 제한됩니다.");
+        }
+
+        int score = topScore(base);
+        boolean extractedAnySignal = hasAnySignal(request);
+        if (!extractedAnySignal) {
+            return new FallbackDecision(false, RelaxStage.NONE, "원하는 조건(지역/스타일/예산/활동/언어/기간/인원)을 조금 더 구체적으로 알려주세요.");
+        }
+
+        if (base == null || base.getTotalCount() == 0) {
+            return new FallbackDecision(true, RelaxStage.DROP_REGION_STYLE, "조건을 일부 완화해 비슷한 가이드를 다시 찾아봤어요.");
+        }
+
+        if (score < LOW_SIGNAL_SCORE_THRESHOLD) {
+            return new FallbackDecision(true, RelaxStage.DROP_REGION, "조건을 일부 완화해 더 많은 후보를 찾아봤어요.");
+        }
+
+        return new FallbackDecision(false, RelaxStage.NONE, null);
+    }
+
+    private static boolean hasAnySignal(GuideRecommendRequest req) {
+        if (req == null) return false;
+        return notBlank(req.getRegion())
+                || notBlank(req.getTravelStyle())
+                || notBlank(req.getBudgetLevel())
+                || notBlank(req.getCompanionType())
+                || (req.getActivityTags() != null && !req.getActivityTags().isEmpty())
+                || (req.getPreferredLanguages() != null && !req.getPreferredLanguages().isEmpty())
+                || req.getHeadcount() != null
+                || req.getDurationDays() != null
+                || (req.getExcludedActivityTags() != null && !req.getExcludedActivityTags().isEmpty());
+    }
+
+    private GuideRecommendRequest relax(GuideRecommendRequest original, RelaxStage stage) {
+        if (original == null) {
+            return null;
+        }
+
+        String region = original.getRegion();
+        String style = original.getTravelStyle();
+        List<String> langs = original.getPreferredLanguages();
+        List<String> tags = original.getActivityTags();
+
+        if (stage == RelaxStage.DROP_REGION) {
+            region = null;
+        } else if (stage == RelaxStage.DROP_REGION_STYLE) {
+            region = null;
+            style = null;
+        } else if (stage == RelaxStage.DROP_REGION_STYLE_LANGUAGE) {
+            region = null;
+            style = null;
+            langs = List.of();
+        } else if (stage == RelaxStage.DROP_REGION_STYLE_TAGS_LANGUAGE) {
+            region = null;
+            style = null;
+            langs = List.of();
+            tags = List.of();
+        }
+
+        return GuideRecommendRequest.builder()
+                .region(region)
+                .travelStyle(style)
+                .budgetLevel(original.getBudgetLevel())
+                .companionType(original.getCompanionType())
+                .activityTags(tags)
+                .preferredLanguages(langs)
+                .headcount(original.getHeadcount())
+                .durationDays(original.getDurationDays())
+                .excludedActivityTags(original.getExcludedActivityTags())
+                .topN(original.getTopN())
+                .guideCandidates(original.getGuideCandidates())
+                .build();
+    }
+
+    private void logRecommendation(
+            String prompt,
+            GuideRecommendRequest request,
+            List<GuideRecommendRequest.GuideCandidateDto> guideCandidates,
+            GuideRecommendResponse base,
+            GuideRecommendResponse finalBase,
+            FallbackDecision decision
+    ) {
+        try {
+            int promptHash = Objects.toString(prompt, "").getBytes(StandardCharsets.UTF_8).length == 0
+                    ? 0
+                    : Objects.toString(prompt, "").hashCode();
+            int candidateCount = guideCandidates == null ? 0 : guideCandidates.size();
+            int baseTopScore = topScore(base);
+            int finalTopScore = topScore(finalBase);
+
+            log.info("[AI_RECOMMEND] promptHash={} topN={} candidates={} keywords={{region={},style={},budget={},companion={},headcount={},durationDays={},tags={},excluded={},langs={}}} base={{count={},topScore={}}} final={{count={},topScore={}}} fallback={{used={},stage={}}}",
+                    promptHash,
+                    request == null ? null : request.getTopN(),
+                    candidateCount,
+                    request == null ? null : request.getRegion(),
+                    request == null ? null : request.getTravelStyle(),
+                    request == null ? null : request.getBudgetLevel(),
+                    request == null ? null : request.getCompanionType(),
+                    request == null ? null : request.getHeadcount(),
+                    request == null ? null : request.getDurationDays(),
+                    request == null ? null : request.getActivityTags(),
+                    request == null ? null : request.getExcludedActivityTags(),
+                    request == null ? null : request.getPreferredLanguages(),
+                    base == null ? 0 : base.getTotalCount(),
+                    baseTopScore,
+                    finalBase == null ? 0 : finalBase.getTotalCount(),
+                    finalTopScore,
+                    decision != null && decision.shouldFallback,
+                    decision == null ? null : decision.stage
+            );
+        } catch (Exception e) {
+            log.debug("[AI_RECOMMEND] logging skipped: {}", e.toString());
+        }
+    }
+
+    private static boolean notBlank(String s) {
+        return s != null && !s.isBlank();
+    }
+
+    private enum RelaxStage {
+        NONE,
+        DROP_REGION,
+        DROP_REGION_STYLE,
+        DROP_REGION_STYLE_LANGUAGE,
+        DROP_REGION_STYLE_TAGS_LANGUAGE
+    }
+
+    private static class FallbackDecision {
+        private final boolean shouldFallback;
+        private final RelaxStage stage;
+        private final String notice;
+
+        private FallbackDecision(boolean shouldFallback, RelaxStage stage, String notice) {
+            this.shouldFallback = shouldFallback;
+            this.stage = stage;
+            this.notice = notice;
+        }
     }
 }

--- a/backend/module-ai/src/test/java/com/team6/module/ai/parser/PromptParserTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/parser/PromptParserTest.java
@@ -47,4 +47,29 @@ class PromptParserTest {
         assertThat(request.getExcludedActivityTags()).contains("술집");
         assertThat(request.getActivityTags()).contains("바다", "맛집");
     }
+
+    @Test
+    void parse_should_extract_duration_for_daytrip_weekend_and_weeks() {
+        GuideRecommendRequest daytrip = promptParser.parse("서울 당일치기 여행 추천", 3, List.of());
+        assertThat(daytrip.getDurationDays()).isEqualTo(1);
+
+        GuideRecommendRequest weekend = promptParser.parse("부산 주말 여행할건데 맛집 위주", 3, List.of());
+        assertThat(weekend.getDurationDays()).isEqualTo(2);
+
+        GuideRecommendRequest weeks = promptParser.parse("제주 2주 살기 느낌으로 로컬 위주", 3, List.of());
+        assertThat(weeks.getDurationDays()).isEqualTo(14);
+    }
+
+    @Test
+    void parse_should_extract_budget_level_from_manwon_band() {
+        GuideRecommendRequest request = promptParser.parse("경주 10만원대 가성비로 부탁", 3, List.of());
+        assertThat(request.getBudgetLevel()).isEqualTo("낮음");
+    }
+
+    @Test
+    void parse_should_extract_companion_pet_and_exclusion_synonyms() {
+        GuideRecommendRequest request = promptParser.parse("강릉 반려견이랑 가는데 술집은 싫어", 3, List.of());
+        assertThat(request.getCompanionType()).isEqualTo("반려견");
+        assertThat(request.getExcludedActivityTags()).contains("술집");
+    }
 }


### PR DESCRIPTION
## 작업 내용
- 추천 결과가 없거나 신뢰도가 낮을 때 조건을 일부 완화하여 재추천(fallback)하고, 응답에 notice를 포함
- PromptParser 인식 범위 확장(당일/주말/주, 만원대, 반려견, 제외 표현) + 테스트 추가
- reason를 핵심 근거 3개 중심으로 중복 제거/요약
- 추천 요청/결과를 운영에서 추적할 수 있도록 구조화 로그 추가(개인정보 미포함)

## 변경 사항
- `/ai/recommend` 응답 확장: `notice` 필드 추가
- `PromptRecommendationService`: low-signal/empty 대응(fallback) + 운영 로그
- `PromptParser`: 기간/예산/동행/제외 표현 커버리지 확장
- `ReasonGenerator`: 핵심 근거 3개 우선 노출

## 테스트
- `./gradlew :module-ai:test`

Closes #75

Made with [Cursor](https://cursor.com)