### PR TITLE
Feat/be#134: AI 추천 후보 데이터 보강

### DIFF
--- a/backend/module-ai-integration/src/main/java/com/team6/integration/ai/DbBackedGuideCandidateProvider.java
+++ b/backend/module-ai-integration/src/main/java/com/team6/integration/ai/DbBackedGuideCandidateProvider.java
@@ -1,6 +1,10 @@
 package com.team6.integration.ai;
 
 import com.team6.domain.guide.entity.GuideProfile;
+import com.team6.domain.guide.entity.GuideCareer;
+import com.team6.domain.guide.entity.GuideFeed;
+import com.team6.domain.guide.repository.GuideCareerRepository;
+import com.team6.domain.guide.repository.GuideFeedRepository;
 import com.team6.domain.guide.repository.GuideProfileRepository;
 import com.team6.domain.matching.entity.enums.RefundStatus;
 import com.team6.domain.matching.repository.RefundRepository;
@@ -19,6 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * 클라이언트가 후보를 내려보내지 않은 경우, 승인·활성 {@link GuideProfile}을 DB에서 읽어 AI 후보로 채운다.
@@ -32,6 +37,8 @@ public class DbBackedGuideCandidateProvider implements GuideCandidateProvider {
     static final int MAX_SERVER_CANDIDATES = 200;
 
     private final GuideProfileRepository guideProfileRepository;
+    private final GuideFeedRepository guideFeedRepository;
+    private final GuideCareerRepository guideCareerRepository;
     private final RefundRepository refundRepository;
     private final PromptParser promptParser;
 
@@ -65,8 +72,41 @@ public class DbBackedGuideCandidateProvider implements GuideCandidateProvider {
             profiles = guideProfileRepository.findByIsApprovedTrueAndIsActiveTrue(pageable).getContent();
         }
         List<GuideRecommendRequest.GuideCandidateDto> mapped =
-                profiles.stream().map(GuideProfileAiCandidateMapper::toCandidate).toList();
+                mapProfilesToCandidates(profiles);
         return mergeApprovedRefundCounts(mapped);
+    }
+
+    private List<GuideRecommendRequest.GuideCandidateDto> mapProfilesToCandidates(List<GuideProfile> profiles) {
+        List<Long> guideIds = profiles.stream()
+                .map(GuideProfile::getId)
+                .filter(Objects::nonNull)
+                .toList();
+
+        Map<Long, List<GuideFeed>> feedsByGuide = guideIds.isEmpty()
+                ? Map.of()
+                : guideFeedRepository.findByGuideProfile_IdInAndIsDeletedFalse(guideIds).stream()
+                .filter(feed -> feed.getGuideProfile() != null && feed.getGuideProfile().getId() != null)
+                .collect(Collectors.groupingBy(
+                        feed -> feed.getGuideProfile().getId(),
+                        Collectors.toList()
+                ));
+
+        Map<Long, List<GuideCareer>> careersByGuide = guideIds.isEmpty()
+                ? Map.of()
+                : guideCareerRepository.findByGuideProfile_IdIn(guideIds).stream()
+                .filter(career -> career.getGuideProfile() != null && career.getGuideProfile().getId() != null)
+                .collect(Collectors.groupingBy(
+                        career -> career.getGuideProfile().getId(),
+                        Collectors.toList()
+                ));
+
+        return profiles.stream()
+                .map(profile -> GuideProfileAiCandidateMapper.toCandidate(
+                        profile,
+                        feedsByGuide.getOrDefault(profile.getId(), List.of()),
+                        careersByGuide.getOrDefault(profile.getId(), List.of())
+                ))
+                .toList();
     }
 
     private List<GuideRecommendRequest.GuideCandidateDto> mergeApprovedRefundCounts(

--- a/backend/module-ai-integration/src/main/java/com/team6/integration/ai/GuideAiCandidateFeaturesExtractor.java
+++ b/backend/module-ai-integration/src/main/java/com/team6/integration/ai/GuideAiCandidateFeaturesExtractor.java
@@ -1,0 +1,177 @@
+package com.team6.integration.ai;
+
+import com.team6.domain.guide.entity.GuideCareer;
+import com.team6.domain.guide.entity.GuideFeed;
+import com.team6.domain.guide.entity.GuideProfile;
+import com.team6.module.ai.parser.KeywordNormalizer;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * 가이드 도메인 데이터를 AI 후보 특징값(스타일/전문 태그)으로 요약한다.
+ */
+public final class GuideAiCandidateFeaturesExtractor {
+
+    private GuideAiCandidateFeaturesExtractor() {
+    }
+
+    private static final Map<String, List<String>> STYLE_KEYWORDS = new LinkedHashMap<>();
+    private static final Map<String, List<String>> TAG_KEYWORDS = new LinkedHashMap<>();
+
+    static {
+        STYLE_KEYWORDS.put("감성", List.of("감성", "감성샷", "인스타", "핫플", "사진", "카페", "브런치"));
+        STYLE_KEYWORDS.put("액티비티", List.of("액티비티", "익스트림", "스릴", "트레킹", "등산", "서핑", "래프팅", "패러글라이딩", "레포츠"));
+        STYLE_KEYWORDS.put("힐링", List.of("힐링", "여유", "조용", "편안", "휴식", "산책", "온천", "노천탕", "스파"));
+        STYLE_KEYWORDS.put("로컬", List.of("로컬", "현지", "골목", "시장", "동네", "문화", "역사", "유적", "전통"));
+
+        TAG_KEYWORDS.put("카페", List.of("카페", "브런치", "카페투어"));
+        TAG_KEYWORDS.put("야경", List.of("야경", "일몰", "노을", "밤거리", "야경명소"));
+        TAG_KEYWORDS.put("맛집", List.of("맛집", "먹방", "식도락", "음식", "먹거리"));
+        TAG_KEYWORDS.put("산책", List.of("산책", "걷기", "걷고", "드라이브", "골목"));
+        TAG_KEYWORDS.put("등산", List.of("등산", "트레킹"));
+        TAG_KEYWORDS.put("사진", List.of("사진", "포토", "인생샷", "감성샷"));
+        TAG_KEYWORDS.put("쇼핑", List.of("쇼핑", "쇼핑몰", "아울렛"));
+        TAG_KEYWORDS.put("바다", List.of("바다", "해변", "오션뷰", "해수욕장", "스노클링", "다이빙", "스쿠버", "서핑"));
+        TAG_KEYWORDS.put("전시", List.of("전시", "박물관", "미술관"));
+        TAG_KEYWORDS.put("시장", List.of("시장", "전통시장", "야시장", "로컬시장"));
+        TAG_KEYWORDS.put("술집", List.of("술집", "클럽", "바"));
+        TAG_KEYWORDS.put("온천", List.of("온천", "노천탕", "스파"));
+        TAG_KEYWORDS.put("골프", List.of("골프", "골프장"));
+        TAG_KEYWORDS.put("드라이브", List.of("드라이브", "드라이브코스"));
+        TAG_KEYWORDS.put("한옥", List.of("한옥", "한옥마을", "한옥스테이"));
+        TAG_KEYWORDS.put("테마파크", List.of("테마파크", "놀이공원", "놀이동산"));
+        TAG_KEYWORDS.put("캠핑", List.of("캠핑", "글램핑", "오토캠핑"));
+        TAG_KEYWORDS.put("사찰", List.of("사찰", "템플스테이"));
+        TAG_KEYWORDS.put("유적", List.of("유적", "고분", "왕릉"));
+        TAG_KEYWORDS.put("자전거", List.of("자전거", "라이딩", "사이클"));
+        TAG_KEYWORDS.put("래프팅", List.of("래프팅", "레포츠", "짚라인"));
+        TAG_KEYWORDS.put("스키", List.of("스키", "보드", "스노보드", "슬로프"));
+        TAG_KEYWORDS.put("계곡", List.of("계곡", "폭포"));
+        TAG_KEYWORDS.put("패러글라이딩", List.of("패러글라이딩", "패러"));
+        TAG_KEYWORDS.put("낚시", List.of("낚시", "바다낚시"));
+    }
+
+    public static Features extract(
+            GuideProfile profile,
+            List<GuideFeed> feeds,
+            List<GuideCareer> careers
+    ) {
+        String styleCorpus = buildStyleCorpus(profile, feeds, careers);
+        String tagCorpus = buildTagCorpus(profile, feeds, careers);
+        return new Features(inferStyle(styleCorpus), inferTags(tagCorpus));
+    }
+
+    private static String buildStyleCorpus(
+            GuideProfile profile,
+            List<GuideFeed> feeds,
+            List<GuideCareer> careers
+    ) {
+        List<String> parts = new ArrayList<>();
+        addIfNotBlank(parts, profile == null ? null : profile.getBio());
+        if (feeds != null) {
+            feeds.stream()
+                    .map(GuideFeed::getContent)
+                    .forEach(text -> addIfNotBlank(parts, text));
+        }
+        if (careers != null) {
+            careers.forEach(career -> {
+                addIfNotBlank(parts, career.getTitle());
+                addIfNotBlank(parts, career.getDescription());
+            });
+        }
+        return String.join(" ", parts).toLowerCase(Locale.ROOT);
+    }
+
+    private static String buildTagCorpus(
+            GuideProfile profile,
+            List<GuideFeed> feeds,
+            List<GuideCareer> careers
+    ) {
+        List<String> parts = new ArrayList<>();
+        addIfNotBlank(parts, profile == null ? null : profile.getBio());
+        addIfNotBlank(parts, profile == null ? null : profile.getLocalStory());
+        if (feeds != null) {
+            feeds.stream()
+                    .map(GuideFeed::getContent)
+                    .forEach(text -> addIfNotBlank(parts, text));
+        }
+        if (careers != null) {
+            careers.forEach(career -> {
+                addIfNotBlank(parts, career.getTitle());
+                addIfNotBlank(parts, career.getDescription());
+            });
+        }
+        return String.join(" ", parts).toLowerCase(Locale.ROOT);
+    }
+
+    private static String inferStyle(String corpus) {
+        if (corpus == null || corpus.isBlank()) {
+            return null;
+        }
+        String bestStyle = null;
+        int bestScore = 0;
+        for (Map.Entry<String, List<String>> entry : STYLE_KEYWORDS.entrySet()) {
+            int score = countMatches(corpus, entry.getValue());
+            if (corpus.contains(entry.getKey().toLowerCase(Locale.ROOT))) {
+                score += 10;
+            }
+            if (score > bestScore) {
+                bestStyle = entry.getKey();
+                bestScore = score;
+            }
+        }
+        return bestStyle;
+    }
+
+    private static List<String> inferTags(String corpus) {
+        if (corpus == null || corpus.isBlank()) {
+            return List.of();
+        }
+        LinkedHashSet<String> tags = new LinkedHashSet<>();
+        for (Map.Entry<String, List<String>> entry : TAG_KEYWORDS.entrySet()) {
+            if (containsAny(corpus, entry.getValue())) {
+                String normalized = KeywordNormalizer.normalizeTag(entry.getKey());
+                if (normalized != null && !normalized.isBlank()) {
+                    tags.add(normalized);
+                }
+            }
+        }
+        return new ArrayList<>(tags);
+    }
+
+    private static int countMatches(String corpus, List<String> keywords) {
+        int score = 0;
+        for (String keyword : keywords) {
+            if (keyword != null && !keyword.isBlank() && corpus.contains(keyword.toLowerCase(Locale.ROOT))) {
+                score++;
+            }
+        }
+        return score;
+    }
+
+    private static boolean containsAny(String corpus, List<String> keywords) {
+        for (String keyword : keywords) {
+            if (keyword != null && !keyword.isBlank() && corpus.contains(keyword.toLowerCase(Locale.ROOT))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void addIfNotBlank(List<String> parts, String value) {
+        if (value != null && !value.isBlank()) {
+            parts.add(value.trim());
+        }
+    }
+
+    public record Features(
+            String guideStyle,
+            List<String> specialtyTags
+    ) {
+    }
+}

--- a/backend/module-ai-integration/src/main/java/com/team6/integration/ai/GuideProfileAiCandidateMapper.java
+++ b/backend/module-ai-integration/src/main/java/com/team6/integration/ai/GuideProfileAiCandidateMapper.java
@@ -1,6 +1,8 @@
 package com.team6.integration.ai;
 
 import com.team6.domain.guide.entity.GuideProfile;
+import com.team6.domain.guide.entity.GuideCareer;
+import com.team6.domain.guide.entity.GuideFeed;
 import com.team6.module.ai.dto.request.GuideRecommendRequest;
 
 import java.math.BigDecimal;
@@ -15,14 +17,20 @@ public final class GuideProfileAiCandidateMapper {
     private GuideProfileAiCandidateMapper() {
     }
 
-    public static GuideRecommendRequest.GuideCandidateDto toCandidate(GuideProfile profile) {
+    public static GuideRecommendRequest.GuideCandidateDto toCandidate(
+            GuideProfile profile,
+            List<GuideFeed> feeds,
+            List<GuideCareer> careers
+    ) {
+        GuideAiCandidateFeaturesExtractor.Features features =
+                GuideAiCandidateFeaturesExtractor.extract(profile, feeds, careers);
         return GuideRecommendRequest.GuideCandidateDto.builder()
                 .guideId(profile.getId())
                 .guideName(profile.getNickname())
                 .region(profile.getRegion())
-                .guideStyle(null)
+                .guideStyle(features.guideStyle())
                 .priceLevel(priceLevelFromHourly(profile.getPricePerHour()))
-                .specialtyTags(List.of())
+                .specialtyTags(features.specialtyTags())
                 .languages(splitLanguages(profile.getLanguage()))
                 .averageRating(profile.getAverageRating())
                 .reviewCount(profile.getReviewCount())

--- a/backend/module-ai-integration/src/test/java/com/team6/integration/ai/DbBackedGuideCandidateProviderTest.java
+++ b/backend/module-ai-integration/src/test/java/com/team6/integration/ai/DbBackedGuideCandidateProviderTest.java
@@ -1,6 +1,10 @@
 package com.team6.integration.ai;
 
 import com.team6.domain.guide.entity.GuideProfile;
+import com.team6.domain.guide.entity.GuideCareer;
+import com.team6.domain.guide.entity.GuideFeed;
+import com.team6.domain.guide.repository.GuideCareerRepository;
+import com.team6.domain.guide.repository.GuideFeedRepository;
 import com.team6.domain.guide.repository.GuideProfileRepository;
 import com.team6.domain.matching.entity.enums.RefundStatus;
 import com.team6.domain.matching.repository.RefundRepository;
@@ -17,6 +21,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,6 +38,12 @@ class DbBackedGuideCandidateProviderTest {
     private GuideProfileRepository guideProfileRepository;
 
     @Mock
+    private GuideFeedRepository guideFeedRepository;
+
+    @Mock
+    private GuideCareerRepository guideCareerRepository;
+
+    @Mock
     private RefundRepository refundRepository;
 
     private DbBackedGuideCandidateProvider provider;
@@ -41,6 +52,8 @@ class DbBackedGuideCandidateProviderTest {
     void setUp() {
         provider = new DbBackedGuideCandidateProvider(
                 guideProfileRepository,
+                guideFeedRepository,
+                guideCareerRepository,
                 refundRepository,
                 new PromptParser(new LocalGuestAiProperties())
         );
@@ -63,6 +76,8 @@ class DbBackedGuideCandidateProviderTest {
                 provider.getCandidates("제주 2박", 3, client);
         assertThat(out).isSameAs(client);
         verify(guideProfileRepository, never()).findByIsApprovedTrueAndIsActiveTrue(any(Pageable.class));
+        verify(guideFeedRepository, never()).findByGuideProfile_IdInAndIsDeletedFalse(any());
+        verify(guideCareerRepository, never()).findByGuideProfile_IdIn(any());
         verify(refundRepository, never()).countApprovedRefundsGroupedByGuideId(any(), any());
     }
 
@@ -73,6 +88,7 @@ class DbBackedGuideCandidateProviderTest {
                 .memberId(10L)
                 .nickname("가이드A")
                 .region("제주")
+                .bio("감성 사진과 카페 중심 여행을 안내합니다.")
                 .language("한국어, English")
                 .pricePerHour(new BigDecimal("40000"))
                 .isApproved(true)
@@ -82,6 +98,24 @@ class DbBackedGuideCandidateProviderTest {
                 eq("제주"),
                 any(Pageable.class)
         )).thenReturn(new PageImpl<>(List.of(p)));
+        when(guideFeedRepository.findByGuideProfile_IdInAndIsDeletedFalse(List.of(1L)))
+                .thenReturn(List.of(
+                        GuideFeed.builder()
+                                .id(100L)
+                                .guideProfile(p)
+                                .content("감성 카페와 오션뷰 해변 포토스팟을 안내합니다.")
+                                .build()
+                ));
+        when(guideCareerRepository.findByGuideProfile_IdIn(List.of(1L)))
+                .thenReturn(List.of(
+                        GuideCareer.builder()
+                                .id(200L)
+                                .guideProfile(p)
+                                .title("현지 시장 로컬 투어")
+                                .description("야경 맛집 코스 운영")
+                                .acquiredAt(LocalDate.of(2024, 1, 1))
+                                .build()
+                ));
         when(refundRepository.countApprovedRefundsGroupedByGuideId(any(), eq(RefundStatus.APPROVED)))
                 .thenReturn(List.of());
 
@@ -93,6 +127,8 @@ class DbBackedGuideCandidateProviderTest {
         assertThat(out.get(0).getRegion()).isEqualTo("제주");
         assertThat(out.get(0).getLanguages()).containsExactly("한국어", "English");
         assertThat(out.get(0).getPriceLevel()).isEqualTo("낮음");
+        assertThat(out.get(0).getGuideStyle()).isEqualTo("감성");
+        assertThat(out.get(0).getSpecialtyTags()).contains("카페", "바다", "사진", "시장", "야경", "맛집");
         assertThat(out.get(0).getApprovedRefundCount()).isZero();
     }
 
@@ -114,6 +150,10 @@ class DbBackedGuideCandidateProviderTest {
                 .build();
         when(guideProfileRepository.findByIsApprovedTrueAndIsActiveTrue(PageRequest.of(0, DbBackedGuideCandidateProvider.MAX_SERVER_CANDIDATES)))
                 .thenReturn(new PageImpl<>(List.of(p)));
+        when(guideFeedRepository.findByGuideProfile_IdInAndIsDeletedFalse(List.of(2L)))
+                .thenReturn(List.of());
+        when(guideCareerRepository.findByGuideProfile_IdIn(List.of(2L)))
+                .thenReturn(List.of());
         when(refundRepository.countApprovedRefundsGroupedByGuideId(any(), eq(RefundStatus.APPROVED)))
                 .thenReturn(List.of());
 
@@ -139,6 +179,10 @@ class DbBackedGuideCandidateProviderTest {
                 .build();
         when(guideProfileRepository.findByIsApprovedTrueAndIsActiveTrue(any(Pageable.class)))
                 .thenReturn(new PageImpl<>(List.of(p)));
+        when(guideFeedRepository.findByGuideProfile_IdInAndIsDeletedFalse(List.of(3L)))
+                .thenReturn(List.of());
+        when(guideCareerRepository.findByGuideProfile_IdIn(List.of(3L)))
+                .thenReturn(List.of());
         when(refundRepository.countApprovedRefundsGroupedByGuideId(any(), eq(RefundStatus.APPROVED)))
                 .thenReturn(List.of());
 

--- a/backend/module-ai-integration/src/test/java/com/team6/integration/ai/GuideProfileAiCandidateMapperTest.java
+++ b/backend/module-ai-integration/src/test/java/com/team6/integration/ai/GuideProfileAiCandidateMapperTest.java
@@ -1,0 +1,53 @@
+package com.team6.integration.ai;
+
+import com.team6.domain.guide.entity.GuideCareer;
+import com.team6.domain.guide.entity.GuideFeed;
+import com.team6.domain.guide.entity.GuideProfile;
+import com.team6.module.ai.dto.request.GuideRecommendRequest;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GuideProfileAiCandidateMapperTest {
+
+    @Test
+    void toCandidate_should_extract_style_and_specialty_tags_from_guide_content() {
+        GuideProfile profile = GuideProfile.builder()
+                .id(1L)
+                .memberId(10L)
+                .nickname("로컬가이드")
+                .region("제주")
+                .bio("감성 카페와 오션뷰 해변 포토스팟을 안내합니다.")
+                .localStory("현지 골목과 전통시장을 함께 소개하는 로컬 투어를 운영합니다.")
+                .language("한국어, English")
+                .pricePerHour(new BigDecimal("70000"))
+                .build();
+
+        GuideFeed feed = GuideFeed.builder()
+                .id(100L)
+                .guideProfile(profile)
+                .content("제주 바다 노을 맛집과 야시장 코스를 자주 소개합니다.")
+                .build();
+
+        GuideCareer career = GuideCareer.builder()
+                .id(200L)
+                .guideProfile(profile)
+                .title("감성 사진 투어 운영")
+                .description("카페, 야경, 인생샷 중심 코스를 운영한 경험")
+                .acquiredAt(LocalDate.of(2024, 1, 1))
+                .build();
+
+        GuideRecommendRequest.GuideCandidateDto candidate =
+                GuideProfileAiCandidateMapper.toCandidate(profile, List.of(feed), List.of(career));
+
+        assertThat(candidate.getGuideStyle()).isEqualTo("감성");
+        assertThat(candidate.getSpecialtyTags())
+                .contains("카페", "바다", "사진", "시장", "맛집", "야경");
+        assertThat(candidate.getLanguages()).containsExactly("한국어", "English");
+        assertThat(candidate.getPriceLevel()).isEqualTo("중간");
+    }
+}

--- a/backend/module-domain/src/main/java/com/team6/domain/guide/repository/GuideCareerRepository.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/repository/GuideCareerRepository.java
@@ -14,6 +14,9 @@ public interface GuideCareerRepository extends JpaRepository<GuideCareer, Long> 
     // 가이드 경력 목록 조회 — 프로필 상세 조회 시 사용 (F06-01)
     List<GuideCareer> findByGuideProfile_Id(Long guideId);
 
+    // 여러 가이드 경력 목록 조회 — AI 후보 집계용
+    List<GuideCareer> findByGuideProfile_IdIn(List<Long> guideIds);
+
     // 경력 단건 조회 — 본인 소유 여부 확인 (F06-01)
     Optional<GuideCareer> findByIdAndGuideProfile_Id(Long id, Long guideId);
 }

--- a/backend/module-domain/src/main/java/com/team6/domain/guide/repository/GuideFeedRepository.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/repository/GuideFeedRepository.java
@@ -14,6 +14,9 @@ public interface GuideFeedRepository extends JpaRepository<GuideFeed, Long> {
     // 특정 가이드의 삭제되지 않은 피드 목록 조회 — 최신순 정렬 (F06-03)
     List<GuideFeed> findByGuideProfile_IdAndIsDeletedFalseOrderByCreatedAtDesc(Long guideId);
 
+    // 여러 가이드의 삭제되지 않은 피드 목록 조회 — AI 후보 집계용
+    List<GuideFeed> findByGuideProfile_IdInAndIsDeletedFalse(List<Long> guideIds);
+
     // 피드 단건 조회 — 삭제되지 않은 피드만 (F06-03)
     Optional<GuideFeed> findByIdAndIsDeletedFalse(Long id);
 }


### PR DESCRIPTION
## 🔗 이슈 번호

- Closes #134

---

## 💡 주요 변경 사항

- DB 기반 AI 후보 생성 시 가이드 피드/경력 데이터를 함께 조회하도록 확장
- 소개글, 로컬 스토리, 피드, 경력 텍스트를 바탕으로 guideStyle/specialtyTags를 추출하는 로직 추가
- GuideProfileAiCandidateMapper가 추출된 스타일/전문 태그를 실제 후보 DTO에 반영하도록 보강
- 다건 feed/career 조회용 repository 메서드 및 매핑 테스트 추가

---

## ⚠️ 주의 사항 / 질문

- 현재 도메인 모델에는 기본 코스/전문 분야 전용 저장 필드가 없어 bio/localStory/feed/career 텍스트를 기반으로 특징값을 추출합니다.
- localStory가 항상 로컬 성향으로 과도하게 치우치지 않도록 스타일 판정은 bio/feed/career 중심으로 계산했습니다.

---

## ✅ 체크리스트

- [x] 빌드가 정상적으로 되는가?
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [x] .gitignore에 설정 파일이 잘 포함되었는가?
- [x] 관련 테스트를 추가하거나 갱신했는가?