### PR TITLE
Feat/be AI 추천: 회귀 테스트·POLICY_VERSION 계약 보강

### DIFF
--- a/backend/module-ai/src/test/java/com/team6/module/ai/regression/AiRecommendationRegressionTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/regression/AiRecommendationRegressionTest.java
@@ -17,6 +17,7 @@ import com.team6.module.ai.policy.StyleMatchPolicy;
 import com.team6.module.ai.service.AiRecommendationService;
 import com.team6.module.ai.service.AiRecommendationServiceImpl;
 import com.team6.module.ai.support.AiRecommendationMetrics;
+import com.team6.module.ai.support.AiRecommendationTuning;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
 
@@ -27,8 +28,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * 룰 기반 AI 추천의 회귀(품질 퇴보)를 빠르게 감지하기 위한 테스트.
- * - 프롬프트 파싱 → 추천 엔진까지 end-to-end로 검증
- * - 과도하게 빡센 기대값 대신 "Top1 안정성/근거 필드 유효성" 위주로 체크
+ * <ul>
+ *   <li>프롬프트 파싱 → 추천 엔진까지 end-to-end로 검증</li>
+ *   <li>과도하게 빡센 기대값 대신 Top1 안정성·근거 필드 유효성 위주</li>
+ * </ul>
+ * <p><b>유지보수</b>: 스코어·Reason·응답 계약을 바꾼 PR에서는
+ * {@link com.team6.module.ai.support.AiRecommendationTuning#POLICY_VERSION} 상향 여부를 검토하고,
+ * 이 클래스의 시나리오·별도 엣지 테스트({@code regression_*})를 함께 갱신한다.
  */
 class AiRecommendationRegressionTest {
 
@@ -74,6 +80,73 @@ class AiRecommendationRegressionTest {
                         .contains(s.expectedReasonCode());
             }
         }
+    }
+
+    @Test
+    void regression_adjacent_region_when_pool_lacks_exact_region() {
+        List<GuideRecommendRequest.GuideCandidateDto> pool = List.of(
+                GuideRecommendRequest.GuideCandidateDto.builder()
+                        .guideId(70L)
+                        .guideName("속초인접")
+                        .region("속초")
+                        .guideStyle("힐링")
+                        .priceLevel("낮음")
+                        .specialtyTags(List.of("산책", "바다", "카페"))
+                        .languages(List.of("한국어"))
+                        .build(),
+                GuideRecommendRequest.GuideCandidateDto.builder()
+                        .guideId(71L)
+                        .guideName("부산비교")
+                        .region("부산")
+                        .guideStyle("힐링")
+                        .priceLevel("낮음")
+                        .specialtyTags(List.of("산책", "바다"))
+                        .languages(List.of("한국어"))
+                        .build()
+        );
+        GuideRecommendRequest parsed = promptParser.parse("강릉 힐링 산책 바다", 2, pool);
+        GuideRecommendResponse response = aiRecommendationService.recommend(parsed);
+
+        assertThat(response.getRecommendations()).isNotEmpty();
+        var top1 = response.getRecommendations().get(0);
+        assertThat(top1.getGuideId()).isEqualTo(70L);
+        assertThat(top1.getMatched().isRegion()).isFalse();
+        assertThat(top1.getMatched().isRegionAdjacent()).isTrue();
+        assertThat(top1.getReasonCodes()).contains(ReasonGenerator.CODE_REGION_ADJACENT);
+    }
+
+    @Test
+    void regression_budget_adjacent_reason_on_tier_gap() {
+        List<GuideRecommendRequest.GuideCandidateDto> pool = List.of(
+                GuideRecommendRequest.GuideCandidateDto.builder()
+                        .guideId(80L)
+                        .guideName("부산가이드")
+                        .region("부산")
+                        .guideStyle("감성")
+                        .priceLevel("중간")
+                        .specialtyTags(List.of("카페", "야경"))
+                        .languages(List.of("한국어"))
+                        .build()
+        );
+        GuideRecommendRequest parsed = promptParser.parse("부산 가성비 저렴 감성 카페", 1, pool);
+        GuideRecommendResponse response = aiRecommendationService.recommend(parsed);
+
+        assertThat(response.getRecommendations()).hasSize(1);
+        assertThat(response.getRecommendations().get(0).getGuideId()).isEqualTo(80L);
+        assertThat(response.getRecommendations().get(0).getReasonCodes())
+                .contains(ReasonGenerator.CODE_BUDGET_ADJACENT);
+    }
+
+    @Test
+    void regression_policy_version_echoes_tuning_constant() {
+        GuideRecommendRequest parsed = promptParser.parse(
+                "부산 감성 카페",
+                1,
+                List.of(defaultCandidates().get(0))
+        );
+        GuideRecommendResponse response = aiRecommendationService.recommend(parsed);
+
+        assertThat(response.getPolicyVersion()).isEqualTo(AiRecommendationTuning.POLICY_VERSION);
     }
 
     private List<Scenario> regressionScenarios() {

--- a/backend/module-ai/src/test/java/com/team6/module/ai/support/PolicyVersionContractTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/support/PolicyVersionContractTest.java
@@ -1,0 +1,16 @@
+package com.team6.module.ai.support;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@link AiRecommendationTuning#POLICY_VERSION} 문자열 계약(로그·헤더·캐시 키 구분용).
+ */
+class PolicyVersionContractTest {
+
+    @Test
+    void policy_version_should_use_year_month_serial_format() {
+        assertThat(AiRecommendationTuning.POLICY_VERSION).matches("\\d{4}\\.\\d{2}\\.\\d{1,2}");
+    }
+}


### PR DESCRIPTION
## 변경 범위
- `AiRecommendationRegressionTest`: 인접 지역만 맞는 풀·예산 인접 Reason·응답 `policyVersion` 회귀 추가, Javadoc 유지보수 체크리스트
- `PolicyVersionContractTest`: `POLICY_VERSION` 문자열 형식(`yyyy.MM.n`) 고정

## 스키마/런타임
변경 없음(테스트·문서만)

## 검증
```bash
cd backend && ./gradlew :module-ai:test :api-server:compileJava
```

Closes #132

Made with [Cursor](https://cursor.com)