### PR TITLE
Feat/be#112: matching JWT 연동 및 역할 기반 권한 검증, 환불 처리 개선

### DIFF
--- a/backend/module-domain/src/main/java/com/team6/domain/matching/controller/MatchRequestController.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/controller/MatchRequestController.java
@@ -1,5 +1,8 @@
 package com.team6.domain.matching.controller;
 
+import com.team6.domain.guide.repository.GuideProfileRepository;
+import com.team6.domain.matching.exception.MatchingErrorCode;
+import com.team6.domain.matching.exception.MatchingException;
 import com.team6.domain.matching.dto.request.CancelRequestDto;
 import com.team6.domain.matching.dto.request.MatchRequestDeclineRequest;
 import com.team6.domain.matching.dto.request.MatchRequestCreateRequest;
@@ -7,6 +10,10 @@ import com.team6.domain.matching.dto.request.MatchRequestProposeRequest;
 import com.team6.domain.matching.dto.response.MatchRequestActionResponse;
 import com.team6.domain.matching.dto.response.MatchRequestCreateResponse;
 import com.team6.domain.matching.service.MatchRequestService;
+import com.team6.domain.member.entity.Member;
+import com.team6.domain.member.entity.Role;
+import com.team6.domain.member.repository.MemberRepository;
+import com.team6.module.common.global.util.SecurityUtil;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -20,79 +27,53 @@ import java.util.List;
 public class MatchRequestController {
 
     private final MatchRequestService matchRequestService;
+    private final MemberRepository memberRepository;
+    private final GuideProfileRepository guideProfileRepository;
 
     @PostMapping
     public ResponseEntity<MatchRequestCreateResponse> createMatchRequest(
             @RequestBody @Valid MatchRequestCreateRequest request
     ) {
-        Long guestId = 1L; // TODO: JWT 연동 후 교체
+        Long guestId = getCurrentMemberId(Role.GUEST);
+        if (!guideProfileRepository.existsById(request.getGuideId())) {
+            throw new MatchingException(MatchingErrorCode.INVALID_REQUEST);
+        }
 
         MatchRequestCreateResponse saved = matchRequestService.createMatchRequest(guestId, request);
 
         return ResponseEntity.ok(saved);
     }
 
-    /**
-     * 가이드가 자신에게 들어온 매칭 요청 목록을 조회하는 API
-     *
-     * 현재는 guideId를 path variable로 받아 테스트한다.
-     * 추후 JWT 연동 시 guideId는 인증 정보에서 추출하도록 변경 가능하다.
-     */
-    @GetMapping("/guides/{guideId}")
-    public ResponseEntity<List<MatchRequestCreateResponse>> getGuideRequests(
-            @PathVariable Long guideId
-    ) {
+    @GetMapping("/guides/me")
+    public ResponseEntity<List<MatchRequestCreateResponse>> getGuideRequests() {
+        Long guideId = getCurrentGuideProfileId();
         return ResponseEntity.ok(matchRequestService.getGuideRequests(guideId));
     }
 
-    /**
-     * 가이드가 특정 매칭 요청을 거절하는 API
-     *
-     * 현재는 guideId를 request param으로 받아 권한을 검증한다.
-     * 추후 JWT 연동 시 guideId는 인증 정보에서 추출하도록 변경 가능하다.
-     */
     @PatchMapping("/{requestId}/reject")
     public ResponseEntity<MatchRequestActionResponse> rejectMatchRequest(
-            @PathVariable Long requestId,
-            @RequestParam Long guideId
+            @PathVariable Long requestId
     ) {
+        Long guideId = getCurrentGuideProfileId();
         MatchRequestActionResponse updated = matchRequestService.rejectMatchRequest(guideId, requestId);
         return ResponseEntity.ok(updated);
     }
 
-    /**
-     * 가이드가 특정 매칭 요청을 제안 단계(PROPOSED)로 변경하는 API
-     *
-     * 현재는 guideId를 request param으로 받아 권한을 검증한다.
-     * 추후 JWT 연동 시 guideId는 인증 정보에서 추출하도록 변경 가능하다.
-     *
-     * 주의:
-     * 현재 MatchRequest 엔티티에는 실제 제안 내용(일정/메시지) 저장 필드가 없어서
-     * 우선 상태만 PENDING -> PROPOSED 로 변경한다.
-     */
     @PatchMapping("/{requestId}/propose")
     public ResponseEntity<MatchRequestActionResponse> proposeMatchRequest(
             @PathVariable Long requestId,
-            @RequestParam Long guideId,
             @RequestBody @Valid MatchRequestProposeRequest request
     ) {
+        Long guideId = getCurrentGuideProfileId();
         MatchRequestActionResponse updated = matchRequestService.proposeMatchRequest(guideId, requestId, request);
         return ResponseEntity.ok(updated);
     }
 
-    /**
-     * 게스트가 가이드의 제안을 최종 수락하는 API
-     *
-     * 현재는 guestId를 request param으로 받아 권한을 검증한다.
-     * 추후 JWT 연동 시 guestId는 인증 정보에서 추출하도록 변경 가능하다.
-     *
-     * 현재 상태가 PROPOSED일 때만 ACCEPTED로 변경된다.
-     */
     @PatchMapping("/{requestId}/accept")
     public ResponseEntity<MatchRequestActionResponse> acceptMatchRequest(
-            @PathVariable Long requestId,
-            @RequestParam Long guestId
+            @PathVariable Long requestId
     ) {
+        Long guestId = getCurrentMemberId(Role.GUEST);
         MatchRequestActionResponse updated = matchRequestService.acceptMatchRequest(guestId, requestId);
         return ResponseEntity.ok(updated);
     }
@@ -103,9 +84,9 @@ public class MatchRequestController {
     @PatchMapping("/{requestId}/decline")
     public ResponseEntity<MatchRequestActionResponse> declineMatchRequest(
             @PathVariable Long requestId,
-            @RequestParam Long guestId,
             @RequestBody @Valid MatchRequestDeclineRequest request
     ) {
+        Long guestId = getCurrentMemberId(Role.GUEST);
         MatchRequestActionResponse updated = matchRequestService.declineMatchRequest(guestId, requestId, request);
         return ResponseEntity.ok(updated);
     }
@@ -113,10 +94,9 @@ public class MatchRequestController {
     @PatchMapping("/{requestId}/guest/cancel")
     public ResponseEntity<MatchRequestActionResponse> cancelByGuest(
             @PathVariable Long requestId,
-            @RequestParam Long guestId,
             @RequestBody @Valid CancelRequestDto request
     ) {
-        // TODO: 인증 모듈 연동 시 guestId는 토큰 클레임에서 추출한다.
+        Long guestId = getCurrentMemberId(Role.GUEST);
         MatchRequestActionResponse updated =
                 matchRequestService.cancelByGuest(guestId, requestId, request.getCancelReason());
         return ResponseEntity.ok(updated);
@@ -125,12 +105,32 @@ public class MatchRequestController {
     @PatchMapping("/{requestId}/guide/cancel")
     public ResponseEntity<MatchRequestActionResponse> cancelByGuide(
             @PathVariable Long requestId,
-            @RequestParam Long guideId,
             @RequestBody @Valid CancelRequestDto request
     ) {
-        // TODO: 인증 모듈 연동 시 guideId는 토큰 클레임에서 추출한다.
+        Long guideId = getCurrentGuideProfileId();
         MatchRequestActionResponse updated =
                 matchRequestService.cancelByGuide(guideId, requestId, request.getCancelReason());
         return ResponseEntity.ok(updated);
+    }
+
+    private Long getCurrentMemberId(Role requiredRole) {
+        String email = SecurityUtil.getCurrentUserEmail();
+        return memberRepository.findByEmail(email)
+                .map(member -> validateAndGetMemberId(member, requiredRole))
+                .orElseThrow(() -> new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED));
+    }
+
+    private Long validateAndGetMemberId(Member member, Role requiredRole) {
+        if (requiredRole != null && member.getRole() != requiredRole) {
+            throw new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED);
+        }
+        return member.getId();
+    }
+
+    private Long getCurrentGuideProfileId() {
+        Long memberId = getCurrentMemberId(Role.GUIDE);
+        return guideProfileRepository.findByMemberId(memberId)
+                .map(guideProfile -> guideProfile.getId())
+                .orElseThrow(() -> new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED));
     }
 }

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/controller/PaymentController.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/controller/PaymentController.java
@@ -1,0 +1,47 @@
+package com.team6.domain.matching.controller;
+
+import com.team6.domain.matching.dto.request.RefundRequestDto;
+import com.team6.domain.matching.dto.response.RefundResponseDto;
+import com.team6.domain.matching.exception.MatchingErrorCode;
+import com.team6.domain.matching.exception.MatchingException;
+import com.team6.domain.matching.service.PaymentService;
+import com.team6.domain.member.entity.Member;
+import com.team6.domain.member.entity.Role;
+import com.team6.domain.member.repository.MemberRepository;
+import com.team6.module.common.global.util.SecurityUtil;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/matching/payments")
+public class PaymentController {
+
+    private final PaymentService paymentService;
+    private final MemberRepository memberRepository;
+
+    @PostMapping("/refunds")
+    public ResponseEntity<RefundResponseDto> requestRefund(@RequestBody @Valid RefundRequestDto request) {
+        Long guestId = getCurrentMemberId(Role.GUEST);
+        return ResponseEntity.ok(paymentService.requestGuestRefund(guestId, request));
+    }
+
+    private Long getCurrentMemberId(Role requiredRole) {
+        String email = SecurityUtil.getCurrentUserEmail();
+        return memberRepository.findByEmail(email)
+                .map(member -> validateAndGetMemberId(member, requiredRole))
+                .orElseThrow(() -> new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED));
+    }
+
+    private Long validateAndGetMemberId(Member member, Role requiredRole) {
+        if (requiredRole != null && member.getRole() != requiredRole) {
+            throw new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED);
+        }
+        return member.getId();
+    }
+}

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/controller/TourExtensionController.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/controller/TourExtensionController.java
@@ -1,8 +1,15 @@
 package com.team6.domain.matching.controller;
 
+import com.team6.domain.guide.repository.GuideProfileRepository;
 import com.team6.domain.matching.dto.request.TourExtensionSelectRequest;
 import com.team6.domain.matching.dto.response.TourExtensionResponseDto;
+import com.team6.domain.matching.exception.MatchingErrorCode;
+import com.team6.domain.matching.exception.MatchingException;
 import com.team6.domain.matching.service.TourExtensionService;
+import com.team6.domain.member.entity.Member;
+import com.team6.domain.member.entity.Role;
+import com.team6.domain.member.repository.MemberRepository;
+import com.team6.module.common.global.util.SecurityUtil;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -11,7 +18,6 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -20,22 +26,52 @@ import org.springframework.web.bind.annotation.RestController;
 public class TourExtensionController {
 
     private final TourExtensionService tourExtensionService;
+    private final MemberRepository memberRepository;
+    private final GuideProfileRepository guideProfileRepository;
 
     @GetMapping("/{requestId}")
     public ResponseEntity<TourExtensionResponseDto> getExtension(
             @PathVariable Long requestId
     ) {
-        return ResponseEntity.ok(tourExtensionService.getByRequestId(requestId));
+        Member member = getCurrentMember();
+        Long actorId = resolveActorIdForExtensionRead(member);
+        return ResponseEntity.ok(tourExtensionService.getByRequestId(requestId, actorId));
     }
 
-    // 게스트 전용 연장 선택 API (임시: guestId는 request param)
+    // 게스트 전용 연장 선택 API
     @PatchMapping("/{requestId}/select")
     public ResponseEntity<TourExtensionResponseDto> selectByGuest(
             @PathVariable Long requestId,
-            @RequestParam Long guestId,
             @RequestBody @Valid TourExtensionSelectRequest request
     ) {
-        // TODO: 인증 모듈 연동 시 guestId는 토큰 클레임에서 추출한다.
+        Long guestId = getCurrentMemberId(Role.GUEST);
         return ResponseEntity.ok(tourExtensionService.selectByGuest(guestId, requestId, request));
+    }
+
+    private Long getCurrentMemberId(Role requiredRole) {
+        return validateAndGetMemberId(getCurrentMember(), requiredRole);
+    }
+
+    private Member getCurrentMember() {
+        String email = SecurityUtil.getCurrentUserEmail();
+        return memberRepository.findByEmail(email)
+                .map(member -> member)
+                .orElseThrow(() -> new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED));
+    }
+
+    private Long validateAndGetMemberId(Member member, Role requiredRole) {
+        if (requiredRole != null && member.getRole() != requiredRole) {
+            throw new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED);
+        }
+        return member.getId();
+    }
+
+    private Long resolveActorIdForExtensionRead(Member member) {
+        if (member.getRole() == Role.GUIDE) {
+            return guideProfileRepository.findByMemberId(member.getId())
+                    .map(guideProfile -> guideProfile.getId())
+                    .orElseThrow(() -> new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED));
+        }
+        return member.getId();
     }
 }

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/dto/request/MatchRequestCreateRequest.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/dto/request/MatchRequestCreateRequest.java
@@ -12,6 +12,10 @@ import java.time.LocalDate;
 public class MatchRequestCreateRequest {
 
     @NotNull
+    /**
+     * 가이드 식별자 (guide_profiles.id)
+     * member.id가 아닌 guide_profiles PK를 전달해야 한다.
+     */
     private Long guideId;
 
     @NotBlank

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/dto/request/RefundRequestDto.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/dto/request/RefundRequestDto.java
@@ -2,12 +2,18 @@ package com.team6.domain.matching.dto.request;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 @Getter
 @NoArgsConstructor
 public class RefundRequestDto {
 
+    @NotNull
     private Long paymentId;      // 결제 ID
+
+    @NotBlank
     private String reason;       // 환불 사유
+
     private String evidenceUrl;  // 증빙 자료 URL (선택)
 }

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/service/PaymentService.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/service/PaymentService.java
@@ -1,0 +1,68 @@
+package com.team6.domain.matching.service;
+
+import com.team6.domain.matching.dto.request.RefundRequestDto;
+import com.team6.domain.matching.dto.response.RefundResponseDto;
+import com.team6.domain.matching.entity.Payment;
+import com.team6.domain.matching.entity.Refund;
+import com.team6.domain.matching.entity.enums.PaymentStatus;
+import com.team6.domain.matching.entity.enums.RefundType;
+import com.team6.domain.matching.exception.MatchingErrorCode;
+import com.team6.domain.matching.exception.MatchingException;
+import com.team6.domain.matching.repository.PaymentRepository;
+import com.team6.domain.matching.repository.RefundRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PaymentService {
+
+    private final PaymentRepository paymentRepository;
+    private final RefundRepository refundRepository;
+
+    // F05-04: 가이드 불만족 환불 신청 및 처리 (결제 후 2시간 이내)
+    public RefundResponseDto requestGuestRefund(Long guestId, RefundRequestDto request) {
+        Payment payment = paymentRepository.findById(request.getPaymentId())
+                .orElseThrow(() -> new MatchingException(MatchingErrorCode.PAYMENT_NOT_FOUND));
+
+        if (!payment.getPayerId().equals(guestId)) {
+            throw new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED);
+        }
+
+        if (payment.getStatus() != PaymentStatus.COMPLETED) {
+            throw new MatchingException(MatchingErrorCode.PAYMENT_NOT_COMPLETED);
+        }
+
+        if (payment.getRefundDeadline() == null || LocalDateTime.now().isAfter(payment.getRefundDeadline())) {
+            throw new MatchingException(MatchingErrorCode.REFUND_DEADLINE_EXCEEDED);
+        }
+
+        if (refundRepository.findByPayment_Id(payment.getId()).isPresent()) {
+            throw new MatchingException(MatchingErrorCode.REFUND_ALREADY_REQUESTED);
+        }
+
+        Refund refund = Refund.builder()
+                .payment(payment)
+                .requesterId(guestId)
+                .refundType(RefundType.MANUAL)
+                .reason(request.getReason())
+                .evidenceUrl(request.getEvidenceUrl())
+                .aiProcessed(true)
+                .build();
+
+        // 현재 F05-04 요구사항에 맞춰 신청과 동시에 처리 완료로 반영
+        refund.approve();
+        payment.refund();
+
+        Refund saved = refundRepository.save(refund);
+        log.info("[F05-04] 가이드 불만족 환불 처리 완료 — paymentId={}, guestId={}, refundId={}",
+                payment.getId(), guestId, saved.getId());
+        return RefundResponseDto.from(saved);
+    }
+}

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/service/TourExtensionService.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/service/TourExtensionService.java
@@ -30,9 +30,16 @@ public class TourExtensionService {
     private final MatchRequestRepository matchRequestRepository;
 
     @Transactional(readOnly = true)
-    public TourExtensionResponseDto getByRequestId(Long requestId) {
+    public TourExtensionResponseDto getByRequestId(Long requestId, Long memberId) {
         TourExtension extension = tourExtensionRepository.findByMatchRequest_Id(requestId)
                 .orElseThrow(() -> new MatchingException(MatchingErrorCode.TOUR_EXTENSION_NOT_FOUND));
+
+        boolean isGuest = extension.getGuestId().equals(memberId);
+        boolean isGuide = extension.getMatchRequest().getGuideId().equals(memberId);
+        if (!isGuest && !isGuide) {
+            throw new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED);
+        }
+
         return TourExtensionResponseDto.from(extension);
     }
 

--- a/backend/module-domain/src/test/java/com/team6/domain/matching/service/PaymentServiceTest.java
+++ b/backend/module-domain/src/test/java/com/team6/domain/matching/service/PaymentServiceTest.java
@@ -1,0 +1,124 @@
+package com.team6.domain.matching.service;
+
+import com.team6.domain.matching.dto.request.RefundRequestDto;
+import com.team6.domain.matching.dto.response.RefundResponseDto;
+import com.team6.domain.matching.entity.MatchRequest;
+import com.team6.domain.matching.entity.Payment;
+import com.team6.domain.matching.entity.Refund;
+import com.team6.domain.matching.entity.enums.PaymentStatus;
+import com.team6.domain.matching.entity.enums.RefundType;
+import com.team6.domain.matching.exception.MatchingErrorCode;
+import com.team6.domain.matching.exception.MatchingException;
+import com.team6.domain.matching.repository.PaymentRepository;
+import com.team6.domain.matching.repository.RefundRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentServiceTest {
+
+    @Mock
+    private PaymentRepository paymentRepository;
+    @Mock
+    private RefundRepository refundRepository;
+    @InjectMocks
+    private PaymentService paymentService;
+
+    @Test
+    void 게스트_환불요청_성공() {
+        Long guestId = 10L;
+        Long paymentId = 100L;
+
+        Payment payment = completedPayment(paymentId, guestId, LocalDateTime.now().plusMinutes(30));
+        RefundRequestDto request = refundRequest(paymentId, "가이드 불만족", "https://evidence.local/1");
+
+        when(paymentRepository.findById(paymentId)).thenReturn(Optional.of(payment));
+        when(refundRepository.findByPayment_Id(paymentId)).thenReturn(Optional.empty());
+        when(refundRepository.save(any(Refund.class))).thenAnswer(invocation -> {
+            Refund refund = invocation.getArgument(0);
+            setField(refund, "id", 999L);
+            return refund;
+        });
+
+        RefundResponseDto response = paymentService.requestGuestRefund(guestId, request);
+
+        assertEquals(999L, response.getRefundId());
+        assertEquals(paymentId, response.getPaymentId());
+        assertEquals(PaymentStatus.REFUNDED, payment.getStatus());
+    }
+
+    @Test
+    void 환불요청_타인결제면_권한예외() {
+        Payment payment = completedPayment(200L, 777L, LocalDateTime.now().plusMinutes(30));
+        RefundRequestDto request = refundRequest(200L, "사유", null);
+        when(paymentRepository.findById(200L)).thenReturn(Optional.of(payment));
+
+        MatchingException ex = assertThrows(MatchingException.class,
+                () -> paymentService.requestGuestRefund(10L, request));
+        assertEquals(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED, ex.getErrorCode());
+    }
+
+    @Test
+    void 환불요청_마감초과면_예외() {
+        Long paymentId = 300L;
+        Payment payment = completedPayment(paymentId, 10L, LocalDateTime.now().minusSeconds(1));
+        RefundRequestDto request = refundRequest(paymentId, "사유", null);
+        when(paymentRepository.findById(paymentId)).thenReturn(Optional.of(payment));
+
+        MatchingException ex = assertThrows(MatchingException.class,
+                () -> paymentService.requestGuestRefund(10L, request));
+        assertEquals(MatchingErrorCode.REFUND_DEADLINE_EXCEEDED, ex.getErrorCode());
+    }
+
+    private Payment completedPayment(Long paymentId, Long payerId, LocalDateTime refundDeadline) {
+        MatchRequest matchRequest = MatchRequest.builder()
+                .id(1L)
+                .guestId(payerId)
+                .guideId(2L)
+                .destination("Seoul")
+                .desiredDate(LocalDate.now())
+                .build();
+        return Payment.builder()
+                .id(paymentId)
+                .matchRequest(matchRequest)
+                .payerId(payerId)
+                .amount(10000)
+                .paymentType("ACCOMPANY")
+                .pgOrderNo("ORDER-" + paymentId)
+                .status(PaymentStatus.COMPLETED)
+                .paidAt(LocalDateTime.now().minusMinutes(10))
+                .refundDeadline(refundDeadline)
+                .build();
+    }
+
+    private RefundRequestDto refundRequest(Long paymentId, String reason, String evidenceUrl) {
+        RefundRequestDto dto = new RefundRequestDto();
+        setField(dto, "paymentId", paymentId);
+        setField(dto, "reason", reason);
+        setField(dto, "evidenceUrl", evidenceUrl);
+        return dto;
+    }
+
+    private void setField(Object target, String fieldName, Object value) {
+        try {
+            Field field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/backend/module-domain/src/test/java/com/team6/domain/matching/service/TourExtensionServiceTest.java
+++ b/backend/module-domain/src/test/java/com/team6/domain/matching/service/TourExtensionServiceTest.java
@@ -1,0 +1,80 @@
+package com.team6.domain.matching.service;
+
+import com.team6.domain.matching.entity.MatchRequest;
+import com.team6.domain.matching.entity.TourExtension;
+import com.team6.domain.matching.entity.enums.TourExtensionStatus;
+import com.team6.domain.matching.exception.MatchingErrorCode;
+import com.team6.domain.matching.exception.MatchingException;
+import com.team6.domain.matching.repository.MatchRequestRepository;
+import com.team6.domain.matching.repository.TourExtensionRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TourExtensionServiceTest {
+
+    @Mock
+    private TourExtensionRepository tourExtensionRepository;
+    @Mock
+    private MatchRequestRepository matchRequestRepository;
+    @InjectMocks
+    private TourExtensionService tourExtensionService;
+
+    @Test
+    void 연장조회_게스트본인_성공() {
+        TourExtension extension = sampleExtension(10L, 20L);
+        when(tourExtensionRepository.findByMatchRequest_Id(1L)).thenReturn(Optional.of(extension));
+
+        assertEquals(1L, tourExtensionService.getByRequestId(1L, 10L).getRequestId());
+    }
+
+    @Test
+    void 연장조회_가이드본인_성공() {
+        TourExtension extension = sampleExtension(10L, 20L);
+        when(tourExtensionRepository.findByMatchRequest_Id(1L)).thenReturn(Optional.of(extension));
+
+        assertEquals(1L, tourExtensionService.getByRequestId(1L, 20L).getRequestId());
+    }
+
+    @Test
+    void 연장조회_당사자아니면_권한예외() {
+        TourExtension extension = sampleExtension(10L, 20L);
+        when(tourExtensionRepository.findByMatchRequest_Id(1L)).thenReturn(Optional.of(extension));
+
+        MatchingException ex = assertThrows(MatchingException.class,
+                () -> tourExtensionService.getByRequestId(1L, 999L));
+        assertEquals(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED, ex.getErrorCode());
+    }
+
+    private TourExtension sampleExtension(Long guestId, Long guideId) {
+        MatchRequest matchRequest = MatchRequest.builder()
+                .id(1L)
+                .guestId(guestId)
+                .guideId(guideId)
+                .destination("Seoul")
+                .desiredDate(LocalDate.now())
+                .build();
+
+        return TourExtension.builder()
+                .id(100L)
+                .matchRequest(matchRequest)
+                .guestId(guestId)
+                .extendedDate(LocalDate.now().plusDays(1))
+                .extendedPrice(15000)
+                .status(TourExtensionStatus.REQUESTED)
+                .requestedAt(LocalDateTime.now())
+                .deadlineAt(LocalDateTime.now().plusHours(1))
+                .build();
+    }
+}


### PR DESCRIPTION
# 🔗 이슈 번호
- Closes #112 

---

## 💡 주요 변경 사항
- JWT role claim을 Spring Security 권한으로 매핑하여 role 기반 인가 동작 보완
- `AuthController` 로그아웃 Authorization 헤더 처리 정리
- `Member.socialType`에 `@Enumerated(EnumType.STRING)` 적용 (DB enum과 정합성 맞춤)
- matching 전반 JWT 연동:
  - 컨트롤러에서 `guestId/guideId` 외부 입력 제거
  - 토큰 사용자 기반 member 조회 및 역할 검증(`GUEST`/`GUIDE`)
- TourExtension 조회 권한 검증 강화(게스트/가이드 당사자만 허용)
- F05-04 환불 구현 추가:
  - `PaymentService`, `PaymentController` 신규 추가
  - 게스트 환불 신청/처리(2시간 이내, 중복 방지, aiProcessed 반영)
- 테스트 추가:
  - `PaymentServiceTest`
  - `TourExtensionServiceTest`
- MatchRequestCreateRequest.guideId에 명시 주석 추가
  - guide_profiles.id를 넣어야 하고 member.id 아님
  - MatchRequestController 가이드 액션 정리
- JWT 사용자(member.id)에서 guide_profiles.id를 조회해서 사용하도록 변경
  - 대상: 가이드 목록 조회, 거절, 제안, 가이드 취소
  - 매칭 생성 시에도 request.guideId가 실제 guide_profiles에 존재하는지 검증 추가
- TourExtensionController 조회 보정
  - 게스트는 member.id 기준
  - 가이드는 guide_profiles.id로 변환해서 조회 권한 검증과 맞추도록 변경
---

## 🧪 테스트 결과
- [x] `./gradlew.bat :module-domain:compileJava` 성공
- [x] `./gradlew.bat :api-server:compileJava` 성공
- [x] `./gradlew.bat :module-domain:test --tests "com.team6.domain.matching.service.PaymentServiceTest" --tests "com.team6.domain.matching.service.TourExtensionServiceTest"` 성공
- [x] `./gradlew.bat :api-server:bootRun` 실행 시 `social_type` 스키마 검증 오류 해소 및 정상 기동 확인
- [ ] role별 endpoint(`hasRole`, `@PreAuthorize`) 통합 테스트는 후속 예정

---

## ⚠️ 주의 사항 / 질문
- 가이드 목록 조회 경로가 JWT 기준으로 `/matching/requests/guides/me`로 변경되었습니다. 프론트 경로 동기화가 필요합니다.
- 현재 환불은 F05-04 요구사항에 맞춰 신청 즉시 승인 처리합니다
- `@PreAuthorize` 기반 메서드 보안은 아직 미적용이며, 현재는 컨트롤러 내부 role 검증으로 처리합니다.


---

## ✅ 체크리스트
- [x] 빌드가 정상적으로 되는가?
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [x] .gitignore에 설정 파일이 잘 포함되었는가? (application-local.yml 등)
- [x] 로그인이 필요 없는 API를 만드시는 분은 SecurityConfig의 requestMatchers에 해당 경로를 추가해 주세요. 그 외의 모든 경로는 기본적으로 로그인이 필요하도록 설정해 두었습니다!