### PR TITLE
Feat/be#103 : 리뷰/평점 기능 구현

### DIFF
--- a/backend/module-domain/src/main/java/com/team6/domain/review/controller/ReviewController.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/review/controller/ReviewController.java
@@ -50,4 +50,10 @@ public class ReviewController {
     (@PathVariable Long guideId, @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
         return ResponseEntity.ok(reviewService.getReviewsByGuide(guideId, pageable));
     }
+
+    @DeleteMapping("/{reviewId}")
+    public ResponseEntity<Void> deleteReview(@PathVariable Long reviewId) {
+        reviewService.deleteReview(reviewId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/backend/module-domain/src/main/java/com/team6/domain/review/controller/ReviewController.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/review/controller/ReviewController.java
@@ -1,0 +1,53 @@
+package com.team6.domain.review.controller;
+
+import com.team6.domain.review.dto.reqeust.ReviewRequest;
+import com.team6.domain.review.dto.reqeust.ReviewUpdateRequest;
+import com.team6.domain.review.dto.response.ReviewResponse;
+import com.team6.domain.review.entity.Review;
+import com.team6.domain.review.service.ReviewService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableArgumentResolver;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/reviews")
+@RequiredArgsConstructor
+public class ReviewController {
+    private final ReviewService reviewService;
+
+    @GetMapping
+    public ResponseEntity<Page<ReviewResponse>> getReviews(
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ){
+        return ResponseEntity.ok(reviewService.findAll(pageable));
+    }
+
+    @PostMapping
+    public ResponseEntity<String> create(@Valid @RequestBody ReviewRequest request) {
+        reviewService.saveReview(request);
+        return ResponseEntity.ok("리뷰 등록 완료!");
+    }
+
+    @PostMapping("/{reviewId}/update")
+    public ResponseEntity<Void> updateReview
+            (@PathVariable Long reviewId, @Valid @RequestBody ReviewUpdateRequest request)
+    {
+        reviewService.updateReview(reviewId, request);
+        return ResponseEntity.ok().build();
+    }
+
+    // AI담당자는 데이터를 긁어가십시여
+    @GetMapping("/guide/{guideId}")
+    public ResponseEntity<Page<ReviewResponse>> getReviews
+    (@PathVariable Long guideId, @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok(reviewService.getReviewsByGuide(guideId, pageable));
+    }
+}

--- a/backend/module-domain/src/main/java/com/team6/domain/review/dto/reqeust/ReviewRequest.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/review/dto/reqeust/ReviewRequest.java
@@ -11,6 +11,9 @@ public class ReviewRequest {
     @NotNull(message = "리뷰 대상(가이드) 정보가 없습니다. ")
     private Long guideId;
 
+    @NotNull(message = "매칭 정보가 누락되었습니다")
+    private Long matchRequestId;
+
     @NotNull(message = "별점은 필수입니다. ")
     @Min(value = 1, message = "별점은 최소 1점 이상이어야 합니다. ")
     @Max(value = 5, message = "별점은 최대 5점 이하여야 합니다. ")

--- a/backend/module-domain/src/main/java/com/team6/domain/review/dto/reqeust/ReviewRequest.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/review/dto/reqeust/ReviewRequest.java
@@ -1,0 +1,22 @@
+package com.team6.domain.review.dto.reqeust;
+
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.aspectj.bridge.IMessage;
+
+@Getter
+@NoArgsConstructor
+public class ReviewRequest {
+    @NotNull(message = "리뷰 대상(가이드) 정보가 없습니다. ")
+    private Long guideId;
+
+    @NotNull(message = "별점은 필수입니다. ")
+    @Min(value = 1, message = "별점은 최소 1점 이상이어야 합니다. ")
+    @Max(value = 5, message = "별점은 최대 5점 이하여야 합니다. ")
+    private Integer rating;
+
+    @NotBlank(message = "리뷰 내용을 입력해주세요. ")
+    @Size(min = 10, max = 500, message = "리뷰는 10자 이상 500자 이하로 작성해주세요. ")
+    private String content;
+}

--- a/backend/module-domain/src/main/java/com/team6/domain/review/dto/reqeust/ReviewUpdateRequest.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/review/dto/reqeust/ReviewUpdateRequest.java
@@ -1,0 +1,20 @@
+package com.team6.domain.review.dto.reqeust;
+
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.aspectj.bridge.IMessage;
+
+@Getter
+@NoArgsConstructor
+public class ReviewUpdateRequest {
+
+    @NotNull(message = "별점은 필수입니다. ")
+    @Min(value = 1, message = "별점은 최소 1점 이상이어야 합니다. ")
+    @Max(value = 5, message = "별점은 최대 5점 이하여야 합니다. ")
+    private Integer rating;
+
+    @NotBlank(message = "리뷰 내용을 입력해주세요. ")
+    @Size(min = 10, max = 500, message = "리뷰는 10자 이상 500자 이하로 작성해주세요. ")
+    private String content;
+}

--- a/backend/module-domain/src/main/java/com/team6/domain/review/dto/response/ReviewResponse.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/review/dto/response/ReviewResponse.java
@@ -1,0 +1,24 @@
+package com.team6.domain.review.dto.response;
+
+import com.team6.domain.review.entity.Review;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+public class ReviewResponse {
+    private Long id;
+    private Integer rating;
+    private String content;
+    private String writeNickname;
+    private LocalDateTime createdAt;
+
+    public ReviewResponse (Review review) {
+        this.id = review.getId();
+        this.rating = review.getRating();
+        this.content = review.getContent();
+        this.writeNickname = review.getMember().getNickname();
+        this.createdAt = review.getCreatedAt();
+    }
+}

--- a/backend/module-domain/src/main/java/com/team6/domain/review/entity/Review.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/review/entity/Review.java
@@ -1,0 +1,55 @@
+package com.team6.domain.review.entity;
+
+import com.team6.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Review {
+    @Id@GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Integer rating;
+
+    @Column(columnDefinition = "Text")
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Column(name = "guide_id")
+    private Long guideId;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false, columnDefinition = "DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6)")
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false, columnDefinition = "DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)")
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public Review(Integer rating, String content, Member member, Long guideId) {
+        this.rating = rating;
+        this.content = content;
+        this.member = member;
+        this.guideId = guideId;
+    }
+
+    // 리뷰 수정시 날짜 및 콘텐츠 수정
+    public void update(Integer rating, String content) {
+        this.rating = rating;
+        this.content = content;
+    }
+}

--- a/backend/module-domain/src/main/java/com/team6/domain/review/entity/Review.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/review/entity/Review.java
@@ -19,6 +19,9 @@ public class Review {
     @Id@GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "match_request_id", nullable = false, unique = true)
+    private Long matchRequestId;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
@@ -47,11 +50,12 @@ public class Review {
     private LocalDateTime deletedAt;
 
     @Builder
-    public Review(Integer rating, String content, Member member, Long guideId) {
+    public Review(Integer rating, String content, Member member, Long guideId, Long matchRequestId) {
         this.rating = rating;
         this.content = content;
         this.member = member;
         this.guideId = guideId;
+        this.matchRequestId = matchRequestId;
     }
 
     // 리뷰 수정시 날짜 및 콘텐츠 수정

--- a/backend/module-domain/src/main/java/com/team6/domain/review/entity/Review.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/review/entity/Review.java
@@ -1,6 +1,7 @@
 package com.team6.domain.review.entity;
 
 import com.team6.domain.member.entity.Member;
+import com.team6.domain.member.service.MemberService;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -18,18 +19,21 @@ public class Review {
     @Id@GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "guide_id")
+    private Long guideId;
+
     @Column(nullable = false)
     private Integer rating;
 
     @Column(columnDefinition = "Text")
     private String content;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
-    private Member member;
-
-    @Column(name = "guide_id")
-    private Long guideId;
+    @Column(nullable = false)
+    private boolean deleted = false;
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false, columnDefinition = "DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6)")
@@ -38,6 +42,9 @@ public class Review {
     @UpdateTimestamp
     @Column(name = "updated_at", nullable = false, columnDefinition = "DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)")
     private LocalDateTime updatedAt;
+
+    // 삭제된 날짜
+    private LocalDateTime deletedAt;
 
     @Builder
     public Review(Integer rating, String content, Member member, Long guideId) {
@@ -51,5 +58,10 @@ public class Review {
     public void update(Integer rating, String content) {
         this.rating = rating;
         this.content = content;
+    }
+
+    public void delete() {
+        this.deleted = true;
+        this.deletedAt = LocalDateTime.now();
     }
 }

--- a/backend/module-domain/src/main/java/com/team6/domain/review/repository/ReviewRepository.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/review/repository/ReviewRepository.java
@@ -15,5 +15,5 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     @EntityGraph(attributePaths = {"member"})
     Page<Review> findAllByDeletedFalse(Pageable pageable);
 
-    boolean existsByMemberAndGuideIdAndDeletedFalse(Member member, Long guideId);
+    boolean existsByMatchRequestedId(Long matchedRequestedId);
 }

--- a/backend/module-domain/src/main/java/com/team6/domain/review/repository/ReviewRepository.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/review/repository/ReviewRepository.java
@@ -11,10 +11,9 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+    Page<Review> findAllByGuideIdAndDeletedFalse(Long guideId, Pageable pageable);
     @EntityGraph(attributePaths = {"member"})
-    Page<Review> findAllByGuideId(Long guideId , Pageable pageable);
-    @EntityGraph(attributePaths = {"member"})
-    Page<Review> findAll(Pageable pageable);
+    Page<Review> findAllByDeletedFalse(Pageable pageable);
 
-    boolean existsByMemberAndGuideId(Member member, Long guideId);
+    boolean existsByMemberAndGuideIdAndDeletedFalse(Member member, Long guideId);
 }

--- a/backend/module-domain/src/main/java/com/team6/domain/review/repository/ReviewRepository.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,20 @@
+package com.team6.domain.review.repository;
+
+import com.team6.domain.member.entity.Member;
+import com.team6.domain.review.entity.Review;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+@Repository
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+    @EntityGraph(attributePaths = {"member"})
+    Page<Review> findAllByGuideId(Long guideId , Pageable pageable);
+    @EntityGraph(attributePaths = {"member"})
+    Page<Review> findAll(Pageable pageable);
+
+    boolean existsByMemberAndGuideId(Member member, Long guideId);
+}

--- a/backend/module-domain/src/main/java/com/team6/domain/review/service/ReviewService.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/review/service/ReviewService.java
@@ -26,6 +26,7 @@ public class ReviewService {
     private final ReviewRepository reviewRepository;
     private final MemberRepository memberRepository;
 
+    // 리뷰 저장
     @Transactional
     public void saveReview(ReviewRequest request) {
         String email = SecurityUtil.getCurrentUserEmail();
@@ -33,7 +34,7 @@ public class ReviewService {
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
-        if(reviewRepository.existsByMemberAndGuideId(member, request.getGuideId())) {
+        if(reviewRepository.existsByMemberAndGuideIdAndDeletedFalse(member, request.getGuideId())) {
             throw new IllegalStateException("이미 이 가이드에 대한 리뷰를 작성하셨습니다. ");
         }
 
@@ -50,7 +51,7 @@ public class ReviewService {
         reviewRepository.save(review);
     }
 
-    // 리뷰 수정(24시간 이내 1번만 수정 가능)
+    // 리뷰 수정 (24시간 이내만 수정 가능)
     @Transactional
     public void updateReview(Long reviewId, ReviewUpdateRequest request) {
         String email = SecurityUtil.getCurrentUserEmail();
@@ -74,14 +75,30 @@ public class ReviewService {
     // 모든 리뷰 조회
     @Transactional(readOnly = true)
     public Page<ReviewResponse> findAll(Pageable pageable) {
-        return reviewRepository.findAll(pageable)
+        return reviewRepository.findAllByDeletedFalse(pageable)
                 .map(ReviewResponse::new);
     }
 
     // 특정 가이드에 대한 모든 리뷰 페이징기법으로 조회
     @Transactional(readOnly = true)
     public Page<ReviewResponse> getReviewsByGuide(Long guideId, Pageable pageable) {
-        return reviewRepository.findAllByGuideId(guideId, pageable)
+        return reviewRepository.findAllByGuideIdAndDeletedFalse(guideId, pageable)
                 .map(ReviewResponse::new);
+    }
+
+    // 리뷰 삭제
+    @Transactional
+    public void deleteReview(Long reviewId) {
+        String email = SecurityUtil.getCurrentUserEmail();
+
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new IllegalArgumentException(("리뷰를 찾을 수 없습니다. ")));
+
+        // 본인 확인
+        if(!review.getMember().getEmail().equals(email)) {
+            throw new IllegalStateException("본인이 작성한 리뷰만 삭제할 수 있습니다.");
+        }
+
+        review.delete();
     }
 }

--- a/backend/module-domain/src/main/java/com/team6/domain/review/service/ReviewService.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/review/service/ReviewService.java
@@ -1,0 +1,87 @@
+package com.team6.domain.review.service;
+
+import com.team6.domain.member.entity.Member;
+import com.team6.domain.member.entity.Status;
+import com.team6.domain.member.repository.MemberRepository;
+import com.team6.domain.review.dto.reqeust.ReviewRequest;
+import com.team6.domain.review.dto.reqeust.ReviewUpdateRequest;
+import com.team6.domain.review.dto.response.ReviewResponse;
+import com.team6.domain.review.entity.Review;
+import com.team6.domain.review.repository.ReviewRepository;
+import com.team6.module.common.global.util.SecurityUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+@Service
+@RequiredArgsConstructor
+public class ReviewService {
+    private final ReviewRepository reviewRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void saveReview(ReviewRequest request) {
+        String email = SecurityUtil.getCurrentUserEmail();
+
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        if(reviewRepository.existsByMemberAndGuideId(member, request.getGuideId())) {
+            throw new IllegalStateException("이미 이 가이드에 대한 리뷰를 작성하셨습니다. ");
+        }
+
+        if(member.getStatus() == Status.WITHDRAWN) {
+            throw new IllegalStateException("탈퇴한 회원은 서비스를 이용할 수 없습니다.");
+        }
+
+        Review review = Review.builder()
+                .rating(request.getRating())
+                .content(request.getContent())
+                .member(member)
+                .guideId(request.getGuideId())
+                .build();
+        reviewRepository.save(review);
+    }
+
+    // 리뷰 수정(24시간 이내 1번만 수정 가능)
+    @Transactional
+    public void updateReview(Long reviewId, ReviewUpdateRequest request) {
+        String email = SecurityUtil.getCurrentUserEmail();
+
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(()-> new IllegalArgumentException("리뷰를 찾을 수 없습니다."));
+
+        // 본인 확인
+        if(!review.getMember().getEmail().equals(email)) {
+            throw new IllegalStateException("본인이 작성한 리뷰만 수정할 수 있습니다.");
+        }
+
+        // 수정 기간 확인
+        if(review.getCreatedAt().isBefore(LocalDateTime.now().minusDays(1))) {
+            throw new IllegalStateException("리뷰 수정 가능 시간(24시간)이 지났습니다.");
+        }
+
+        review.update(request.getRating(), request.getContent());
+    }
+
+    // 모든 리뷰 조회
+    @Transactional(readOnly = true)
+    public Page<ReviewResponse> findAll(Pageable pageable) {
+        return reviewRepository.findAll(pageable)
+                .map(ReviewResponse::new);
+    }
+
+    // 특정 가이드에 대한 모든 리뷰 페이징기법으로 조회
+    @Transactional(readOnly = true)
+    public Page<ReviewResponse> getReviewsByGuide(Long guideId, Pageable pageable) {
+        return reviewRepository.findAllByGuideId(guideId, pageable)
+                .map(ReviewResponse::new);
+    }
+}

--- a/backend/module-domain/src/main/java/com/team6/domain/review/service/ReviewService.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/review/service/ReviewService.java
@@ -34,7 +34,7 @@ public class ReviewService {
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
-        if(reviewRepository.existsByMemberAndGuideIdAndDeletedFalse(member, request.getGuideId())) {
+        if(reviewRepository.existsByMatchRequestedId(request.getMatchRequestId())) {
             throw new IllegalStateException("이미 이 가이드에 대한 리뷰를 작성하셨습니다. ");
         }
 


### PR DESCRIPTION
# 🔗 이슈 번호
- Closes #103

---

## 💡 주요 변경 사항
리뷰 및 평점 시스템의 핵심 CRUD 기능을 구현하고, 매칭(Matching) 도메인과의 연동을 통해 데이터 정합성을 확보했습니다.

### 1. 리뷰 CRUD 및 Soft Delete
- **CRUD 구현**: 등록, 수정, 조회, 삭제 기능 개발 완료.
- **Soft Delete 적용**: `deleted` (TINYINT) 플래그 및 `deletedAt` 필드를 도입하여 데이터 삭제 시 물리적 삭제 대신 논리 삭제 방식을 채택했습니다. 이는 향후 가이드 평점 통계 및 데이터 보존을 위함입니다.

### 2. 매칭 도메인 연동 (`MatchRequest` ID 참조)
- **ID 참조 설계**: 리뷰 테이블에 `match_request_id` 필드를 추가하여 특정 '여행 사건'과 리뷰를 1:1로 매핑했습니다.
- **확장성 확보**: 유저-가이드 직접 매핑이 아닌 매칭 ID를 참조함으로써, 동일 가이드와 여러 번 매칭되는 **'단골 고객'이 각 여행 건마다 리뷰를 남길 수 있도록** 설계했습니다.

### 3. 중복 작성 방지 로직 고도화
- **검증 기준 변경**: 기존의 '유저-가이드' 기준 체크를 **'매칭 요청 ID(matchRequestId)'** 기준으로 변경했습니다.
- **데이터 무결성**: 하나의 `MatchRequest`에 대해 하나의 리뷰만 작성 가능하도록 `unique = true` 제약 조건을 적용했습니다.

### 4. 성능 및 비즈니스 정책 최적화
- **N+1 문제 해결**: `@EntityGraph`를 통해 리뷰 조회 시 작성자(`Member`) 정보를 `Fetch Join`으로 한 번에 가져오도록 개선했습니다.
- **수정 제한**: 리뷰 수정은 작성 후 **24시간 이내**에만 가능하도록 비즈니스 로직을 강화했습니다.

---

## ⚠️ 주의 사항 및 리뷰 포인트
- **DTO 구조**: `ReviewRequest`에서 `guideId`와 `matchRequestId`를 모두 받습니다. 이는 매칭 도메인에 대한 의존성을 낮추고, 리뷰 목록 조회 시 성능을 최적화하기 위한 의도적인 중복 저장입니다.
- **오타 및 명명 규칙**: 생성자 및 Repository에서 발생했던 오타(`matchRequestedId`)를 필드명인 `matchRequestId`로 전면 수정하여 일관성을 맞췄습니다.

---

## ✅ 체크리스트
- [x] 빌드가 정상적으로 되는가?
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [x] Soft Delete 적용 후 조회 로직(`DeletedFalse`)이 정상 작동하는가?
- [x] 한 개 매칭 건당 중복 리뷰 작성이 차단되는지 확인했는가?

---

## 🚀 향후 구현 예정
1. **리뷰 평점 평균 계산**: 가이드 프로필에 반영될 실시간/배치 평점 집계 기능.
2. **상태값 검증**: `MatchRequest`의 상태가 `COMPLETED`인 경우에만 리뷰 작성이 가능하도록 하는 인터-도메인 검증 추가.
3. **리뷰 임시저장**: 작성 중인 긴 리뷰의 휘발 방지를 위한 기능.