### PR TITLE
Feat/be#120 AI 추천: 리뷰·환불 피드백 룰 반영

### DIFF
--- a/backend/module-ai-integration/src/main/java/com/team6/integration/ai/DbBackedGuideCandidateProvider.java
+++ b/backend/module-ai-integration/src/main/java/com/team6/integration/ai/DbBackedGuideCandidateProvider.java
@@ -2,6 +2,8 @@ package com.team6.integration.ai;
 
 import com.team6.domain.guide.entity.GuideProfile;
 import com.team6.domain.guide.repository.GuideProfileRepository;
+import com.team6.domain.matching.entity.enums.RefundStatus;
+import com.team6.domain.matching.repository.RefundRepository;
 import com.team6.module.ai.dto.request.GuideRecommendRequest;
 import com.team6.module.ai.parser.PromptParser;
 import com.team6.module.ai.support.AiRecommendationTuning;
@@ -13,7 +15,10 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 /**
  * 클라이언트가 후보를 내려보내지 않은 경우, 승인·활성 {@link GuideProfile}을 DB에서 읽어 AI 후보로 채운다.
@@ -27,6 +32,7 @@ public class DbBackedGuideCandidateProvider implements GuideCandidateProvider {
     static final int MAX_SERVER_CANDIDATES = 200;
 
     private final GuideProfileRepository guideProfileRepository;
+    private final RefundRepository refundRepository;
     private final PromptParser promptParser;
 
     @Override
@@ -58,6 +64,49 @@ public class DbBackedGuideCandidateProvider implements GuideCandidateProvider {
             log.info("[AI_RECOMMEND] No region in prompt; loading global approved-active guide pool");
             profiles = guideProfileRepository.findByIsApprovedTrueAndIsActiveTrue(pageable).getContent();
         }
-        return profiles.stream().map(GuideProfileAiCandidateMapper::toCandidate).toList();
+        List<GuideRecommendRequest.GuideCandidateDto> mapped =
+                profiles.stream().map(GuideProfileAiCandidateMapper::toCandidate).toList();
+        return mergeApprovedRefundCounts(mapped);
+    }
+
+    private List<GuideRecommendRequest.GuideCandidateDto> mergeApprovedRefundCounts(
+            List<GuideRecommendRequest.GuideCandidateDto> candidates
+    ) {
+        List<Long> guideIds = candidates.stream()
+                .map(GuideRecommendRequest.GuideCandidateDto::getGuideId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+        if (guideIds.isEmpty()) {
+            return candidates;
+        }
+        List<Object[]> rows = refundRepository.countApprovedRefundsGroupedByGuideId(guideIds, RefundStatus.APPROVED);
+        Map<Long, Integer> countByGuide = new HashMap<>();
+        for (Object[] row : rows) {
+            Long gid = (Long) row[0];
+            int cnt = ((Number) row[1]).intValue();
+            countByGuide.put(gid, cnt);
+        }
+        return candidates.stream()
+                .map(d -> rebuildWithRefund(d, countByGuide.getOrDefault(d.getGuideId(), 0)))
+                .toList();
+    }
+
+    private static GuideRecommendRequest.GuideCandidateDto rebuildWithRefund(
+            GuideRecommendRequest.GuideCandidateDto d,
+            int approvedRefundCount
+    ) {
+        return GuideRecommendRequest.GuideCandidateDto.builder()
+                .guideId(d.getGuideId())
+                .guideName(d.getGuideName())
+                .region(d.getRegion())
+                .guideStyle(d.getGuideStyle())
+                .priceLevel(d.getPriceLevel())
+                .specialtyTags(d.getSpecialtyTags())
+                .languages(d.getLanguages())
+                .averageRating(d.getAverageRating())
+                .reviewCount(d.getReviewCount())
+                .approvedRefundCount(approvedRefundCount)
+                .build();
     }
 }

--- a/backend/module-ai-integration/src/main/java/com/team6/integration/ai/GuideProfileAiCandidateMapper.java
+++ b/backend/module-ai-integration/src/main/java/com/team6/integration/ai/GuideProfileAiCandidateMapper.java
@@ -24,6 +24,9 @@ public final class GuideProfileAiCandidateMapper {
                 .priceLevel(priceLevelFromHourly(profile.getPricePerHour()))
                 .specialtyTags(List.of())
                 .languages(splitLanguages(profile.getLanguage()))
+                .averageRating(profile.getAverageRating())
+                .reviewCount(profile.getReviewCount())
+                .approvedRefundCount(null)
                 .build();
     }
 

--- a/backend/module-ai-integration/src/test/java/com/team6/integration/ai/DbBackedGuideCandidateProviderTest.java
+++ b/backend/module-ai-integration/src/test/java/com/team6/integration/ai/DbBackedGuideCandidateProviderTest.java
@@ -2,6 +2,8 @@ package com.team6.integration.ai;
 
 import com.team6.domain.guide.entity.GuideProfile;
 import com.team6.domain.guide.repository.GuideProfileRepository;
+import com.team6.domain.matching.entity.enums.RefundStatus;
+import com.team6.domain.matching.repository.RefundRepository;
 import com.team6.module.ai.config.LocalGuestAiProperties;
 import com.team6.module.ai.dto.request.GuideRecommendRequest;
 import com.team6.module.ai.parser.PromptParser;
@@ -30,12 +32,16 @@ class DbBackedGuideCandidateProviderTest {
     @Mock
     private GuideProfileRepository guideProfileRepository;
 
+    @Mock
+    private RefundRepository refundRepository;
+
     private DbBackedGuideCandidateProvider provider;
 
     @BeforeEach
     void setUp() {
         provider = new DbBackedGuideCandidateProvider(
                 guideProfileRepository,
+                refundRepository,
                 new PromptParser(new LocalGuestAiProperties())
         );
     }
@@ -57,6 +63,7 @@ class DbBackedGuideCandidateProviderTest {
                 provider.getCandidates("제주 2박", 3, client);
         assertThat(out).isSameAs(client);
         verify(guideProfileRepository, never()).findByIsApprovedTrueAndIsActiveTrue(any(Pageable.class));
+        verify(refundRepository, never()).countApprovedRefundsGroupedByGuideId(any(), any());
     }
 
     @Test
@@ -75,6 +82,8 @@ class DbBackedGuideCandidateProviderTest {
                 eq("제주"),
                 any(Pageable.class)
         )).thenReturn(new PageImpl<>(List.of(p)));
+        when(refundRepository.countApprovedRefundsGroupedByGuideId(any(), eq(RefundStatus.APPROVED)))
+                .thenReturn(List.of());
 
         List<GuideRecommendRequest.GuideCandidateDto> out =
                 provider.getCandidates("제주에서 힐링하고 싶어요", 3, List.of());
@@ -84,6 +93,7 @@ class DbBackedGuideCandidateProviderTest {
         assertThat(out.get(0).getRegion()).isEqualTo("제주");
         assertThat(out.get(0).getLanguages()).containsExactly("한국어", "English");
         assertThat(out.get(0).getPriceLevel()).isEqualTo("낮음");
+        assertThat(out.get(0).getApprovedRefundCount()).isZero();
     }
 
     @Test
@@ -104,6 +114,8 @@ class DbBackedGuideCandidateProviderTest {
                 .build();
         when(guideProfileRepository.findByIsApprovedTrueAndIsActiveTrue(PageRequest.of(0, DbBackedGuideCandidateProvider.MAX_SERVER_CANDIDATES)))
                 .thenReturn(new PageImpl<>(List.of(p)));
+        when(refundRepository.countApprovedRefundsGroupedByGuideId(any(), eq(RefundStatus.APPROVED)))
+                .thenReturn(List.of());
 
         List<GuideRecommendRequest.GuideCandidateDto> out =
                 provider.getCandidates("제주 가고 싶어요", 3, null);
@@ -127,6 +139,8 @@ class DbBackedGuideCandidateProviderTest {
                 .build();
         when(guideProfileRepository.findByIsApprovedTrueAndIsActiveTrue(any(Pageable.class)))
                 .thenReturn(new PageImpl<>(List.of(p)));
+        when(refundRepository.countApprovedRefundsGroupedByGuideId(any(), eq(RefundStatus.APPROVED)))
+                .thenReturn(List.of());
 
         List<GuideRecommendRequest.GuideCandidateDto> out =
                 provider.getCandidates("그냥 여행 가고 싶어요", 3, List.of());

--- a/backend/module-ai/src/main/java/com/team6/module/ai/controller/AiController.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/controller/AiController.java
@@ -44,7 +44,7 @@ public class AiController {
             headers = @Header(
                     name = RecommendationHttpHeaders.X_RECOMMENDATION_POLICY,
                     description = "룰 정책 버전(응답 body의 policyVersion과 동일). 캐시 키·디버깅에 활용 가능.",
-                    schema = @Schema(implementation = String.class, example = "2026.04.5")
+                    schema = @Schema(implementation = String.class, example = "2026.04.6")
             ),
             content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = GuideRecommendResponse.class))
     )

--- a/backend/module-ai/src/main/java/com/team6/module/ai/dto/request/GuideRecommendRequest.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/dto/request/GuideRecommendRequest.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 @Schema(name = "GuideRecommendRequest", description = "파싱 결과 또는 직접 구성한 추천 요청(내부/테스트용)")
@@ -37,5 +38,13 @@ public class GuideRecommendRequest {
         private String priceLevel;
         private List<String> specialtyTags;
         private List<String> languages;
+        /** 도메인 집계: 평균 평점(없으면 null — 감점 미적용). */
+        @Schema(description = "가이드 평균 평점(리뷰 집계). 미전달 시 피드백 감점에 쓰이지 않음")
+        private BigDecimal averageRating;
+        @Schema(description = "리뷰 수. averageRating과 함께 쓰여 저평점 감점 여부를 판단")
+        private Integer reviewCount;
+        /** 승인된 환불 건수(가이드 기준). 미전달 시 환불 감점 미적용. */
+        @Schema(description = "승인(APPROVED) 환불 건수. 집계해 전달하면 룰 기반 감점에 반영")
+        private Integer approvedRefundCount;
     }
 }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/dto/response/GuideRecommendResponse.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/dto/response/GuideRecommendResponse.java
@@ -24,7 +24,7 @@ public class GuideRecommendResponse {
     /**
      * 룰 기반 추천 정책 버전({@link com.team6.module.ai.support.AiRecommendationTuning#POLICY_VERSION}).
      */
-    @Schema(description = "룰 기반 추천 정책 버전(동일 프롬프트라도 정책 변경 구분용)", example = "2026.04.5")
+    @Schema(description = "룰 기반 추천 정책 버전(동일 프롬프트라도 정책 변경 구분용)", example = "2026.04.6")
     private String policyVersion;
     @Schema(description = "추천 항목 개수")
     private int totalCount;

--- a/backend/module-ai/src/main/java/com/team6/module/ai/engine/ReasonGenerator.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/engine/ReasonGenerator.java
@@ -3,6 +3,7 @@ package com.team6.module.ai.engine;
 import com.team6.module.ai.model.GuideAiProfile;
 import com.team6.module.ai.model.TravelerPreference;
 import com.team6.module.ai.parser.KeywordNormalizer;
+import com.team6.module.ai.support.AiRecommendationTuning;
 import com.team6.module.ai.support.BudgetTier;
 import org.springframework.stereotype.Component;
 
@@ -22,6 +23,8 @@ public class ReasonGenerator {
     public static final String CODE_SOFT_ACTIVITY_PENALTY = "SOFT_ACTIVITY_PENALTY";
     public static final String CODE_BUDGET_MATCH = "BUDGET_MATCH";
     public static final String CODE_GENERAL_FALLBACK = "GENERAL_FALLBACK";
+    public static final String CODE_FEEDBACK_REFUND_APPROVED = "FEEDBACK_REFUND_APPROVED";
+    public static final String CODE_FEEDBACK_LOW_RATING = "FEEDBACK_LOW_RATING";
 
     /** soft 부담 등이 잘리지 않도록 여유를 둔다. */
     private static final int MAX_DISPLAY_SEGMENTS = 4;
@@ -161,6 +164,32 @@ public class ReasonGenerator {
                     "예산 범위가 한 단계 차이로 가까움",
                     listNonNull(guide.getPriceLevel())
             ));
+        }
+
+        if (guide.getApprovedRefundCount() != null && guide.getApprovedRefundCount() > 0) {
+            segments.add(new Segment(
+                    CODE_FEEDBACK_REFUND_APPROVED,
+                    "승인된 환불 이력이 있어 점수에서 보수적으로 반영",
+                    List.of(String.valueOf(guide.getApprovedRefundCount()))
+            ));
+        }
+
+        if (guide.getAverageRating() != null && guide.getReviewCount() != null
+                && guide.getReviewCount() >= AiRecommendationTuning.FEEDBACK_LOW_RATING_MIN_REVIEWS) {
+            double a = guide.getAverageRating().doubleValue();
+            if (a < AiRecommendationTuning.FEEDBACK_VERY_LOW_RATING_THRESHOLD) {
+                segments.add(new Segment(
+                        CODE_FEEDBACK_LOW_RATING,
+                        "리뷰 평균이 매우 낮아 신중히 반영",
+                        List.of(guide.getAverageRating().toPlainString(), String.valueOf(guide.getReviewCount()))
+                ));
+            } else if (a < AiRecommendationTuning.FEEDBACK_LOW_RATING_THRESHOLD) {
+                segments.add(new Segment(
+                        CODE_FEEDBACK_LOW_RATING,
+                        "리뷰 평균이 낮은 편이라 보수적으로 반영",
+                        List.of(guide.getAverageRating().toPlainString(), String.valueOf(guide.getReviewCount()))
+                ));
+            }
         }
 
         return segments;

--- a/backend/module-ai/src/main/java/com/team6/module/ai/engine/ScoreCalculator.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/engine/ScoreCalculator.java
@@ -4,6 +4,7 @@ import com.team6.module.ai.model.GuideAiProfile;
 import com.team6.module.ai.model.TravelerPreference;
 import com.team6.module.ai.policy.ActivityMatchPolicy;
 import com.team6.module.ai.policy.BudgetMatchPolicy;
+import com.team6.module.ai.policy.FeedbackMatchPolicy;
 import com.team6.module.ai.policy.LanguageMatchPolicy;
 import com.team6.module.ai.policy.RegionMatchPolicy;
 import com.team6.module.ai.policy.StyleMatchPolicy;
@@ -19,6 +20,7 @@ public class ScoreCalculator {
     private final BudgetMatchPolicy budgetMatchPolicy;
     private final ActivityMatchPolicy activityMatchPolicy;
     private final LanguageMatchPolicy languageMatchPolicy;
+    private final FeedbackMatchPolicy feedbackMatchPolicy;
 
     public int calculate(TravelerPreference pref, GuideAiProfile guide) {
         int score = 0;
@@ -27,6 +29,7 @@ public class ScoreCalculator {
         score += budgetMatchPolicy.score(pref, guide);
         score += activityMatchPolicy.score(pref, guide);
         score += languageMatchPolicy.score(pref, guide);
+        score += feedbackMatchPolicy.score(pref, guide);
         return score;
     }
 }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/model/GuideAiProfile.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/model/GuideAiProfile.java
@@ -3,6 +3,7 @@ package com.team6.module.ai.model;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 @Getter
@@ -15,4 +16,9 @@ public class GuideAiProfile {
     private String priceLevel;
     private List<String> specialtyTags;
     private List<String> languages;
+    /** 평균 평점(도메인). null이면 평점 감점 없음. */
+    private BigDecimal averageRating;
+    private Integer reviewCount;
+    /** 승인 환불 건수. null이면 환불 감점 없음. */
+    private Integer approvedRefundCount;
 }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/policy/FeedbackMatchPolicy.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/policy/FeedbackMatchPolicy.java
@@ -1,0 +1,41 @@
+package com.team6.module.ai.policy;
+
+import com.team6.module.ai.model.GuideAiProfile;
+import com.team6.module.ai.model.TravelerPreference;
+import com.team6.module.ai.support.AiRecommendationTuning;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+
+/**
+ * 리뷰·환불 등 **사후 피드백** 기반 감점. 선호(TravelerPreference)와 무관하게 가이드 신호만 본다.
+ */
+@Component
+public class FeedbackMatchPolicy {
+
+    public int score(TravelerPreference pref, GuideAiProfile guide) {
+        int penalty = 0;
+
+        Integer refunds = guide.getApprovedRefundCount();
+        if (refunds != null && refunds > 0) {
+            penalty += Math.min(
+                    refunds * AiRecommendationTuning.FEEDBACK_REFUND_PENALTY_PER_APPROVED,
+                    AiRecommendationTuning.FEEDBACK_REFUND_PENALTY_MAX
+            );
+        }
+
+        BigDecimal avg = guide.getAverageRating();
+        Integer reviewCount = guide.getReviewCount();
+        if (avg != null && reviewCount != null
+                && reviewCount >= AiRecommendationTuning.FEEDBACK_LOW_RATING_MIN_REVIEWS) {
+            double a = avg.doubleValue();
+            if (a < AiRecommendationTuning.FEEDBACK_VERY_LOW_RATING_THRESHOLD) {
+                penalty += AiRecommendationTuning.FEEDBACK_VERY_LOW_RATING_PENALTY;
+            } else if (a < AiRecommendationTuning.FEEDBACK_LOW_RATING_THRESHOLD) {
+                penalty += AiRecommendationTuning.FEEDBACK_LOW_RATING_PENALTY;
+            }
+        }
+
+        return -penalty;
+    }
+}

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationMapper.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationMapper.java
@@ -57,6 +57,9 @@ public class AiRecommendationMapper {
                         .priceLevel(candidate.getPriceLevel())
                         .specialtyTags(candidate.getSpecialtyTags())
                         .languages(candidate.getLanguages())
+                        .averageRating(candidate.getAverageRating())
+                        .reviewCount(candidate.getReviewCount())
+                        .approvedRefundCount(candidate.getApprovedRefundCount())
                         .build())
                 .toList();
     }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationTuning.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationTuning.java
@@ -14,7 +14,7 @@ public final class AiRecommendationTuning {
     /**
      * 룰/스코어/Reason/응답 계약이 바뀔 때마다 올린다. 로그·API에서 동일 프롬프트 비교 시 정책 변경 여부를 구분하는 데 쓴다.
      */
-    public static final String POLICY_VERSION = "2026.04.5";
+    public static final String POLICY_VERSION = "2026.04.6";
 
     public static final int DEFAULT_TOP_N = 3;
 
@@ -32,4 +32,15 @@ public final class AiRecommendationTuning {
      * 와 겹칠 때마다 활동 점수에서 차감하는 값(한 태그당, {@link com.team6.module.ai.policy.ScoreWeight#ACTIVITY}와 동일 스케일).
      */
     public static final int SOFT_ACTIVITY_PENALTY_PER_TAG = 6;
+
+    /** 승인 환불 1건당 감점(상한 {@link #FEEDBACK_REFUND_PENALTY_MAX}). */
+    public static final int FEEDBACK_REFUND_PENALTY_PER_APPROVED = 8;
+    public static final int FEEDBACK_REFUND_PENALTY_MAX = 24;
+
+    /** 평균 평점 감점: 최소 리뷰 수(노이즈 완화). */
+    public static final int FEEDBACK_LOW_RATING_MIN_REVIEWS = 3;
+    public static final double FEEDBACK_LOW_RATING_THRESHOLD = 3.5;
+    public static final int FEEDBACK_LOW_RATING_PENALTY = 10;
+    public static final double FEEDBACK_VERY_LOW_RATING_THRESHOLD = 2.5;
+    public static final int FEEDBACK_VERY_LOW_RATING_PENALTY = 16;
 }

--- a/backend/module-ai/src/test/java/com/team6/module/ai/policy/FeedbackMatchPolicyTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/policy/FeedbackMatchPolicyTest.java
@@ -1,0 +1,57 @@
+package com.team6.module.ai.policy;
+
+import com.team6.module.ai.model.GuideAiProfile;
+import com.team6.module.ai.model.TravelerPreference;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FeedbackMatchPolicyTest {
+
+    private final FeedbackMatchPolicy policy = new FeedbackMatchPolicy();
+
+    @Test
+    void no_signal_returns_zero() {
+        TravelerPreference pref = TravelerPreference.builder().region("제주").activityTags(List.of()).build();
+        GuideAiProfile guide = GuideAiProfile.builder()
+                .guideId(1L)
+                .guideName("a")
+                .region("제주")
+                .languages(List.of())
+                .specialtyTags(List.of())
+                .build();
+        assertThat(policy.score(pref, guide)).isZero();
+    }
+
+    @Test
+    void approved_refunds_apply_penalty_capped() {
+        TravelerPreference pref = TravelerPreference.builder().region("제주").activityTags(List.of()).build();
+        GuideAiProfile guide = GuideAiProfile.builder()
+                .guideId(1L)
+                .guideName("a")
+                .region("제주")
+                .languages(List.of())
+                .specialtyTags(List.of())
+                .approvedRefundCount(5)
+                .build();
+        assertThat(policy.score(pref, guide)).isEqualTo(-24);
+    }
+
+    @Test
+    void low_average_rating_penalty() {
+        TravelerPreference pref = TravelerPreference.builder().region("제주").activityTags(List.of()).build();
+        GuideAiProfile guide = GuideAiProfile.builder()
+                .guideId(1L)
+                .guideName("a")
+                .region("제주")
+                .languages(List.of())
+                .specialtyTags(List.of())
+                .averageRating(new BigDecimal("2.4"))
+                .reviewCount(5)
+                .build();
+        assertThat(policy.score(pref, guide)).isEqualTo(-16);
+    }
+}

--- a/backend/module-ai/src/test/java/com/team6/module/ai/regression/AiRecommendationRegressionTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/regression/AiRecommendationRegressionTest.java
@@ -9,6 +9,7 @@ import com.team6.module.ai.engine.ScoreCalculator;
 import com.team6.module.ai.parser.PromptParser;
 import com.team6.module.ai.policy.ActivityMatchPolicy;
 import com.team6.module.ai.policy.BudgetMatchPolicy;
+import com.team6.module.ai.policy.FeedbackMatchPolicy;
 import com.team6.module.ai.policy.LanguageMatchPolicy;
 import com.team6.module.ai.policy.RegionMatchPolicy;
 import com.team6.module.ai.policy.StyleMatchPolicy;
@@ -197,7 +198,8 @@ class AiRecommendationRegressionTest {
                 new StyleMatchPolicy(),
                 new BudgetMatchPolicy(),
                 new ActivityMatchPolicy(),
-                new LanguageMatchPolicy()
+                new LanguageMatchPolicy(),
+                new FeedbackMatchPolicy()
         );
 
         return new AiRecommendationServiceImpl(new MatchingEngine(scoreCalculator, new ReasonGenerator()));

--- a/backend/module-ai/src/test/java/com/team6/module/ai/service/AiRecommendationServiceTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/service/AiRecommendationServiceTest.java
@@ -7,6 +7,7 @@ import com.team6.module.ai.engine.ReasonGenerator;
 import com.team6.module.ai.engine.ScoreCalculator;
 import com.team6.module.ai.policy.ActivityMatchPolicy;
 import com.team6.module.ai.policy.BudgetMatchPolicy;
+import com.team6.module.ai.policy.FeedbackMatchPolicy;
 import com.team6.module.ai.policy.LanguageMatchPolicy;
 import com.team6.module.ai.policy.RegionMatchPolicy;
 import com.team6.module.ai.policy.StyleMatchPolicy;
@@ -25,7 +26,8 @@ class AiRecommendationServiceTest {
                 new StyleMatchPolicy(),
                 new BudgetMatchPolicy(),
                 new ActivityMatchPolicy(),
-                new LanguageMatchPolicy()
+                new LanguageMatchPolicy(),
+                new FeedbackMatchPolicy()
         );
 
         return new AiRecommendationServiceImpl(

--- a/backend/module-ai/src/test/java/com/team6/module/ai/service/PromptRecommendationServiceTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/service/PromptRecommendationServiceTest.java
@@ -12,6 +12,7 @@ import com.team6.module.ai.support.AdjacentRegionProvider;
 import com.team6.module.ai.support.AiRecommendationMetrics;
 import com.team6.module.ai.support.RecommendationNoticeCodes;
 import com.team6.module.ai.policy.BudgetMatchPolicy;
+import com.team6.module.ai.policy.FeedbackMatchPolicy;
 import com.team6.module.ai.policy.LanguageMatchPolicy;
 import com.team6.module.ai.policy.RegionMatchPolicy;
 import com.team6.module.ai.policy.StyleMatchPolicy;
@@ -31,7 +32,8 @@ class PromptRecommendationServiceTest {
                 new StyleMatchPolicy(),
                 new BudgetMatchPolicy(),
                 new ActivityMatchPolicy(),
-                new LanguageMatchPolicy()
+                new LanguageMatchPolicy(),
+                new FeedbackMatchPolicy()
         );
         AiRecommendationService aiRecommendationService =
                 new AiRecommendationServiceImpl(new MatchingEngine(scoreCalculator, new ReasonGenerator()));

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/repository/RefundRepository.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/repository/RefundRepository.java
@@ -3,6 +3,9 @@ package com.team6.domain.matching.repository;
 import com.team6.domain.matching.entity.Refund;
 import com.team6.domain.matching.entity.enums.RefundStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -16,4 +19,21 @@ public interface RefundRepository extends JpaRepository<Refund, Long> {
 
     // 상태별 환불 목록 조회 (관리자용)
     List<Refund> findByStatus(RefundStatus status);
+
+    /**
+     * 가이드 프로필 ID(match_requests.guide_id) 기준 승인 환불 건수 집계 (AI 피드백·대시보드용).
+     */
+    @Query("""
+            SELECT mr.guideId, COUNT(r)
+            FROM Refund r
+            JOIN r.payment p
+            JOIN p.matchRequest mr
+            WHERE mr.guideId IN :guideIds
+              AND r.status = :status
+            GROUP BY mr.guideId
+            """)
+    List<Object[]> countApprovedRefundsGroupedByGuideId(
+            @Param("guideIds") List<Long> guideIds,
+            @Param("status") RefundStatus status
+    );
 }


### PR DESCRIPTION
## 요약
- \`GuideCandidateDto\` / \`GuideAiProfile\`에 **평균 평점·리뷰 수·승인 환불 건수** 필드 추가 (미전달 시 기존과 동일 동작).
- \`FeedbackMatchPolicy\` + \`ScoreCalculator\` 연동: 승인 환불·저평점(리뷰 수 하한 이상) **감점**.
- \`ReasonGenerator\`에 **FEEDBACK_*** 근거 코드·문구 추가.
- \`RefundRepository\`: 가이드별 **승인 환불 건수** JPQL 집계.
- \`module-ai-integration\`: DB 후보 조회 시 **프로필 평점/리뷰 수** 매핑 + **환불 건수 병합**.
- \`POLICY_VERSION\` → \`2026.04.6\`

## 검증
\`\`\`bash
cd backend && ./gradlew :module-domain:compileJava :module-ai:test :module-ai-integration:test :api-server:compileJava
\`\`\`

Closes #120

Made with [Cursor](https://cursor.com)