### PR TITLE
Feat/be AI 추천: 프롬프트 파싱 보강(영문 지역·region-aliases·구어)

### DIFF
--- a/backend/module-ai/src/main/java/com/team6/module/ai/config/LocalGuestAiProperties.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/config/LocalGuestAiProperties.java
@@ -44,5 +44,10 @@ public class LocalGuestAiProperties {
         private List<String> softPenaltyShoppingActivityContext = new ArrayList<>();
         /** 제외 의도(빼고·싫어 등). 비어 있으면 내장. */
         private List<String> exclusionIntentKeywords = new ArrayList<>();
+        /**
+         * 프롬프트에 부분 문자열로 등장하는 표기 → canonical 지역명(한글).
+         * 키는 소문자로 정규화되어 매칭된다. 내장 영문·로마자 맵 이후에 병합되며 동일 키는 YAML이 덮어쓴다.
+         */
+        private Map<String, String> regionAliases = new LinkedHashMap<>();
     }
 }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/controller/AiController.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/controller/AiController.java
@@ -44,7 +44,7 @@ public class AiController {
             headers = @Header(
                     name = RecommendationHttpHeaders.X_RECOMMENDATION_POLICY,
                     description = "룰 정책 버전(응답 body의 policyVersion과 동일). 캐시 키·디버깅에 활용 가능.",
-                    schema = @Schema(implementation = String.class, example = "2026.04.6")
+                    schema = @Schema(implementation = String.class, example = "2026.04.7")
             ),
             content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = GuideRecommendResponse.class))
     )

--- a/backend/module-ai/src/main/java/com/team6/module/ai/dto/response/GuideRecommendResponse.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/dto/response/GuideRecommendResponse.java
@@ -24,7 +24,7 @@ public class GuideRecommendResponse {
     /**
      * 룰 기반 추천 정책 버전({@link com.team6.module.ai.support.AiRecommendationTuning#POLICY_VERSION}).
      */
-    @Schema(description = "룰 기반 추천 정책 버전(동일 프롬프트라도 정책 변경 구분용)", example = "2026.04.6")
+    @Schema(description = "룰 기반 추천 정책 버전(동일 프롬프트라도 정책 변경 구분용)", example = "2026.04.7")
     private String policyVersion;
     @Schema(description = "추천 항목 개수")
     private int totalCount;

--- a/backend/module-ai/src/main/java/com/team6/module/ai/parser/KeywordNormalizer.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/parser/KeywordNormalizer.java
@@ -46,6 +46,7 @@ public final class KeywordNormalizer {
             Map.entry("브런치", "카페"),
             Map.entry("카페투어", "카페"),
             Map.entry("포토", "사진"),
+            Map.entry("포토스팟", "사진"),
             Map.entry("인생샷", "사진"),
             Map.entry("전시", "전시"),
             Map.entry("미술관", "전시"),

--- a/backend/module-ai/src/main/java/com/team6/module/ai/parser/PromptParser.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/parser/PromptParser.java
@@ -6,9 +6,12 @@ import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -34,9 +37,12 @@ public class PromptParser {
     };
 
     private final LocalGuestAiProperties aiProperties;
+    /** 길이 내림차순: {@code jeju island}가 {@code jeju}보다 먼저 매칭되도록 */
+    private final List<Map.Entry<String, String>> regionAliasEntries;
 
     public PromptParser(LocalGuestAiProperties aiProperties) {
         this.aiProperties = aiProperties;
+        this.regionAliasEntries = buildRegionAliasEntries(aiProperties);
     }
 
     private static final Pattern BUDGET_WON = Pattern.compile("(\\d{1,3}(?:,\\d{3})+|\\d+)\\s*(원|만원)");
@@ -144,11 +150,101 @@ public class PromptParser {
         if (containsAny(prompt, "구례")) return "구례";
         if (containsAny(prompt, "보성")) return "보성";
         if (containsAny(prompt, "익산")) return "익산";
+        return resolveRegionFromAliases(prompt);
+    }
+
+    /**
+     * 한글 고정 목록에 없을 때 영문·로마자·팀 YAML({@code region-aliases})로 지역을 짐작한다.
+     */
+    private String resolveRegionFromAliases(String prompt) {
+        for (Map.Entry<String, String> e : regionAliasEntries) {
+            if (prompt.contains(e.getKey())) {
+                return e.getValue();
+            }
+        }
         return null;
     }
 
+    private static List<Map.Entry<String, String>> buildRegionAliasEntries(LocalGuestAiProperties props) {
+        LinkedHashMap<String, String> merged = new LinkedHashMap<>(defaultEnglishRegionAliases());
+        Map<String, String> yaml = props.getParser().getRegionAliases();
+        if (yaml != null) {
+            for (Map.Entry<String, String> e : yaml.entrySet()) {
+                if (e.getKey() == null || e.getValue() == null) {
+                    continue;
+                }
+                String k = e.getKey().trim().toLowerCase(Locale.ROOT);
+                String v = e.getValue().trim();
+                if (!k.isEmpty() && !v.isEmpty()) {
+                    merged.put(k, v);
+                }
+            }
+        }
+        return merged.entrySet().stream()
+                .sorted(Comparator.comparingInt((Map.Entry<String, String> en) -> en.getKey().length()).reversed())
+                .toList();
+    }
+
+    /**
+     * 여행광고·검색에 흔한 영문 표기. 키는 소문자.
+     */
+    private static LinkedHashMap<String, String> defaultEnglishRegionAliases() {
+        LinkedHashMap<String, String> m = new LinkedHashMap<>();
+        String[][] pairs = {
+                {"jeju island", "제주"}, {"jeju-do", "제주"}, {"jejudo", "제주"}, {"jeju", "제주"},
+                {"busan", "부산"}, {"pusan", "부산"},
+                {"seoul", "서울"},
+                {"gangneung", "강릉"}, {"kangnung", "강릉"},
+                {"gyeongju", "경주"}, {"kyongju", "경주"},
+                {"daegu", "대구"}, {"taegu", "대구"},
+                {"jeonju", "전주"},
+                {"yeosu", "여수"},
+                {"suncheon", "순천"},
+                {"gunsan", "군산"},
+                {"chuncheon", "춘천"},
+                {"tongyeong", "통영"},
+                {"geojedo", "거제"}, {"geoje", "거제"},
+                {"mokpo", "목포"},
+                {"taean", "태안"},
+                {"incheon", "인천"},
+                {"suwon", "수원"},
+                {"sokcho", "속초"},
+                {"donghae", "동해"},
+                {"samcheok", "삼척"},
+                {"yangyang", "양양"},
+                {"pyeongchang", "평창"},
+                {"hongcheon", "홍천"},
+                {"taebaek", "태백"},
+                {"ulsan", "울산"},
+                {"changwon", "창원"},
+                {"pohang", "포항"},
+                {"andong", "안동"},
+                {"gwangju", "광주"},
+                {"daejeon", "대전"},
+                {"namhae", "남해"},
+                {"miryang", "밀양"},
+                {"gimhae", "김해"},
+                {"gapyeong", "가평"},
+                {"yangpyeong", "양평"},
+                {"paju", "파주"},
+                {"yeoju", "여주"},
+                {"jecheon", "제천"},
+                {"danyang", "단양"},
+                {"jeongseon", "정선"},
+                {"inje", "인제"},
+                {"hadong", "하동"},
+                {"gurye", "구례"},
+                {"boseong", "보성"},
+                {"iksan", "익산"}
+        };
+        for (String[] p : pairs) {
+            m.put(p[0].toLowerCase(Locale.ROOT), p[1]);
+        }
+        return m;
+    }
+
     private String extractTravelStyle(String prompt) {
-        if (containsAny(prompt, "감성", "감성적인", "감성샷")) return "감성";
+        if (containsAny(prompt, "감성", "감성적인", "감성샷", "핫플", "인스타", "인스타그램")) return "감성";
         if (containsAny(prompt, "액티비티", "활동적인", "신나게", "역동적인", "익스트림", "스릴", "짜릿")) {
             return "액티비티";
         }
@@ -219,7 +315,7 @@ public class PromptParser {
     }
 
     private String extractCompanionType(String prompt) {
-        if (containsAny(prompt, "혼자", "혼행", "1인")) return "혼자";
+        if (containsAny(prompt, "혼자", "혼행", "1인", "솔로")) return "혼자";
         if (containsAny(prompt, "친구", "친구랑", "우정", "동창")) return "친구";
         if (containsAny(prompt, "가족", "부모님", "엄마", "아빠", "아이", "애기")) return "가족";
         if (containsAny(prompt, "반려견", "강아지", "댕댕이", "반려동물")) return "반려견";
@@ -238,7 +334,7 @@ public class PromptParser {
         if (containsAny(prompt, "등산", "트레킹")) tags.add("등산");
         if (containsAny(prompt, "사진", "포토", "인생샷")) tags.add("사진");
         if (containsAny(prompt, "쇼핑")) tags.add("쇼핑");
-        if (containsAny(prompt, "바다", "해변", "오션뷰", "해수욕장")) tags.add("바다");
+        if (containsAny(prompt, "바다", "해변", "오션뷰", "해수욕장", "스노클링", "다이빙", "스쿠버")) tags.add("바다");
         if (containsAny(prompt, "일몰", "노을", "야경명소")) tags.add("일몰");
         if (containsAny(prompt, "박물관", "미술관", "전시")) tags.add("전시");
         if (containsAny(prompt, "시장", "전통시장", "로컬시장", "야시장")) tags.add("시장");

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationTuning.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationTuning.java
@@ -14,7 +14,7 @@ public final class AiRecommendationTuning {
     /**
      * 룰/스코어/Reason/응답 계약이 바뀔 때마다 올린다. 로그·API에서 동일 프롬프트 비교 시 정책 변경 여부를 구분하는 데 쓴다.
      */
-    public static final String POLICY_VERSION = "2026.04.6";
+    public static final String POLICY_VERSION = "2026.04.7";
 
     public static final int DEFAULT_TOP_N = 3;
 

--- a/backend/module-ai/src/test/java/com/team6/module/ai/parser/PromptParserTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/parser/PromptParserTest.java
@@ -135,4 +135,31 @@ class PromptParserTest {
         );
         assertThat(request.getSoftPenaltyActivityTags()).contains("쇼핑");
     }
+
+    @Test
+    void parse_should_resolve_region_from_english_and_romanization() {
+        assertThat(promptParser.parse("Jeju cafe tour 감성", 3, List.of()).getRegion()).isEqualTo("제주");
+        assertThat(promptParser.parse("Busan night food 맛집", 3, List.of()).getRegion()).isEqualTo("부산");
+        assertThat(promptParser.parse("Seoul shopping day", 3, List.of()).getRegion()).isEqualTo("서울");
+        assertThat(promptParser.parse("Gangneung beach walk", 3, List.of()).getRegion()).isEqualTo("강릉");
+    }
+
+    @Test
+    void parse_should_apply_yaml_region_aliases_over_defaults() {
+        LocalGuestAiProperties props = new LocalGuestAiProperties();
+        props.getParser().getRegionAliases().put("jeju", "부산");
+        PromptParser custom = new PromptParser(props);
+        assertThat(custom.parse("Jeju 카페", 3, List.of()).getRegion()).isEqualTo("부산");
+    }
+
+    @Test
+    void parse_should_extract_solo_companion_and_insta_style_and_marine_activity() {
+        GuideRecommendRequest r = promptParser.parse("부산 솔로 여행 인스타 핫플 카페", 3, List.of());
+        assertThat(r.getCompanionType()).isEqualTo("혼자");
+        assertThat(r.getTravelStyle()).isEqualTo("감성");
+
+        GuideRecommendRequest r2 = promptParser.parse("제주 스노클링 다이빙 하고 싶어", 3, List.of());
+        assertThat(r2.getRegion()).isEqualTo("제주");
+        assertThat(r2.getActivityTags()).contains("바다");
+    }
 }

--- a/backend/module-ai/src/test/java/com/team6/module/ai/regression/AiRecommendationRegressionTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/regression/AiRecommendationRegressionTest.java
@@ -80,6 +80,7 @@ class AiRecommendationRegressionTest {
                 scenario("부산 감성 카페 여행하고 싶어요", 3, 1L, "카페", null),
                 scenario("부산 야경 맛집 위주로 추천", 3, 1L, "야경", null),
                 scenario("제주 감성 오션뷰(바다) 필수!", 3, 2L, "바다", null),
+                scenario("Jeju trip 오션뷰 바다 감성으로 추천", 3, 2L, "바다", null),
                 scenario("제주 식도락(맛집) + 카페", 3, 2L, "맛집", null),
                 scenario("서울 액티비티 등산 트레킹 하고 싶어요", 3, 3L, "등산", null),
                 scenario("서울 쇼핑 + 맛집 코스", 3, 3L, "쇼핑", null),


### PR DESCRIPTION
## 변경 범위
- `PromptParser`: 한글 고정 매칭 후 영문·로마자 지역 표기(`Jeju`, `Busan`, `Gangneung` 등)로 canonical 지역명 추론
- `localguest.ai.parser.region-aliases`: 팀 보강용 YAML 맵(키 소문자 정규화, 긴 키 우선 매칭, 내장 맵 동일 키는 덮어쓰기)
- 구어: 동반 `솔로`→혼자, 스타일 `핫플`/`인스타`→감성, 활동 `스노클링`/`다이빙`/`스쿠버`→바다
- `KeywordNormalizer`: `포토스팟`→사진
- 파서 계약 반영: `AiRecommendationTuning.POLICY_VERSION` `2026.04.7`, OpenAPI 예시 정합

## 스키마 영향
없음

## 검증
```bash
cd backend && ./gradlew :module-ai:test :api-server:compileJava
```

Closes #124

Made with [Cursor](https://cursor.com)