### PR TITLE
Feat/be AI 추천: 인접 지역 부분 점수·Reason·matched 증거

### DIFF
--- a/backend/module-ai/src/main/java/com/team6/module/ai/controller/AiController.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/controller/AiController.java
@@ -44,7 +44,7 @@ public class AiController {
             headers = @Header(
                     name = RecommendationHttpHeaders.X_RECOMMENDATION_POLICY,
                     description = "룰 정책 버전(응답 body의 policyVersion과 동일). 캐시 키·디버깅에 활용 가능.",
-                    schema = @Schema(implementation = String.class, example = "2026.04.7")
+                    schema = @Schema(implementation = String.class, example = "2026.04.8")
             ),
             content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = GuideRecommendResponse.class))
     )

--- a/backend/module-ai/src/main/java/com/team6/module/ai/dto/response/GuideRecommendItem.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/dto/response/GuideRecommendItem.java
@@ -45,6 +45,8 @@ public class GuideRecommendItem {
     @Builder
     public static class MatchedEvidence {
         private boolean region;
+        @Schema(description = "희망 지역과 정확히 같지는 않지만 인접 지역으로 매칭된 경우")
+        private boolean regionAdjacent;
         private boolean style;
         @Schema(description = "예산 티어(낮음/중간/높음) 완전 일치")
         private boolean budget;

--- a/backend/module-ai/src/main/java/com/team6/module/ai/dto/response/GuideRecommendResponse.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/dto/response/GuideRecommendResponse.java
@@ -24,7 +24,7 @@ public class GuideRecommendResponse {
     /**
      * 룰 기반 추천 정책 버전({@link com.team6.module.ai.support.AiRecommendationTuning#POLICY_VERSION}).
      */
-    @Schema(description = "룰 기반 추천 정책 버전(동일 프롬프트라도 정책 변경 구분용)", example = "2026.04.7")
+    @Schema(description = "룰 기반 추천 정책 버전(동일 프롬프트라도 정책 변경 구분용)", example = "2026.04.8")
     private String policyVersion;
     @Schema(description = "추천 항목 개수")
     private int totalCount;

--- a/backend/module-ai/src/main/java/com/team6/module/ai/engine/MatchingEngine.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/engine/MatchingEngine.java
@@ -5,6 +5,7 @@ import com.team6.module.ai.dto.response.GuideRecommendResponse;
 import com.team6.module.ai.model.GuideAiProfile;
 import com.team6.module.ai.model.TravelerPreference;
 import com.team6.module.ai.parser.KeywordNormalizer;
+import com.team6.module.ai.support.AdjacentRegionProvider;
 import com.team6.module.ai.support.AiRecommendationTuning;
 import com.team6.module.ai.support.BudgetTier;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +25,7 @@ public class MatchingEngine {
 
     private final ScoreCalculator scoreCalculator;
     private final ReasonGenerator reasonGenerator;
+    private final AdjacentRegionProvider adjacentRegionProvider;
 
 
     public GuideRecommendResponse recommend(
@@ -214,6 +216,7 @@ public class MatchingEngine {
 
     private GuideRecommendItem.MatchedEvidence buildMatchedEvidence(TravelerPreference pref, GuideAiProfile guide) {
         boolean region = safeEquals(pref.getRegion(), guide.getRegion());
+        boolean regionAdjacent = !region && adjacentRegionProvider.isAdjacentTo(pref.getRegion(), guide.getRegion());
         boolean style = safeEquals(pref.getTravelStyle(), guide.getGuideStyle());
         boolean budgetExact = safeEquals(pref.getBudgetLevel(), guide.getPriceLevel());
         boolean budgetAdjacent = !budgetExact
@@ -225,6 +228,7 @@ public class MatchingEngine {
 
         return GuideRecommendItem.MatchedEvidence.builder()
                 .region(region)
+                .regionAdjacent(regionAdjacent)
                 .style(style)
                 .budget(budgetExact)
                 .budgetAdjacent(budgetAdjacent)

--- a/backend/module-ai/src/main/java/com/team6/module/ai/engine/ReasonGenerator.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/engine/ReasonGenerator.java
@@ -3,8 +3,10 @@ package com.team6.module.ai.engine;
 import com.team6.module.ai.model.GuideAiProfile;
 import com.team6.module.ai.model.TravelerPreference;
 import com.team6.module.ai.parser.KeywordNormalizer;
+import com.team6.module.ai.support.AdjacentRegionProvider;
 import com.team6.module.ai.support.AiRecommendationTuning;
 import com.team6.module.ai.support.BudgetTier;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -14,9 +16,13 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 @Component
+@RequiredArgsConstructor
 public class ReasonGenerator {
 
+    private final AdjacentRegionProvider adjacentRegionProvider;
+
     public static final String CODE_REGION_MATCH = "REGION_MATCH";
+    public static final String CODE_REGION_ADJACENT = "REGION_ADJACENT";
     public static final String CODE_STYLE_MATCH = "STYLE_MATCH";
     public static final String CODE_LANGUAGE_MATCH = "LANGUAGE_MATCH";
     public static final String CODE_ACTIVITY_MATCH = "ACTIVITY_MATCH";
@@ -78,6 +84,12 @@ public class ReasonGenerator {
             segments.add(new Segment(
                     CODE_REGION_MATCH,
                     "희망 지역과 가이드 활동 지역이 같음",
+                    listNonNull(guide.getRegion())
+            ));
+        } else if (adjacentRegionProvider.isAdjacentTo(pref.getRegion(), guide.getRegion())) {
+            segments.add(new Segment(
+                    CODE_REGION_ADJACENT,
+                    "희망 지역과 인접한 활동 지역(이동 가능권)",
                     listNonNull(guide.getRegion())
             ));
         }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/policy/RegionMatchPolicy.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/policy/RegionMatchPolicy.java
@@ -2,15 +2,25 @@ package com.team6.module.ai.policy;
 
 import com.team6.module.ai.model.GuideAiProfile;
 import com.team6.module.ai.model.TravelerPreference;
+import com.team6.module.ai.support.AdjacentRegionProvider;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class RegionMatchPolicy {
+
+    private final AdjacentRegionProvider adjacentRegionProvider;
 
     public int score(TravelerPreference pref, GuideAiProfile guide) {
         if (pref.getRegion() == null || guide.getRegion() == null) {
             return 0;
         }
-        return pref.getRegion().equalsIgnoreCase(guide.getRegion()) ? ScoreWeight.REGION : 0;
+        if (pref.getRegion().equalsIgnoreCase(guide.getRegion())) {
+            return ScoreWeight.REGION;
+        }
+        return adjacentRegionProvider.isAdjacentTo(pref.getRegion(), guide.getRegion())
+                ? ScoreWeight.REGION_ADJACENT
+                : 0;
     }
 }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/policy/ScoreWeight.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/policy/ScoreWeight.java
@@ -6,6 +6,8 @@ public final class ScoreWeight {
     }
 
     public static final int REGION = 30;
+    /** {@link com.team6.module.ai.policy.RegionMatchPolicy} 인접 지역(이동 가능권) 부분 일치. */
+    public static final int REGION_ADJACENT = 15;
     public static final int STYLE = 25;
     public static final int BUDGET = 15;
     /** {@link com.team6.module.ai.policy.BudgetMatchPolicy} 인접 티어(낮음↔중간↔높음) 부분 일치. */

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/AdjacentRegionProvider.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/AdjacentRegionProvider.java
@@ -34,4 +34,22 @@ public class AdjacentRegionProvider {
         }
         return AdjacentRegionMap.neighbors(r);
     }
+
+    /**
+     * 여행자 희망 지역과 가이드 활동 지역이 다르지만, 내장/YAML 인접 맵상 이웃이면 true.
+     */
+    public boolean isAdjacentTo(String travelerRegion, String guideRegion) {
+        if (travelerRegion == null || guideRegion == null) {
+            return false;
+        }
+        String tr = travelerRegion.trim();
+        String gr = guideRegion.trim();
+        if (tr.isEmpty() || gr.isEmpty()) {
+            return false;
+        }
+        if (tr.equalsIgnoreCase(gr)) {
+            return false;
+        }
+        return neighbors(tr).stream().anyMatch(n -> n.equalsIgnoreCase(gr));
+    }
 }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationTuning.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationTuning.java
@@ -14,7 +14,7 @@ public final class AiRecommendationTuning {
     /**
      * 룰/스코어/Reason/응답 계약이 바뀔 때마다 올린다. 로그·API에서 동일 프롬프트 비교 시 정책 변경 여부를 구분하는 데 쓴다.
      */
-    public static final String POLICY_VERSION = "2026.04.7";
+    public static final String POLICY_VERSION = "2026.04.8";
 
     public static final int DEFAULT_TOP_N = 3;
 

--- a/backend/module-ai/src/test/java/com/team6/module/ai/engine/ScoreCalculatorFeedbackMetricsTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/engine/ScoreCalculatorFeedbackMetricsTest.java
@@ -6,8 +6,10 @@ import com.team6.module.ai.policy.ActivityMatchPolicy;
 import com.team6.module.ai.policy.BudgetMatchPolicy;
 import com.team6.module.ai.policy.FeedbackMatchPolicy;
 import com.team6.module.ai.policy.LanguageMatchPolicy;
+import com.team6.module.ai.config.LocalGuestAiProperties;
 import com.team6.module.ai.policy.RegionMatchPolicy;
 import com.team6.module.ai.policy.StyleMatchPolicy;
+import com.team6.module.ai.support.AdjacentRegionProvider;
 import com.team6.module.ai.support.AiRecommendationMetrics;
 import com.team6.module.ai.support.AiRecommendationTuning;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -24,8 +26,9 @@ class ScoreCalculatorFeedbackMetricsTest {
     void calculate_records_feedback_penalty_metrics() {
         SimpleMeterRegistry registry = new SimpleMeterRegistry();
         AiRecommendationMetrics metrics = new AiRecommendationMetrics(registry);
+        AdjacentRegionProvider adjacent = new AdjacentRegionProvider(new LocalGuestAiProperties());
         ScoreCalculator calculator = new ScoreCalculator(
-                new RegionMatchPolicy(),
+                new RegionMatchPolicy(adjacent),
                 new StyleMatchPolicy(),
                 new BudgetMatchPolicy(),
                 new ActivityMatchPolicy(),

--- a/backend/module-ai/src/test/java/com/team6/module/ai/policy/RegionMatchPolicyTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/policy/RegionMatchPolicyTest.java
@@ -1,0 +1,52 @@
+package com.team6.module.ai.policy;
+
+import com.team6.module.ai.config.LocalGuestAiProperties;
+import com.team6.module.ai.model.GuideAiProfile;
+import com.team6.module.ai.model.TravelerPreference;
+import com.team6.module.ai.support.AdjacentRegionProvider;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RegionMatchPolicyTest {
+
+    @Test
+    void score_exact_region_full_weight() {
+        AdjacentRegionProvider adjacent = new AdjacentRegionProvider(new LocalGuestAiProperties());
+        RegionMatchPolicy policy = new RegionMatchPolicy(adjacent);
+        TravelerPreference pref = TravelerPreference.builder().region("부산").build();
+        GuideAiProfile guide = GuideAiProfile.builder().region("부산").build();
+        assertThat(policy.score(pref, guide)).isEqualTo(ScoreWeight.REGION);
+    }
+
+    @Test
+    void score_adjacent_region_partial_weight() {
+        AdjacentRegionProvider adjacent = new AdjacentRegionProvider(new LocalGuestAiProperties());
+        RegionMatchPolicy policy = new RegionMatchPolicy(adjacent);
+        TravelerPreference pref = TravelerPreference.builder().region("강릉").build();
+        GuideAiProfile guide = GuideAiProfile.builder().region("속초").build();
+        assertThat(policy.score(pref, guide)).isEqualTo(ScoreWeight.REGION_ADJACENT);
+    }
+
+    @Test
+    void score_non_adjacent_zero() {
+        AdjacentRegionProvider adjacent = new AdjacentRegionProvider(new LocalGuestAiProperties());
+        RegionMatchPolicy policy = new RegionMatchPolicy(adjacent);
+        TravelerPreference pref = TravelerPreference.builder().region("제주").build();
+        GuideAiProfile guide = GuideAiProfile.builder().region("부산").build();
+        assertThat(policy.score(pref, guide)).isZero();
+    }
+
+    @Test
+    void score_yaml_adjacent_overrides_builtin() {
+        LocalGuestAiProperties props = new LocalGuestAiProperties();
+        props.getAdjacentRegions().put("테스트시", List.of("테스트동"));
+        AdjacentRegionProvider adjacent = new AdjacentRegionProvider(props);
+        RegionMatchPolicy policy = new RegionMatchPolicy(adjacent);
+        TravelerPreference pref = TravelerPreference.builder().region("테스트시").build();
+        GuideAiProfile guide = GuideAiProfile.builder().region("테스트동").build();
+        assertThat(policy.score(pref, guide)).isEqualTo(ScoreWeight.REGION_ADJACENT);
+    }
+}

--- a/backend/module-ai/src/test/java/com/team6/module/ai/regression/AiRecommendationRegressionTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/regression/AiRecommendationRegressionTest.java
@@ -1,6 +1,7 @@
 package com.team6.module.ai.regression;
 
 import com.team6.module.ai.config.LocalGuestAiProperties;
+import com.team6.module.ai.support.AdjacentRegionProvider;
 import com.team6.module.ai.dto.request.GuideRecommendRequest;
 import com.team6.module.ai.dto.response.GuideRecommendResponse;
 import com.team6.module.ai.engine.MatchingEngine;
@@ -196,8 +197,10 @@ class AiRecommendationRegressionTest {
     }
 
     private AiRecommendationService createService() {
+        LocalGuestAiProperties aiProps = new LocalGuestAiProperties();
+        AdjacentRegionProvider adjacent = new AdjacentRegionProvider(aiProps);
         ScoreCalculator scoreCalculator = new ScoreCalculator(
-                new RegionMatchPolicy(),
+                new RegionMatchPolicy(adjacent),
                 new StyleMatchPolicy(),
                 new BudgetMatchPolicy(),
                 new ActivityMatchPolicy(),
@@ -205,8 +208,9 @@ class AiRecommendationRegressionTest {
                 new FeedbackMatchPolicy(),
                 new AiRecommendationMetrics(new SimpleMeterRegistry())
         );
+        ReasonGenerator reasonGenerator = new ReasonGenerator(adjacent);
 
-        return new AiRecommendationServiceImpl(new MatchingEngine(scoreCalculator, new ReasonGenerator()));
+        return new AiRecommendationServiceImpl(new MatchingEngine(scoreCalculator, reasonGenerator, adjacent));
     }
 
     private record Scenario(

--- a/backend/module-ai/src/test/java/com/team6/module/ai/service/AiRecommendationServiceTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/service/AiRecommendationServiceTest.java
@@ -9,8 +9,10 @@ import com.team6.module.ai.policy.ActivityMatchPolicy;
 import com.team6.module.ai.policy.BudgetMatchPolicy;
 import com.team6.module.ai.policy.FeedbackMatchPolicy;
 import com.team6.module.ai.policy.LanguageMatchPolicy;
+import com.team6.module.ai.config.LocalGuestAiProperties;
 import com.team6.module.ai.policy.RegionMatchPolicy;
 import com.team6.module.ai.policy.StyleMatchPolicy;
+import com.team6.module.ai.support.AdjacentRegionProvider;
 import com.team6.module.ai.support.AiRecommendationMetrics;
 import com.team6.module.ai.support.AiRecommendationTuning;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -23,8 +25,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 class AiRecommendationServiceTest {
 
     private AiRecommendationService createService() {
+        LocalGuestAiProperties aiProps = new LocalGuestAiProperties();
+        AdjacentRegionProvider adjacent = new AdjacentRegionProvider(aiProps);
         ScoreCalculator scoreCalculator = new ScoreCalculator(
-                new RegionMatchPolicy(),
+                new RegionMatchPolicy(adjacent),
                 new StyleMatchPolicy(),
                 new BudgetMatchPolicy(),
                 new ActivityMatchPolicy(),
@@ -32,9 +36,10 @@ class AiRecommendationServiceTest {
                 new FeedbackMatchPolicy(),
                 new AiRecommendationMetrics(new SimpleMeterRegistry())
         );
+        ReasonGenerator reasonGenerator = new ReasonGenerator(adjacent);
 
         return new AiRecommendationServiceImpl(
-                new MatchingEngine(scoreCalculator, new ReasonGenerator())
+                new MatchingEngine(scoreCalculator, reasonGenerator, adjacent)
         );
     }
 
@@ -82,7 +87,41 @@ class AiRecommendationServiceTest {
         assertThat(response.getRecommendations().get(0).getReasonFacts()).isNotEmpty();
         assertThat(response.getRecommendations().get(0).getMatched()).isNotNull();
         assertThat(response.getRecommendations().get(0).getMatched().isRegion()).isTrue();
+        assertThat(response.getRecommendations().get(0).getMatched().isRegionAdjacent()).isFalse();
         assertThat(response.getPolicyVersion()).isEqualTo(AiRecommendationTuning.POLICY_VERSION);
+    }
+
+    @Test
+    void recommend_adjacent_region_should_add_partial_score_and_matched_flag() {
+        AiRecommendationService aiRecommendationService = createService();
+
+        GuideRecommendRequest request = GuideRecommendRequest.builder()
+                .region("강릉")
+                .travelStyle("힐링")
+                .budgetLevel("낮음")
+                .activityTags(List.of("산책", "바다"))
+                .preferredLanguages(List.of("한국어"))
+                .topN(1)
+                .guideCandidates(List.of(
+                        GuideRecommendRequest.GuideCandidateDto.builder()
+                                .guideId(10L)
+                                .guideName("속초힐링")
+                                .region("속초")
+                                .guideStyle("힐링")
+                                .priceLevel("낮음")
+                                .specialtyTags(List.of("산책", "바다", "카페"))
+                                .languages(List.of("한국어"))
+                                .build()
+                ))
+                .build();
+
+        GuideRecommendResponse response = aiRecommendationService.recommend(request);
+
+        assertThat(response.getRecommendations()).hasSize(1);
+        var top = response.getRecommendations().get(0);
+        assertThat(top.getMatched().isRegion()).isFalse();
+        assertThat(top.getMatched().isRegionAdjacent()).isTrue();
+        assertThat(top.getReasonCodes()).contains(ReasonGenerator.CODE_REGION_ADJACENT);
     }
 
     @Test

--- a/backend/module-ai/src/test/java/com/team6/module/ai/service/PromptRecommendationServiceTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/service/PromptRecommendationServiceTest.java
@@ -28,8 +28,10 @@ class PromptRecommendationServiceTest {
 
     private PromptRecommendationService createService() {
         SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        LocalGuestAiProperties aiProps = new LocalGuestAiProperties();
+        AdjacentRegionProvider adjacent = new AdjacentRegionProvider(aiProps);
         ScoreCalculator scoreCalculator = new ScoreCalculator(
-                new RegionMatchPolicy(),
+                new RegionMatchPolicy(adjacent),
                 new StyleMatchPolicy(),
                 new BudgetMatchPolicy(),
                 new ActivityMatchPolicy(),
@@ -37,13 +39,14 @@ class PromptRecommendationServiceTest {
                 new FeedbackMatchPolicy(),
                 new AiRecommendationMetrics(meterRegistry)
         );
+        ReasonGenerator reasonGenerator = new ReasonGenerator(adjacent);
         AiRecommendationService aiRecommendationService =
-                new AiRecommendationServiceImpl(new MatchingEngine(scoreCalculator, new ReasonGenerator()));
+                new AiRecommendationServiceImpl(new MatchingEngine(scoreCalculator, reasonGenerator, adjacent));
 
         return new PromptRecommendationService(
-                new PromptParser(new LocalGuestAiProperties()),
+                new PromptParser(aiProps),
                 aiRecommendationService,
-                new AdjacentRegionProvider(new LocalGuestAiProperties()),
+                adjacent,
                 new AiRecommendationMetrics(meterRegistry)
         );
     }


### PR DESCRIPTION
## 변경 범위
- `ScoreWeight.REGION_ADJACENT`(15): 정확 일치(30) 미만의 인접 지역 가중
- `AdjacentRegionProvider#isAdjacentTo`: 내장/YAML 인접 맵 기준 이웃 여부
- `RegionMatchPolicy`: 정확 일치 → 인접 → 0
- `ReasonGenerator`: `REGION_ADJACENT` 근거 문구
- `MatchingEngine` / `GuideRecommendItem.MatchedEvidence`: `regionAdjacent` 플래그
- `POLICY_VERSION` `2026.04.8`, OpenAPI 예시 정합

## 스키마 영향
응답 JSON `matched`에 `regionAdjacent` 필드 추가(기본 false). 클라이언트는 선택 반영 가능.

## 검증
```bash
cd backend && ./gradlew :module-ai:test :api-server:compileJava
```

Closes #126

Made with [Cursor](https://cursor.com)