### PR TITLE
Feat/be#79: 회귀·파서·KeywordNormalizer 보강 및 추천 로그(reasonCodes)

### DIFF
--- a/backend/module-ai/src/main/java/com/team6/module/ai/parser/KeywordNormalizer.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/parser/KeywordNormalizer.java
@@ -16,15 +16,25 @@ public final class KeywordNormalizer {
             Map.entry("오션뷰", "바다"),
             Map.entry("해변", "바다"),
             Map.entry("바닷가", "바다"),
+            Map.entry("해수욕장", "바다"),
             Map.entry("식도락", "맛집"),
             Map.entry("먹방", "맛집"),
+            Map.entry("브런치", "카페"),
+            Map.entry("카페투어", "카페"),
             Map.entry("포토", "사진"),
             Map.entry("인생샷", "사진"),
             Map.entry("전시", "전시"),
             Map.entry("미술관", "전시"),
             Map.entry("박물관", "전시"),
             Map.entry("전통시장", "시장"),
-            Map.entry("로컬시장", "시장")
+            Map.entry("로컬시장", "시장"),
+            Map.entry("야시장", "시장"),
+            Map.entry("트레킹", "등산"),
+            Map.entry("일몰", "야경"),
+            Map.entry("노을", "야경"),
+            Map.entry("야경명소", "야경"),
+            Map.entry("쇼핑몰", "쇼핑"),
+            Map.entry("아울렛", "쇼핑")
     );
 
     public static String normalizeTag(String tag) {

--- a/backend/module-ai/src/main/java/com/team6/module/ai/parser/PromptParser.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/parser/PromptParser.java
@@ -7,9 +7,11 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @Component
 public class PromptParser {
@@ -121,12 +123,29 @@ public class PromptParser {
         if (containsAny(prompt, "등산", "트레킹")) tags.add("등산");
         if (containsAny(prompt, "사진", "포토", "인생샷")) tags.add("사진");
         if (containsAny(prompt, "쇼핑")) tags.add("쇼핑");
-        if (containsAny(prompt, "바다", "해변", "오션뷰")) tags.add("바다");
+        if (containsAny(prompt, "바다", "해변", "오션뷰", "해수욕장")) tags.add("바다");
+        if (containsAny(prompt, "일몰", "노을", "야경명소")) tags.add("일몰");
         if (containsAny(prompt, "박물관", "미술관", "전시")) tags.add("전시");
-        if (containsAny(prompt, "시장", "전통시장", "로컬시장")) tags.add("시장");
+        if (containsAny(prompt, "시장", "전통시장", "로컬시장", "야시장")) tags.add("시장");
         if (containsAny(prompt, "술집", "클럽", "바")) tags.add("술집");
+        if (containsAny(prompt, "브런치", "카페투어")) tags.add("브런치");
+        if (containsAny(prompt, "쇼핑몰", "아울렛")) tags.add("쇼핑몰");
 
-        return new ArrayList<>(tags);
+        return normalizeTagList(tags);
+    }
+
+    /**
+     * 추출된 표현을 {@link KeywordNormalizer}로 통일해 매칭 정확도를 맞춘다.
+     */
+    private List<String> normalizeTagList(Set<String> rawTags) {
+        LinkedHashSet<String> out = new LinkedHashSet<>();
+        for (String t : rawTags) {
+            String n = KeywordNormalizer.normalizeTag(t);
+            if (n != null && !n.isBlank()) {
+                out.add(n);
+            }
+        }
+        return new ArrayList<>(out);
     }
 
     private List<String> extractExcludedActivityTags(String prompt) {
@@ -135,9 +154,14 @@ public class PromptParser {
         if (containsAny(prompt, "빼고", "제외", "말고", "싫어", "안 가", "안가", "원치 않아", "원치않아")) {
             if (containsAny(prompt, "술집", "클럽", "바")) excluded.add("술집");
             if (containsAny(prompt, "등산", "트레킹")) excluded.add("등산");
-            if (containsAny(prompt, "쇼핑")) excluded.add("쇼핑");
+            if (containsAny(prompt, "쇼핑", "쇼핑몰", "아울렛")) excluded.add("쇼핑");
         }
-        return new ArrayList<>(excluded);
+        LinkedHashSet<String> normalized = excluded.stream()
+                .map(KeywordNormalizer::normalizeTag)
+                .filter(Objects::nonNull)
+                .filter(s -> !s.isBlank())
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        return new ArrayList<>(normalized);
     }
 
     private List<String> extractLanguages(String prompt) {

--- a/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
@@ -8,9 +8,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import com.team6.module.ai.dto.response.GuideRecommendItem;
+
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Service
 @Slf4j
@@ -72,6 +75,23 @@ public class PromptRecommendationService {
             return 0;
         }
         return resp.getRecommendations().get(0).getScore();
+    }
+
+    /**
+     * 운영 로그용: Top1 추천의 구조화 근거 코드를 짧게 요약(개인정보 없음).
+     */
+    private static String summarizeTopReasonCodes(GuideRecommendResponse resp) {
+        if (resp == null || resp.getRecommendations() == null || resp.getRecommendations().isEmpty()) {
+            return "";
+        }
+        GuideRecommendItem top = resp.getRecommendations().get(0);
+        if (top.getReasonCodes() == null || top.getReasonCodes().isEmpty()) {
+            return "";
+        }
+        return top.getReasonCodes().stream()
+                .filter(Objects::nonNull)
+                .filter(s -> !s.isBlank())
+                .collect(Collectors.joining("|"));
     }
 
     private FallbackDecision decideFallback(GuideRecommendRequest request, GuideRecommendResponse base) {
@@ -166,8 +186,9 @@ public class PromptRecommendationService {
             int candidateCount = guideCandidates == null ? 0 : guideCandidates.size();
             int baseTopScore = topScore(base);
             int finalTopScore = topScore(finalBase);
+            String top1ReasonCodes = summarizeTopReasonCodes(finalBase);
 
-            log.info("[AI_RECOMMEND] promptHash={} topN={} candidates={} keywords={{region={},style={},budget={},companion={},headcount={},durationDays={},tags={},excluded={},langs={}}} base={{count={},topScore={}}} final={{count={},topScore={}}} fallback={{used={},stage={}}}",
+            log.info("[AI_RECOMMEND] promptHash={} topN={} candidates={} keywords={{region={},style={},budget={},companion={},headcount={},durationDays={},tags={},excluded={},langs={}}} base={{count={},topScore={}}} final={{count={},topScore={},top1ReasonCodes={}}} fallback={{used={},stage={}}}",
                     promptHash,
                     request == null ? null : request.getTopN(),
                     candidateCount,
@@ -184,6 +205,7 @@ public class PromptRecommendationService {
                     baseTopScore,
                     finalBase == null ? 0 : finalBase.getTotalCount(),
                     finalTopScore,
+                    top1ReasonCodes,
                     decision != null && decision.shouldFallback,
                     decision == null ? null : decision.stage
             );

--- a/backend/module-ai/src/test/java/com/team6/module/ai/parser/PromptParserTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/parser/PromptParserTest.java
@@ -72,4 +72,10 @@ class PromptParserTest {
         assertThat(request.getCompanionType()).isEqualTo("반려견");
         assertThat(request.getExcludedActivityTags()).contains("술집");
     }
+
+    @Test
+    void parse_should_normalize_activity_tags_via_keyword_normalizer() {
+        GuideRecommendRequest request = promptParser.parse("부산 브런치랑 일몰 보고 싶어", 3, List.of());
+        assertThat(request.getActivityTags()).contains("카페", "야경");
+    }
 }

--- a/backend/module-ai/src/test/java/com/team6/module/ai/regression/AiRecommendationRegressionTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/regression/AiRecommendationRegressionTest.java
@@ -16,6 +16,7 @@ import com.team6.module.ai.service.AiRecommendationServiceImpl;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Objects;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -47,6 +48,12 @@ class AiRecommendationRegressionTest {
                     .isEqualTo(s.expectedTop1GuideId());
 
             assertThat(top1.getReason()).as("reason should be present").isNotBlank();
+            assertThat(top1.getReasonCodes()).as("reasonCodes should be present for prompt: %s".formatted(s.prompt()))
+                    .isNotNull()
+                    .isNotEmpty();
+            assertThat(top1.getReasonCodes().stream().filter(Objects::nonNull).noneMatch(String::isBlank))
+                    .as("reasonCodes should not contain blank entries")
+                    .isTrue();
             assertThat(top1.getMatched()).as("matched evidence should be present").isNotNull();
 
             if (s.expectedTag() != null) {
@@ -81,7 +88,11 @@ class AiRecommendationRegressionTest {
                 new Scenario("제주 2박3일 4명 여행인데 술집은 빼고 카페 바다", 3, 2L, "카페", null),
                 new Scenario("부산 감성 사진 인생샷 카페", 3, 1L, "사진", null),
                 new Scenario("서울 전시 미술관 박물관", 3, 3L, "전시", null),
-                new Scenario("제주 시장 로컬 골목 여행", 3, 5L, "시장", null)
+                new Scenario("제주 시장 로컬 골목 여행", 3, 5L, "시장", null),
+                new Scenario("부산 브런치 감성 카페 추천해줘", 3, 1L, "카페", null),
+                new Scenario("제주 주말 바다 해수욕장 위주로", 3, 2L, "바다", null),
+                new Scenario("강릉 일몰 노을 바다 산책 코스", 3, 4L, "바다", null),
+                new Scenario("서울 아울렛 럭셔리 쇼핑 영어 가능한 가이드", 3, 3L, "쇼핑", "영어")
         );
     }
 


### PR DESCRIPTION
## 작업 내용
- 회귀 테스트 시나리오 추가 및 Top1 reasonCodes 검증
- KeywordNormalizer 태그 동의어 확장(야경/바다/쇼핑/등산 등)
- PromptParser에서 활동·제외 태그를 정규화해 매칭 일관성 강화
- Prompt 추천 운영 로그 `final` 블록에 `top1ReasonCodes` 요약 추가

## 테스트
- `./gradlew :module-ai:test`

Closes #79

Made with [Cursor](https://cursor.com)