### PR TITLE
Feat/be#77: AI 추천 근거 구조화(reasonCodes/reasonFacts)

### DIFF
--- a/backend/module-ai/src/main/java/com/team6/module/ai/dto/response/GuideRecommendItem.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/dto/response/GuideRecommendItem.java
@@ -12,8 +12,23 @@ public class GuideRecommendItem {
     private String guideName;
     private int score;
     private String reason;
+    /**
+     * 구조화된 추천 근거 코드(표시된 상위 근거와 동일 순서, 최대 3개).
+     */
+    private List<String> reasonCodes;
+    /**
+     * 근거 코드별 매칭 값(예: 태그/언어 목록).
+     */
+    private List<ReasonFact> reasonFacts;
 
     private MatchedEvidence matched;
+
+    @Getter
+    @Builder
+    public static class ReasonFact {
+        private String code;
+        private List<String> values;
+    }
 
     @Getter
     @Builder

--- a/backend/module-ai/src/main/java/com/team6/module/ai/engine/MatchingEngine.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/engine/MatchingEngine.java
@@ -36,8 +36,8 @@ public class MatchingEngine {
         List<ScoredGuide> scored = guides.stream()
                 .map(guide -> {
                     int score = scoreCalculator.calculate(preference, guide);
-                    String reason = reasonGenerator.generate(preference, guide, score);
-                    return new ScoredGuide(guide, score, reason);
+                    ReasonBundle bundle = reasonGenerator.generate(preference, guide, score);
+                    return new ScoredGuide(guide, score, bundle);
                 })
                 .sorted(Comparator.comparingInt(ScoredGuide::baseScore).reversed())
                 .toList();
@@ -48,7 +48,9 @@ public class MatchingEngine {
                         .guideId(sg.guide.getGuideId())
                         .guideName(sg.guide.getGuideName())
                         .score(sg.baseScore)
-                        .reason(sg.reason)
+                        .reason(sg.bundle.getText())
+                        .reasonCodes(sg.bundle.getReasonCodes())
+                        .reasonFacts(toResponseFacts(sg.bundle))
                         .matched(buildMatchedEvidence(preference, sg.guide))
                         .build())
                 .toList();
@@ -202,6 +204,18 @@ public class MatchingEngine {
                 .toList();
     }
 
-    private record ScoredGuide(GuideAiProfile guide, int baseScore, String reason) {
+    private List<GuideRecommendItem.ReasonFact> toResponseFacts(ReasonBundle bundle) {
+        if (bundle == null || bundle.getReasonFacts() == null || bundle.getReasonFacts().isEmpty()) {
+            return List.of();
+        }
+        return bundle.getReasonFacts().stream()
+                .map(f -> GuideRecommendItem.ReasonFact.builder()
+                        .code(f.getCode())
+                        .values(f.getValues())
+                        .build())
+                .toList();
+    }
+
+    private record ScoredGuide(GuideAiProfile guide, int baseScore, ReasonBundle bundle) {
     }
 }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/engine/ReasonBundle.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/engine/ReasonBundle.java
@@ -1,0 +1,24 @@
+package com.team6.module.ai.engine;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * 사람이 읽는 reason 문자열과, 프론트/로그용 구조화 근거를 함께 담는다.
+ */
+@Getter
+@Builder
+public class ReasonBundle {
+    private final String text;
+    private final List<String> reasonCodes;
+    private final List<Fact> reasonFacts;
+
+    @Getter
+    @Builder
+    public static class Fact {
+        private final String code;
+        private final List<String> values;
+    }
+}

--- a/backend/module-ai/src/main/java/com/team6/module/ai/engine/ReasonGenerator.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/engine/ReasonGenerator.java
@@ -14,16 +14,70 @@ import java.util.stream.Collectors;
 @Component
 public class ReasonGenerator {
 
-    public String generate(TravelerPreference pref, GuideAiProfile guide, int score) {
-        // "핵심 근거" 위주로 2~3개만 노출 (중복 제거)
-        LinkedHashSet<String> reasons = new LinkedHashSet<>();
+    public static final String CODE_REGION_MATCH = "REGION_MATCH";
+    public static final String CODE_STYLE_MATCH = "STYLE_MATCH";
+    public static final String CODE_LANGUAGE_MATCH = "LANGUAGE_MATCH";
+    public static final String CODE_ACTIVITY_MATCH = "ACTIVITY_MATCH";
+    public static final String CODE_BUDGET_MATCH = "BUDGET_MATCH";
+    public static final String CODE_GENERAL_FALLBACK = "GENERAL_FALLBACK";
+
+    private static final int MAX_DISPLAY_SEGMENTS = 3;
+
+    /**
+     * @param score 현재는 reason 문구 생성에 직접 쓰지 않지만, 추후 임계값/요약에 활용 가능하도록 유지
+     */
+    public ReasonBundle generate(TravelerPreference pref, GuideAiProfile guide, int score) {
+        List<Segment> segments = buildSegments(pref, guide);
+        if (segments.isEmpty()) {
+            segments = List.of(new Segment(
+                    CODE_GENERAL_FALLBACK,
+                    "전체 선호도 기준으로 적합",
+                    List.of()
+            ));
+        }
+
+        int limit = Math.min(MAX_DISPLAY_SEGMENTS, segments.size());
+        List<Segment> displayed = segments.subList(0, limit);
+
+        String text = displayed.stream()
+                .map(Segment::displayText)
+                .collect(Collectors.joining(" · "));
+
+        List<String> codes = displayed.stream()
+                .map(Segment::code)
+                .toList();
+
+        List<ReasonBundle.Fact> facts = displayed.stream()
+                .map(s -> ReasonBundle.Fact.builder()
+                        .code(s.code)
+                        .values(s.factValues)
+                        .build())
+                .toList();
+
+        return ReasonBundle.builder()
+                .text(text)
+                .reasonCodes(codes)
+                .reasonFacts(facts)
+                .build();
+    }
+
+    private List<Segment> buildSegments(TravelerPreference pref, GuideAiProfile guide) {
+        List<Segment> segments = new ArrayList<>();
 
         if (safeEquals(pref.getRegion(), guide.getRegion())) {
-            reasons.add("선호 지역이 일치");
+            segments.add(new Segment(
+                    CODE_REGION_MATCH,
+                    "선호 지역이 일치",
+                    listNonNull(guide.getRegion())
+            ));
         }
 
         if (safeEquals(pref.getTravelStyle(), guide.getGuideStyle())) {
-            reasons.add("여행 스타일이 유사");
+            segments.add(new Segment(
+                    CODE_STYLE_MATCH,
+                    "여행 스타일이 유사",
+                    listNonNull(guide.getGuideStyle())
+            ));
         }
 
         if (pref.getPreferredLanguages() != null && guide.getLanguages() != null) {
@@ -32,13 +86,19 @@ public class ReasonGenerator {
                     .filter(s -> s != null && !s.isBlank())
                     .collect(Collectors.toSet());
 
-            Set<String> matchedLanguages = pref.getPreferredLanguages().stream()
+            LinkedHashSet<String> matchedLanguages = pref.getPreferredLanguages().stream()
                     .map(KeywordNormalizer::normalizeLanguage)
                     .filter(s -> s != null && !s.isBlank())
                     .filter(guideLang::contains)
-                    .collect(Collectors.toSet());
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
+
             if (!matchedLanguages.isEmpty()) {
-                reasons.add("가능 언어(" + String.join("/", matchedLanguages) + ")");
+                List<String> langValues = new ArrayList<>(matchedLanguages);
+                segments.add(new Segment(
+                        CODE_LANGUAGE_MATCH,
+                        "가능 언어(" + String.join("/", langValues) + ")",
+                        langValues
+                ));
             }
         }
 
@@ -57,26 +117,33 @@ public class ReasonGenerator {
 
             if (!matched.isEmpty()) {
                 String head = matched.stream().limit(3).collect(Collectors.joining("/"));
-                reasons.add("관심 활동(" + head + (matched.size() > 3 ? " 외" : "") + ")");
+                String display = "관심 활동(" + head + (matched.size() > 3 ? " 외" : "") + ")";
+                segments.add(new Segment(CODE_ACTIVITY_MATCH, display, matched));
             }
         }
 
         if (safeEquals(pref.getBudgetLevel(), guide.getPriceLevel())) {
-            reasons.add("예산대가 비슷");
+            segments.add(new Segment(
+                    CODE_BUDGET_MATCH,
+                    "예산대가 비슷",
+                    listNonNull(guide.getPriceLevel())
+            ));
         }
 
-        if (reasons.isEmpty()) {
-            reasons.add("전체 선호도 기준으로 적합");
-        }
+        return segments;
+    }
 
-        List<String> top = new ArrayList<>(reasons);
-        if (top.size() > 3) {
-            top = top.subList(0, 3);
+    private static List<String> listNonNull(String value) {
+        if (value == null || value.isBlank()) {
+            return List.of();
         }
-        return String.join(" · ", top);
+        return List.of(value.trim());
     }
 
     private boolean safeEquals(String a, String b) {
         return a != null && a.equalsIgnoreCase(b);
+    }
+
+    private record Segment(String code, String displayText, List<String> factValues) {
     }
 }

--- a/backend/module-ai/src/test/java/com/team6/module/ai/service/AiRecommendationServiceTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/service/AiRecommendationServiceTest.java
@@ -72,6 +72,8 @@ class AiRecommendationServiceTest {
         assertThat(response.getRecommendations()).isNotEmpty();
         assertThat(response.getRecommendations().get(0).getGuideId()).isEqualTo(1L);
         assertThat(response.getRecommendations().get(0).getReason()).contains("선호 지역");
+        assertThat(response.getRecommendations().get(0).getReasonCodes()).contains(ReasonGenerator.CODE_REGION_MATCH);
+        assertThat(response.getRecommendations().get(0).getReasonFacts()).isNotEmpty();
         assertThat(response.getRecommendations().get(0).getMatched()).isNotNull();
         assertThat(response.getRecommendations().get(0).getMatched().isRegion()).isTrue();
     }
@@ -103,6 +105,7 @@ class AiRecommendationServiceTest {
         assertThat(response.getRecommendations()).isNotEmpty();
         assertThat(response.getRecommendations().get(0).getScore()).isGreaterThan(0);
         assertThat(response.getRecommendations().get(0).getReason()).contains("관심 활동");
+        assertThat(response.getRecommendations().get(0).getReasonCodes()).contains(ReasonGenerator.CODE_ACTIVITY_MATCH);
         assertThat(response.getRecommendations().get(0).getMatched()).isNotNull();
         assertThat(response.getRecommendations().get(0).getMatched().getTags()).contains("바다");
     }


### PR DESCRIPTION
## 작업 내용
- 추천 항목에 reason 문자열 유지 + reasonCodes / reasonFacts 추가
- 프론트에서 뱃지·하이라이트용으로 근거 타입과 값을 구조화해 전달

## 상세
- 코드 상수: REGION_MATCH, STYLE_MATCH, LANGUAGE_MATCH, ACTIVITY_MATCH, BUDGET_MATCH, GENERAL_FALLBACK
- 화면에 노출되는 근거 문구와 동일하게 상위 최대 3개만 코드/팩트에 포함
- ReasonBundle 도입 후 MatchingEngine에서 응답 DTO로 매핑

## 테스트
- ./gradlew :module-ai:test

Closes #77

Made with [Cursor](https://cursor.com)