### PR TITLE
Fix/be#109: JWT role 권한 매핑 및 member social_type enum 매핑 정합성 수정

### DIFF
--- a/backend/module-domain/src/main/java/com/team6/domain/auth/filter/JwtAuthenticationFilter.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/auth/filter/JwtAuthenticationFilter.java
@@ -7,12 +7,13 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.util.Collections;
+import java.util.List;
 
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
@@ -29,10 +30,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if(token != null && jwtTokenProvider.validToken(token)) {
             // 토큰에서 이메일 추출
             String email = jwtTokenProvider.getEmail(token);
+            String role = jwtTokenProvider.getRole(token);
+            String authority = role != null && role.startsWith("ROLE_") ? role : "ROLE_" + role;
 
             // 시큐리티 전용 인증 토큰 생성
             UsernamePasswordAuthenticationToken authentication =
-                    new UsernamePasswordAuthenticationToken(email, null, Collections.emptyList());
+                    new UsernamePasswordAuthenticationToken(
+                            email,
+                            null,
+                            List.of(new SimpleGrantedAuthority(authority))
+                    );
 
             // 시큐리티 보관함에 저장
             SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/backend/module-domain/src/main/java/com/team6/domain/auth/provider/JwtTokenProvider.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/auth/provider/JwtTokenProvider.java
@@ -65,4 +65,13 @@ public class JwtTokenProvider {
                 .getBody()
                 .getSubject();
     }
+
+    public String getRole(String token) {
+        return Jwts.parser()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("role", String.class);
+    }
 }

--- a/backend/module-domain/src/main/java/com/team6/domain/member/entity/Member.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/member/entity/Member.java
@@ -4,7 +4,6 @@ import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-import javax.swing.*;
 import java.time.LocalDateTime;
 
 @Entity
@@ -40,6 +39,7 @@ public class Member {
     @Builder.Default
     private Status status = Status.ACTIVE;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "social_type", length = 50)
     private SocialType socialType;
 


### PR DESCRIPTION
# 🔗 이슈 번호
- Closes #109 

---

## 💡 주요 변경 사항
- JWT 필터에서 role claim을 `GrantedAuthority`로 매핑해 role 기반 인가가 동작하도록 수정
- `JwtTokenProvider`에 role 추출 로직(`getRole`) 추가
- `Member.socialType`에 `@Enumerated(EnumType.STRING)` 적용하여 DB enum과 JPA 매핑 정합성 확보
- 로그아웃 토큰 헤더(`Authorization`) 처리 확인
---

## ✅ 체크리스트
- [x] 빌드가 정상적으로 되는가?
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [x] .gitignore에 설정 파일이 잘 포함되었는가? (application-local.yml 등)