### PR TITLE
Feat/be AI 추천: Reason 문구·근거 코드 정리(톤 통일·예산·피드백)

### DIFF
--- a/backend/module-ai/src/main/java/com/team6/module/ai/controller/AiController.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/controller/AiController.java
@@ -44,7 +44,7 @@ public class AiController {
             headers = @Header(
                     name = RecommendationHttpHeaders.X_RECOMMENDATION_POLICY,
                     description = "룰 정책 버전(응답 body의 policyVersion과 동일). 캐시 키·디버깅에 활용 가능.",
-                    schema = @Schema(implementation = String.class, example = "2026.04.8")
+                    schema = @Schema(implementation = String.class, example = "2026.04.9")
             ),
             content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = GuideRecommendResponse.class))
     )

--- a/backend/module-ai/src/main/java/com/team6/module/ai/dto/response/GuideRecommendItem.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/dto/response/GuideRecommendItem.java
@@ -34,7 +34,7 @@ public class GuideRecommendItem {
     @Getter
     @Builder
     public static class ReasonFact {
-        @Schema(description = "ReasonGenerator 코드(예: REGION_MATCH, SOFT_ACTIVITY_PENALTY)")
+        @Schema(description = "ReasonGenerator 코드(예: REGION_MATCH, BUDGET_ADJACENT, FEEDBACK_VERY_LOW_RATING)")
         private String code;
         @Schema(description = "해당 근거에 대응하는 값 목록")
         private List<String> values;

--- a/backend/module-ai/src/main/java/com/team6/module/ai/dto/response/GuideRecommendResponse.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/dto/response/GuideRecommendResponse.java
@@ -24,7 +24,7 @@ public class GuideRecommendResponse {
     /**
      * 룰 기반 추천 정책 버전({@link com.team6.module.ai.support.AiRecommendationTuning#POLICY_VERSION}).
      */
-    @Schema(description = "룰 기반 추천 정책 버전(동일 프롬프트라도 정책 변경 구분용)", example = "2026.04.8")
+    @Schema(description = "룰 기반 추천 정책 버전(동일 프롬프트라도 정책 변경 구분용)", example = "2026.04.9")
     private String policyVersion;
     @Schema(description = "추천 항목 개수")
     private int totalCount;

--- a/backend/module-ai/src/main/java/com/team6/module/ai/engine/ReasonGenerator.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/engine/ReasonGenerator.java
@@ -28,12 +28,16 @@ public class ReasonGenerator {
     public static final String CODE_ACTIVITY_MATCH = "ACTIVITY_MATCH";
     public static final String CODE_SOFT_ACTIVITY_PENALTY = "SOFT_ACTIVITY_PENALTY";
     public static final String CODE_BUDGET_MATCH = "BUDGET_MATCH";
+    /** 예산 티어가 한 단계 차이(인접)일 때. {@link #CODE_BUDGET_MATCH}는 완전 일치. */
+    public static final String CODE_BUDGET_ADJACENT = "BUDGET_ADJACENT";
     public static final String CODE_GENERAL_FALLBACK = "GENERAL_FALLBACK";
     public static final String CODE_FEEDBACK_REFUND_APPROVED = "FEEDBACK_REFUND_APPROVED";
     public static final String CODE_FEEDBACK_LOW_RATING = "FEEDBACK_LOW_RATING";
+    /** 평균 평점이 매우 낮을 때(정책 임계값은 {@link AiRecommendationTuning}). */
+    public static final String CODE_FEEDBACK_VERY_LOW_RATING = "FEEDBACK_VERY_LOW_RATING";
 
-    /** soft 부담 등이 잘리지 않도록 여유를 둔다. */
-    private static final int MAX_DISPLAY_SEGMENTS = 4;
+    /** 상위 근거 노출 개수(지역·활동·부담·스타일·예산·피드백 등이 겹칠 때 잘리지 않도록 여유). */
+    private static final int MAX_DISPLAY_SEGMENTS = 5;
 
     /**
      * @param score 현재는 reason 문구 생성에 직접 쓰지 않지만, 추후 임계값/요약에 활용 가능하도록 유지
@@ -43,7 +47,7 @@ public class ReasonGenerator {
         if (segments.isEmpty()) {
             segments = List.of(new Segment(
                     CODE_GENERAL_FALLBACK,
-                    "프롬프트 선호와 가이드 프로필을 종합한 매칭",
+                    "선호 조건과 가이드 프로필을 종합해 매칭했습니다",
                     List.of()
             ));
         }
@@ -74,8 +78,8 @@ public class ReasonGenerator {
     }
 
     /**
-     * 우선순위: 지역 → (선호)활동 → soft 부담 → 스타일 → 언어 → 예산.
-     * 상위 {@link #MAX_DISPLAY_SEGMENTS}개만 노출되므로 부담 활동이 앞쪽에 오도록 순서를 맞춘다.
+     * 우선순위: 지역 → (선호)활동 → soft 부담 → 스타일 → 언어 → 예산 → 피드백(환불·평점).
+     * 상위 {@link #MAX_DISPLAY_SEGMENTS}개만 노출된다.
      */
     private List<Segment> buildSegments(TravelerPreference pref, GuideAiProfile guide) {
         List<Segment> segments = new ArrayList<>();
@@ -83,13 +87,13 @@ public class ReasonGenerator {
         if (safeEquals(pref.getRegion(), guide.getRegion())) {
             segments.add(new Segment(
                     CODE_REGION_MATCH,
-                    "희망 지역과 가이드 활동 지역이 같음",
+                    "희망 지역과 가이드 활동 지역이 동일합니다",
                     listNonNull(guide.getRegion())
             ));
         } else if (adjacentRegionProvider.isAdjacentTo(pref.getRegion(), guide.getRegion())) {
             segments.add(new Segment(
                     CODE_REGION_ADJACENT,
-                    "희망 지역과 인접한 활동 지역(이동 가능권)",
+                    "희망 지역과 인접한 지역에서 활동합니다",
                     listNonNull(guide.getRegion())
             ));
         }
@@ -109,7 +113,8 @@ public class ReasonGenerator {
 
             if (!matched.isEmpty()) {
                 String head = matched.stream().limit(3).collect(Collectors.joining("/"));
-                String display = "관심 활동 맞춤(" + head + (matched.size() > 3 ? " 외" : "") + ")";
+                String suffix = matched.size() > 3 ? " 외" : "";
+                String display = "관심 활동 분야가 맞습니다(" + head + suffix + ")";
                 segments.add(new Segment(CODE_ACTIVITY_MATCH, display, matched));
             }
         }
@@ -129,7 +134,8 @@ public class ReasonGenerator {
 
             if (!penalized.isEmpty()) {
                 String head = penalized.stream().limit(3).collect(Collectors.joining("/"));
-                String display = "부담되는 활동 반영(" + head + (penalized.size() > 3 ? " 외" : "") + ")";
+                String suffix = penalized.size() > 3 ? " 외" : "";
+                String display = "부담되시는 활동이 겹쳐 가중치를 조정했습니다(" + head + suffix + ")";
                 segments.add(new Segment(CODE_SOFT_ACTIVITY_PENALTY, display, penalized));
             }
         }
@@ -137,7 +143,7 @@ public class ReasonGenerator {
         if (safeEquals(pref.getTravelStyle(), guide.getGuideStyle())) {
             segments.add(new Segment(
                     CODE_STYLE_MATCH,
-                    "여행 스타일이 비슷함",
+                    "여행 스타일이 잘 맞습니다",
                     listNonNull(guide.getGuideStyle())
             ));
         }
@@ -158,7 +164,7 @@ public class ReasonGenerator {
                 List<String> langValues = new ArrayList<>(matchedLanguages);
                 segments.add(new Segment(
                         CODE_LANGUAGE_MATCH,
-                        "가능 언어(" + String.join("/", langValues) + ")",
+                        "요청하신 언어 안내가 가능합니다(" + String.join("/", langValues) + ")",
                         langValues
                 ));
             }
@@ -167,13 +173,13 @@ public class ReasonGenerator {
         if (safeEquals(pref.getBudgetLevel(), guide.getPriceLevel())) {
             segments.add(new Segment(
                     CODE_BUDGET_MATCH,
-                    "예산 범위가 같은 편",
+                    "예산 수준이 동일한 편입니다",
                     listNonNull(guide.getPriceLevel())
             ));
         } else if (BudgetTier.adjacentTiers(pref.getBudgetLevel(), guide.getPriceLevel())) {
             segments.add(new Segment(
-                    CODE_BUDGET_MATCH,
-                    "예산 범위가 한 단계 차이로 가까움",
+                    CODE_BUDGET_ADJACENT,
+                    "예산 수준이 한 단계 차이로 가깝습니다",
                     listNonNull(guide.getPriceLevel())
             ));
         }
@@ -181,7 +187,7 @@ public class ReasonGenerator {
         if (guide.getApprovedRefundCount() != null && guide.getApprovedRefundCount() > 0) {
             segments.add(new Segment(
                     CODE_FEEDBACK_REFUND_APPROVED,
-                    "승인된 환불 이력이 있어 점수에서 보수적으로 반영",
+                    "승인된 환불 이력이 있어 점수에 반영했습니다",
                     List.of(String.valueOf(guide.getApprovedRefundCount()))
             ));
         }
@@ -191,14 +197,14 @@ public class ReasonGenerator {
             double a = guide.getAverageRating().doubleValue();
             if (a < AiRecommendationTuning.FEEDBACK_VERY_LOW_RATING_THRESHOLD) {
                 segments.add(new Segment(
-                        CODE_FEEDBACK_LOW_RATING,
-                        "리뷰 평균이 매우 낮아 신중히 반영",
+                        CODE_FEEDBACK_VERY_LOW_RATING,
+                        "평균 리뷰가 매우 낮아 신중히 반영했습니다",
                         List.of(guide.getAverageRating().toPlainString(), String.valueOf(guide.getReviewCount()))
                 ));
             } else if (a < AiRecommendationTuning.FEEDBACK_LOW_RATING_THRESHOLD) {
                 segments.add(new Segment(
                         CODE_FEEDBACK_LOW_RATING,
-                        "리뷰 평균이 낮은 편이라 보수적으로 반영",
+                        "평균 리뷰가 낮은 편이라 보수적으로 반영했습니다",
                         List.of(guide.getAverageRating().toPlainString(), String.valueOf(guide.getReviewCount()))
                 ));
             }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationTuning.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationTuning.java
@@ -14,7 +14,7 @@ public final class AiRecommendationTuning {
     /**
      * 룰/스코어/Reason/응답 계약이 바뀔 때마다 올린다. 로그·API에서 동일 프롬프트 비교 시 정책 변경 여부를 구분하는 데 쓴다.
      */
-    public static final String POLICY_VERSION = "2026.04.8";
+    public static final String POLICY_VERSION = "2026.04.9";
 
     public static final int DEFAULT_TOP_N = 3;
 

--- a/backend/module-ai/src/test/java/com/team6/module/ai/engine/ReasonGeneratorTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/engine/ReasonGeneratorTest.java
@@ -1,0 +1,81 @@
+package com.team6.module.ai.engine;
+
+import com.team6.module.ai.config.LocalGuestAiProperties;
+import com.team6.module.ai.model.GuideAiProfile;
+import com.team6.module.ai.model.TravelerPreference;
+import com.team6.module.ai.support.AdjacentRegionProvider;
+import com.team6.module.ai.support.AiRecommendationTuning;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ReasonGeneratorTest {
+
+    private static ReasonGenerator generator() {
+        return new ReasonGenerator(new AdjacentRegionProvider(new LocalGuestAiProperties()));
+    }
+
+    @Test
+    void generate_should_use_budget_adjacent_code() {
+        TravelerPreference pref = TravelerPreference.builder()
+                .region("서울")
+                .budgetLevel("낮음")
+                .build();
+        GuideAiProfile guide = GuideAiProfile.builder()
+                .region("서울")
+                .priceLevel("중간")
+                .build();
+
+        ReasonBundle bundle = generator().generate(pref, guide, 0);
+
+        assertThat(bundle.getReasonCodes()).contains(ReasonGenerator.CODE_BUDGET_ADJACENT);
+        assertThat(bundle.getText()).contains("예산");
+    }
+
+    @Test
+    void generate_should_split_very_low_rating_code() {
+        TravelerPreference pref = TravelerPreference.builder().region("제주").build();
+        GuideAiProfile guide = GuideAiProfile.builder()
+                .region("제주")
+                .averageRating(BigDecimal.valueOf(2.0))
+                .reviewCount(AiRecommendationTuning.FEEDBACK_LOW_RATING_MIN_REVIEWS)
+                .build();
+
+        ReasonBundle bundle = generator().generate(pref, guide, 0);
+
+        assertThat(bundle.getReasonCodes()).contains(ReasonGenerator.CODE_FEEDBACK_VERY_LOW_RATING);
+        assertThat(bundle.getReasonCodes()).doesNotContain(ReasonGenerator.CODE_FEEDBACK_LOW_RATING);
+        assertThat(bundle.getText()).contains("평균 리뷰");
+    }
+
+    @Test
+    void generate_should_include_region_adjacent_copy() {
+        TravelerPreference pref = TravelerPreference.builder().region("강릉").build();
+        GuideAiProfile guide = GuideAiProfile.builder().region("속초").build();
+
+        ReasonBundle bundle = generator().generate(pref, guide, 0);
+
+        assertThat(bundle.getReasonCodes()).contains(ReasonGenerator.CODE_REGION_ADJACENT);
+        assertThat(bundle.getText()).contains("인접");
+    }
+
+    @Test
+    void generate_should_describe_activity_match() {
+        TravelerPreference pref = TravelerPreference.builder()
+                .region("부산")
+                .activityTags(List.of("카페"))
+                .build();
+        GuideAiProfile guide = GuideAiProfile.builder()
+                .region("부산")
+                .specialtyTags(List.of("카페"))
+                .build();
+
+        ReasonBundle bundle = generator().generate(pref, guide, 0);
+
+        assertThat(bundle.getReasonCodes()).contains(ReasonGenerator.CODE_ACTIVITY_MATCH);
+        assertThat(bundle.getText()).contains("관심 활동");
+    }
+}


### PR DESCRIPTION
## 변경 범위
- `ReasonGenerator`: 표시 문구를 **합니다/습니다** 톤으로 통일, 활동·부담·언어·예산·피드백 문구 정리
- **근거 코드**: 예산 인접 `BUDGET_ADJACENT`(완전 일치는 기존 `BUDGET_MATCH`), 매우 낮은 평점 `FEEDBACK_VERY_LOW_RATING`(`FEEDBACK_LOW_RATING`과 분리)
- **노출**: `MAX_DISPLAY_SEGMENTS` 4→5
- `POLICY_VERSION` `2026.04.9`, OpenAPI 예시·ReasonFact 설명 보강
- `ReasonGeneratorTest` 추가

## 스키마/API 영향
- `reasonCodes`에 `BUDGET_ADJACENT`, `FEEDBACK_VERY_LOW_RATING`가 나올 수 있음(기존 `BUDGET_MATCH`만 보던 클라이언트는 분기 보강 권장)
- `reason` 문자열 변경

## 검증
```bash
cd backend && ./gradlew :module-ai:test :api-server:compileJava
```

Closes #128

Made with [Cursor](https://cursor.com)