### PR TITLE
Feat/be#122 AI 추천 피드백 감점 Micrometer 지표

### DIFF
--- a/backend/module-ai/src/main/java/com/team6/module/ai/engine/ScoreCalculator.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/engine/ScoreCalculator.java
@@ -8,6 +8,8 @@ import com.team6.module.ai.policy.FeedbackMatchPolicy;
 import com.team6.module.ai.policy.LanguageMatchPolicy;
 import com.team6.module.ai.policy.RegionMatchPolicy;
 import com.team6.module.ai.policy.StyleMatchPolicy;
+import com.team6.module.ai.support.AiRecommendationMetrics;
+import com.team6.module.ai.support.AiRecommendationTuning;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -21,6 +23,7 @@ public class ScoreCalculator {
     private final ActivityMatchPolicy activityMatchPolicy;
     private final LanguageMatchPolicy languageMatchPolicy;
     private final FeedbackMatchPolicy feedbackMatchPolicy;
+    private final AiRecommendationMetrics recommendationMetrics;
 
     public int calculate(TravelerPreference pref, GuideAiProfile guide) {
         int score = 0;
@@ -29,7 +32,11 @@ public class ScoreCalculator {
         score += budgetMatchPolicy.score(pref, guide);
         score += activityMatchPolicy.score(pref, guide);
         score += languageMatchPolicy.score(pref, guide);
-        score += feedbackMatchPolicy.score(pref, guide);
+        int feedback = feedbackMatchPolicy.score(pref, guide);
+        score += feedback;
+        if (feedback < 0) {
+            recommendationMetrics.recordFeedbackPenalty(-feedback, AiRecommendationTuning.POLICY_VERSION);
+        }
         return score;
     }
 }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationMetrics.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationMetrics.java
@@ -17,12 +17,15 @@ import java.util.concurrent.TimeUnit;
  *   <li>{@code .sparse_pool_notice} — 희소 풀 안내 부착</li>
  *   <li>{@code .fallback(stage=...)} — 조건 완화 재시도</li>
  *   <li>{@code .outcome(type=no_region|empty|success)} — 최종 건수 결과</li>
+ *   <li>{@code .feedback_penalty_hits(policy_version=...)} — 후보 1명 스코어링 시
+ *       {@link com.team6.module.ai.policy.FeedbackMatchPolicy} 감점이 적용된 횟수(0보다 작은 기여)</li>
  * </ul>
  * <b>Timer / Summary</b> (태그 {@code policy_version} 권장)
  * <ul>
  *   <li>{@code .latency} — end-to-end 지연</li>
  *   <li>{@code .top1_score} — Top1 룰 점수</li>
  *   <li>{@code .effective_pool_size} — 확장 후 후보 풀 크기</li>
+ *   <li>{@code .feedback_penalty_magnitude} — 후보별 피드백 감점 절댓값(룰 점수에서 깎인 양, 단위: 점)</li>
  * </ul>
  */
 @Component
@@ -89,5 +92,21 @@ public class AiRecommendationMetrics {
         String pv = policyVersion == null ? "unknown" : policyVersion;
         registry.summary(PREFIX + ".effective_pool_size", Tags.of("policy_version", pv))
                 .record(Math.max(0, poolSize));
+    }
+
+    /**
+     * {@link com.team6.module.ai.engine.ScoreCalculator}에서 후보별로 기록.
+     * 피드백(환불·저평점) 룰이 총점에 음수 기여를 한 경우에만 호출한다.
+     *
+     * @param penaltyMagnitude 양수(예: 피드백 정책 점수가 -16이면 16)
+     */
+    public void recordFeedbackPenalty(int penaltyMagnitude, String policyVersion) {
+        if (penaltyMagnitude <= 0) {
+            return;
+        }
+        String pv = policyVersion == null ? "unknown" : policyVersion;
+        Tags tags = Tags.of("policy_version", pv);
+        registry.counter(PREFIX + ".feedback_penalty_hits", tags).increment();
+        registry.summary(PREFIX + ".feedback_penalty_magnitude", tags).record(penaltyMagnitude);
     }
 }

--- a/backend/module-ai/src/test/java/com/team6/module/ai/engine/ScoreCalculatorFeedbackMetricsTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/engine/ScoreCalculatorFeedbackMetricsTest.java
@@ -1,0 +1,72 @@
+package com.team6.module.ai.engine;
+
+import com.team6.module.ai.model.GuideAiProfile;
+import com.team6.module.ai.model.TravelerPreference;
+import com.team6.module.ai.policy.ActivityMatchPolicy;
+import com.team6.module.ai.policy.BudgetMatchPolicy;
+import com.team6.module.ai.policy.FeedbackMatchPolicy;
+import com.team6.module.ai.policy.LanguageMatchPolicy;
+import com.team6.module.ai.policy.RegionMatchPolicy;
+import com.team6.module.ai.policy.StyleMatchPolicy;
+import com.team6.module.ai.support.AiRecommendationMetrics;
+import com.team6.module.ai.support.AiRecommendationTuning;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ScoreCalculatorFeedbackMetricsTest {
+
+    @Test
+    void calculate_records_feedback_penalty_metrics() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        AiRecommendationMetrics metrics = new AiRecommendationMetrics(registry);
+        ScoreCalculator calculator = new ScoreCalculator(
+                new RegionMatchPolicy(),
+                new StyleMatchPolicy(),
+                new BudgetMatchPolicy(),
+                new ActivityMatchPolicy(),
+                new LanguageMatchPolicy(),
+                new FeedbackMatchPolicy(),
+                metrics
+        );
+
+        TravelerPreference pref = TravelerPreference.builder()
+                .region("제주")
+                .activityTags(List.of())
+                .build();
+        GuideAiProfile penalized = GuideAiProfile.builder()
+                .guideId(1L)
+                .guideName("x")
+                .region("제주")
+                .languages(List.of())
+                .specialtyTags(List.of())
+                .approvedRefundCount(2)
+                .build();
+        calculator.calculate(pref, penalized);
+
+        String pv = AiRecommendationTuning.POLICY_VERSION;
+        assertThat(registry.counter("localguest.ai.recommend.feedback_penalty_hits", "policy_version", pv).count())
+                .isEqualTo(1);
+        assertThat(registry.summary("localguest.ai.recommend.feedback_penalty_magnitude", "policy_version", pv).count())
+                .isEqualTo(1);
+
+        GuideAiProfile clean = GuideAiProfile.builder()
+                .guideId(2L)
+                .guideName("y")
+                .region("제주")
+                .languages(List.of())
+                .specialtyTags(List.of())
+                .averageRating(new BigDecimal("5.0"))
+                .reviewCount(10)
+                .approvedRefundCount(0)
+                .build();
+        calculator.calculate(pref, clean);
+
+        assertThat(registry.counter("localguest.ai.recommend.feedback_penalty_hits", "policy_version", pv).count())
+                .isEqualTo(1);
+    }
+}

--- a/backend/module-ai/src/test/java/com/team6/module/ai/regression/AiRecommendationRegressionTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/regression/AiRecommendationRegressionTest.java
@@ -15,6 +15,8 @@ import com.team6.module.ai.policy.RegionMatchPolicy;
 import com.team6.module.ai.policy.StyleMatchPolicy;
 import com.team6.module.ai.service.AiRecommendationService;
 import com.team6.module.ai.service.AiRecommendationServiceImpl;
+import com.team6.module.ai.support.AiRecommendationMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -199,7 +201,8 @@ class AiRecommendationRegressionTest {
                 new BudgetMatchPolicy(),
                 new ActivityMatchPolicy(),
                 new LanguageMatchPolicy(),
-                new FeedbackMatchPolicy()
+                new FeedbackMatchPolicy(),
+                new AiRecommendationMetrics(new SimpleMeterRegistry())
         );
 
         return new AiRecommendationServiceImpl(new MatchingEngine(scoreCalculator, new ReasonGenerator()));

--- a/backend/module-ai/src/test/java/com/team6/module/ai/service/AiRecommendationServiceTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/service/AiRecommendationServiceTest.java
@@ -11,7 +11,9 @@ import com.team6.module.ai.policy.FeedbackMatchPolicy;
 import com.team6.module.ai.policy.LanguageMatchPolicy;
 import com.team6.module.ai.policy.RegionMatchPolicy;
 import com.team6.module.ai.policy.StyleMatchPolicy;
+import com.team6.module.ai.support.AiRecommendationMetrics;
 import com.team6.module.ai.support.AiRecommendationTuning;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -27,7 +29,8 @@ class AiRecommendationServiceTest {
                 new BudgetMatchPolicy(),
                 new ActivityMatchPolicy(),
                 new LanguageMatchPolicy(),
-                new FeedbackMatchPolicy()
+                new FeedbackMatchPolicy(),
+                new AiRecommendationMetrics(new SimpleMeterRegistry())
         );
 
         return new AiRecommendationServiceImpl(

--- a/backend/module-ai/src/test/java/com/team6/module/ai/service/PromptRecommendationServiceTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/service/PromptRecommendationServiceTest.java
@@ -9,13 +9,13 @@ import com.team6.module.ai.config.LocalGuestAiProperties;
 import com.team6.module.ai.parser.PromptParser;
 import com.team6.module.ai.policy.ActivityMatchPolicy;
 import com.team6.module.ai.support.AdjacentRegionProvider;
-import com.team6.module.ai.support.AiRecommendationMetrics;
 import com.team6.module.ai.support.RecommendationNoticeCodes;
 import com.team6.module.ai.policy.BudgetMatchPolicy;
 import com.team6.module.ai.policy.FeedbackMatchPolicy;
 import com.team6.module.ai.policy.LanguageMatchPolicy;
 import com.team6.module.ai.policy.RegionMatchPolicy;
 import com.team6.module.ai.policy.StyleMatchPolicy;
+import com.team6.module.ai.support.AiRecommendationMetrics;
 import com.team6.module.ai.support.AiRecommendationTuning;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
@@ -27,13 +27,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 class PromptRecommendationServiceTest {
 
     private PromptRecommendationService createService() {
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
         ScoreCalculator scoreCalculator = new ScoreCalculator(
                 new RegionMatchPolicy(),
                 new StyleMatchPolicy(),
                 new BudgetMatchPolicy(),
                 new ActivityMatchPolicy(),
                 new LanguageMatchPolicy(),
-                new FeedbackMatchPolicy()
+                new FeedbackMatchPolicy(),
+                new AiRecommendationMetrics(meterRegistry)
         );
         AiRecommendationService aiRecommendationService =
                 new AiRecommendationServiceImpl(new MatchingEngine(scoreCalculator, new ReasonGenerator()));
@@ -42,7 +44,7 @@ class PromptRecommendationServiceTest {
                 new PromptParser(new LocalGuestAiProperties()),
                 aiRecommendationService,
                 new AdjacentRegionProvider(new LocalGuestAiProperties()),
-                new AiRecommendationMetrics(new SimpleMeterRegistry())
+                new AiRecommendationMetrics(meterRegistry)
         );
     }
 

--- a/backend/module-ai/src/test/java/com/team6/module/ai/support/AiRecommendationMetricsTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/support/AiRecommendationMetricsTest.java
@@ -45,4 +45,21 @@ class AiRecommendationMetricsTest {
         assertThat(registry.summary("localguest.ai.recommend.effective_pool_size", "policy_version", "test-policy").count())
                 .isEqualTo(1);
     }
+
+    @Test
+    void feedback_penalty_should_increment_hit_and_magnitude() {
+        metrics.recordFeedbackPenalty(16, "test-policy");
+
+        assertThat(registry.counter("localguest.ai.recommend.feedback_penalty_hits", "policy_version", "test-policy")
+                .count()).isEqualTo(1);
+        assertThat(registry.summary("localguest.ai.recommend.feedback_penalty_magnitude", "policy_version", "test-policy")
+                .count()).isEqualTo(1);
+    }
+
+    @Test
+    void feedback_penalty_zero_should_noop() {
+        metrics.recordFeedbackPenalty(0, "test-policy");
+        assertThat(registry.counter("localguest.ai.recommend.feedback_penalty_hits", "policy_version", "test-policy")
+                .count()).isZero();
+    }
 }


### PR DESCRIPTION
## 변경 범위
- `ScoreCalculator`: `FeedbackMatchPolicy` 점수가 음수(감점)일 때 `AiRecommendationMetrics.recordFeedbackPenalty` 호출
- `AiRecommendationMetrics`: `localguest.ai.recommend.feedback_penalty_hits`(counter), `feedback_penalty_magnitude`(summary), 태그 `policy_version`
- Javadoc에 지표 계약 보강
- 관련 단위·회귀 테스트 및 `ScoreCalculatorFeedbackMetricsTest` 추가

## 스키마 영향
없음 (관측만)

## 검증
```bash
cd backend && ./gradlew :module-ai:test :api-server:compileJava
```

Closes #122

Made with [Cursor](https://cursor.com)