### PR TITLE
Feat/be AI 추천: Top-N 다양성 재랭킹(희망 지역 권역 유사도)

### DIFF
--- a/backend/module-ai/src/main/java/com/team6/module/ai/controller/AiController.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/controller/AiController.java
@@ -44,7 +44,7 @@ public class AiController {
             headers = @Header(
                     name = RecommendationHttpHeaders.X_RECOMMENDATION_POLICY,
                     description = "룰 정책 버전(응답 body의 policyVersion과 동일). 캐시 키·디버깅에 활용 가능.",
-                    schema = @Schema(implementation = String.class, example = "2026.04.9")
+                    schema = @Schema(implementation = String.class, example = "2026.04.10")
             ),
             content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = GuideRecommendResponse.class))
     )

--- a/backend/module-ai/src/main/java/com/team6/module/ai/dto/response/GuideRecommendResponse.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/dto/response/GuideRecommendResponse.java
@@ -24,7 +24,7 @@ public class GuideRecommendResponse {
     /**
      * 룰 기반 추천 정책 버전({@link com.team6.module.ai.support.AiRecommendationTuning#POLICY_VERSION}).
      */
-    @Schema(description = "룰 기반 추천 정책 버전(동일 프롬프트라도 정책 변경 구분용)", example = "2026.04.9")
+    @Schema(description = "룰 기반 추천 정책 버전(동일 프롬프트라도 정책 변경 구분용)", example = "2026.04.10")
     private String policyVersion;
     @Schema(description = "추천 항목 개수")
     private int totalCount;

--- a/backend/module-ai/src/main/java/com/team6/module/ai/engine/DiversityRerankConstants.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/engine/DiversityRerankConstants.java
@@ -5,6 +5,7 @@ package com.team6.module.ai.engine;
  * <p>
  * 유사도는 대략 0~1로 정규화한 뒤 {@code DIVERSITY_LAMBDA}를 곱해 점수에서 뺀다.
  * 가중치 합({@link #REGION_SIM_WEIGHT}+…+{@link #PRICE_TIER_SIM_WEIGHT})으로 나누어 스케일을 맞춘다.
+ * 지역 차원은 동일 지역(1.0) 또는 희망 지역 권역 내 서로 다른 지역 쌍({@link #REGION_CLUSTER_SIMILARITY_RATIO})으로만 채운다.
  */
 public final class DiversityRerankConstants {
 
@@ -14,6 +15,11 @@ public final class DiversityRerankConstants {
     /** 유사도 패널티 강도. 클수록 Top-N에서 중복 성향 후보를 덜 고른다. */
     public static final double DIVERSITY_LAMBDA = 15.0;
     public static final double REGION_SIM_WEIGHT = 1.0;
+    /**
+     * 두 가이드 활동 지역이 다르지만, 모두 여행자 희망 지역 또는 그 인접 지역 안에 있을 때 지역 유사도(0~1).
+     * {@link MatchingEngine}에서 {@link #REGION_SIM_WEIGHT}에 곱해 합산한다.
+     */
+    public static final double REGION_CLUSTER_SIMILARITY_RATIO = 0.42;
     public static final double STYLE_SIM_WEIGHT = 0.8;
     /** 전문 태그 Jaccard에 곱함. */
     public static final double TAG_SIM_WEIGHT = 0.8;

--- a/backend/module-ai/src/main/java/com/team6/module/ai/engine/MatchingEngine.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/engine/MatchingEngine.java
@@ -42,7 +42,7 @@ public class MatchingEngine {
                 .sorted(Comparator.comparingInt(ScoredGuide::baseScore).reversed())
                 .toList();
 
-        List<ScoredGuide> picked = pickWithDiversityPenalty(scored, topN);
+        List<ScoredGuide> picked = pickWithDiversityPenalty(scored, topN, preference);
         List<GuideRecommendItem> items = picked.stream()
                 .map(sg -> GuideRecommendItem.builder()
                         .guideId(sg.guide.getGuideId())
@@ -62,7 +62,11 @@ public class MatchingEngine {
                 .build();
     }
 
-    private List<ScoredGuide> pickWithDiversityPenalty(List<ScoredGuide> candidates, int topN) {
+    private List<ScoredGuide> pickWithDiversityPenalty(
+            List<ScoredGuide> candidates,
+            int topN,
+            TravelerPreference preference
+    ) {
         if (topN <= 0 || candidates.isEmpty()) {
             return List.of();
         }
@@ -79,7 +83,9 @@ public class MatchingEngine {
                 if (c.guide.getGuideId() == null || used.contains(c.guide.getGuideId())) {
                     continue;
                 }
-                double penalty = selected.isEmpty() ? 0.0 : maxSimilarityToSelected(c.guide, selected) * DiversityRerankConstants.DIVERSITY_LAMBDA;
+                double penalty = selected.isEmpty()
+                        ? 0.0
+                        : maxSimilarityToSelected(c.guide, selected, preference) * DiversityRerankConstants.DIVERSITY_LAMBDA;
                 double finalScore = c.baseScore - penalty;
 
                 if (isBetterCandidate(finalScore, c, bestFinal, best)) {
@@ -127,20 +133,26 @@ public class MatchingEngine {
         return a < b;
     }
 
-    private double maxSimilarityToSelected(GuideAiProfile candidate, List<ScoredGuide> selected) {
+    private double maxSimilarityToSelected(
+            GuideAiProfile candidate,
+            List<ScoredGuide> selected,
+            TravelerPreference preference
+    ) {
         double max = 0.0;
         for (ScoredGuide s : selected) {
-            max = Math.max(max, similarity(candidate, s.guide));
+            max = Math.max(max, similarity(preference, candidate, s.guide));
         }
         return max;
     }
 
-    private double similarity(GuideAiProfile a, GuideAiProfile b) {
+    /**
+     * 0~1에 가깝게 정규화한 프로필 유사도. 여행자 희망 지역이 있으면 인접권 안의 서로 다른 지역도 부분 유사로 본다.
+     */
+    private double similarity(TravelerPreference preference, GuideAiProfile a, GuideAiProfile b) {
         double sim = 0.0;
 
-        if (safeEquals(a.getRegion(), b.getRegion())) {
-            sim += DiversityRerankConstants.REGION_SIM_WEIGHT;
-        }
+        sim += DiversityRerankConstants.REGION_SIM_WEIGHT * regionSimilarityForDiversity(preference, a, b);
+
         if (safeEquals(a.getGuideStyle(), b.getGuideStyle())) {
             sim += DiversityRerankConstants.STYLE_SIM_WEIGHT;
         }
@@ -161,6 +173,31 @@ public class MatchingEngine {
                 + DiversityRerankConstants.LANGUAGE_SIM_WEIGHT
                 + DiversityRerankConstants.PRICE_TIER_SIM_WEIGHT;
         return max == 0.0 ? 0.0 : (sim / max);
+    }
+
+    /**
+     * 가이드 둘의 활동 지역이 같으면 1.0. 다르지만 둘 다 여행자 희망 지역 또는 그 인접 지역이면
+     * {@link DiversityRerankConstants#REGION_CLUSTER_SIMILARITY_RATIO}. 그 외 0.
+     */
+    private double regionSimilarityForDiversity(TravelerPreference preference, GuideAiProfile a, GuideAiProfile b) {
+        String ra = a.getRegion();
+        String rb = b.getRegion();
+        if (ra == null || rb == null) {
+            return 0.0;
+        }
+        if (ra.equalsIgnoreCase(rb)) {
+            return 1.0;
+        }
+        if (preference == null || preference.getRegion() == null || preference.getRegion().isBlank()) {
+            return 0.0;
+        }
+        String tr = preference.getRegion().trim();
+        boolean aInTravelZone = tr.equalsIgnoreCase(ra.trim()) || adjacentRegionProvider.isAdjacentTo(tr, ra);
+        boolean bInTravelZone = tr.equalsIgnoreCase(rb.trim()) || adjacentRegionProvider.isAdjacentTo(tr, rb);
+        if (aInTravelZone && bInTravelZone) {
+            return DiversityRerankConstants.REGION_CLUSTER_SIMILARITY_RATIO;
+        }
+        return 0.0;
     }
 
     private double languageJaccard(List<String> la, List<String> lb) {

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationTuning.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationTuning.java
@@ -14,7 +14,7 @@ public final class AiRecommendationTuning {
     /**
      * 룰/스코어/Reason/응답 계약이 바뀔 때마다 올린다. 로그·API에서 동일 프롬프트 비교 시 정책 변경 여부를 구분하는 데 쓴다.
      */
-    public static final String POLICY_VERSION = "2026.04.9";
+    public static final String POLICY_VERSION = "2026.04.10";
 
     public static final int DEFAULT_TOP_N = 3;
 

--- a/backend/module-ai/src/test/java/com/team6/module/ai/engine/MatchingEngineDiversityTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/engine/MatchingEngineDiversityTest.java
@@ -1,0 +1,90 @@
+package com.team6.module.ai.engine;
+
+import com.team6.module.ai.config.LocalGuestAiProperties;
+import com.team6.module.ai.dto.response.GuideRecommendResponse;
+import com.team6.module.ai.model.GuideAiProfile;
+import com.team6.module.ai.model.TravelerPreference;
+import com.team6.module.ai.policy.ActivityMatchPolicy;
+import com.team6.module.ai.policy.BudgetMatchPolicy;
+import com.team6.module.ai.policy.FeedbackMatchPolicy;
+import com.team6.module.ai.policy.LanguageMatchPolicy;
+import com.team6.module.ai.policy.RegionMatchPolicy;
+import com.team6.module.ai.policy.StyleMatchPolicy;
+import com.team6.module.ai.support.AdjacentRegionProvider;
+import com.team6.module.ai.support.AiRecommendationMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Top-N 다양성(유사도 패널티) 스모크. 희망 지역 권역 유사도는 점수만으로는 구분되지 않으므로
+ * 엔진이 예외 없이 결과를 내는지·첫 후보가 최고 base 점수인지 검증한다.
+ */
+class MatchingEngineDiversityTest {
+
+    private static MatchingEngine engine() {
+        LocalGuestAiProperties aiProps = new LocalGuestAiProperties();
+        AdjacentRegionProvider adjacent = new AdjacentRegionProvider(aiProps);
+        ScoreCalculator scoreCalculator = new ScoreCalculator(
+                new RegionMatchPolicy(adjacent),
+                new StyleMatchPolicy(),
+                new BudgetMatchPolicy(),
+                new ActivityMatchPolicy(),
+                new LanguageMatchPolicy(),
+                new FeedbackMatchPolicy(),
+                new AiRecommendationMetrics(new SimpleMeterRegistry())
+        );
+        return new MatchingEngine(scoreCalculator, new ReasonGenerator(adjacent), adjacent);
+    }
+
+    @Test
+    void recommend_should_pick_highest_base_score_first_when_topN_greater_than_one() {
+        TravelerPreference pref = TravelerPreference.builder()
+                .region("강릉")
+                .travelStyle("힐링")
+                .budgetLevel("낮음")
+                .activityTags(List.of("산책", "바다"))
+                .preferredLanguages(List.of("한국어"))
+                .build();
+
+        List<GuideAiProfile> guides = List.of(
+                GuideAiProfile.builder()
+                        .guideId(1L)
+                        .guideName("속초A")
+                        .region("속초")
+                        .guideStyle("힐링")
+                        .priceLevel("낮음")
+                        .specialtyTags(List.of("산책", "바다", "카페"))
+                        .languages(List.of("한국어"))
+                        .build(),
+                GuideAiProfile.builder()
+                        .guideId(2L)
+                        .guideName("동해B")
+                        .region("동해")
+                        .guideStyle("힐링")
+                        .priceLevel("낮음")
+                        .specialtyTags(List.of("산책", "바다", "카페"))
+                        .languages(List.of("한국어"))
+                        .build(),
+                GuideAiProfile.builder()
+                        .guideId(3L)
+                        .guideName("강릉C")
+                        .region("강릉")
+                        .guideStyle("힐링")
+                        .priceLevel("낮음")
+                        .specialtyTags(List.of("산책", "바다", "맛집"))
+                        .languages(List.of("한국어"))
+                        .build()
+        );
+
+        GuideRecommendResponse response = engine().recommend(pref, guides, 2);
+
+        assertThat(response.getRecommendations()).hasSize(2);
+        assertThat(response.getRecommendations().get(0).getGuideId()).isEqualTo(3L);
+        assertThat(response.getRecommendations().get(0).getScore())
+                .isGreaterThanOrEqualTo(response.getRecommendations().get(1).getScore());
+    }
+}


### PR DESCRIPTION
## 변경 범위
- `DiversityRerankConstants.REGION_CLUSTER_SIMILARITY_RATIO`: 여행자 희망 지역 또는 그 **인접 지역** 안에 있는 서로 다른 가이드 지역 쌍에 대한 지역 유사도(0~1)
- `MatchingEngine`: `pickWithDiversityPenalty`에 `TravelerPreference` 전달, `regionSimilarityForDiversity`로 기존 동일 지역(1.0) 외 권역 클러스터 반영
- `POLICY_VERSION` `2026.04.10`, OpenAPI 예시 정합
- `MatchingEngineDiversityTest`: 강릉·속초·동해 시나리오 스모크(첫 슬롯 최고 base 점수)

## 스키마 영향
없음(응답 DTO 필드 변경 없음). Top-N **순서**만 정책에 따라 달라질 수 있음.

## 검증
```bash
cd backend && ./gradlew :module-ai:test :api-server:compileJava
```

Closes #130

Made with [Cursor](https://cursor.com)