### PR TITLE
Feat/be#138: AI 추천 응답의 매칭 요청 재사용성 강화

### DIFF
--- a/backend/module-ai/src/main/java/com/team6/module/ai/dto/response/GuideRecommendResponse.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/dto/response/GuideRecommendResponse.java
@@ -14,6 +14,8 @@ public class GuideRecommendResponse {
     private String conceptSummary;
     @Schema(description = "파싱된 키워드 묶음")
     private Keywords keywords;
+    @Schema(description = "매칭 요청 화면에서 재사용하기 쉬운 AI 정리 초안")
+    private MatchRequestDraft matchRequestDraft;
     @Schema(description = "사용자 안내(지역 누락, 인접 지역 포함, 희소 풀 등)")
     private String notice;
     @Schema(
@@ -46,6 +48,27 @@ public class GuideRecommendResponse {
         private List<String> excludedActivityTags;
         @Schema(description = "soft 부정: 가이드 전문 태그와 겹치면 활동 점수에 패널티")
         private List<String> softPenaltyActivityTags;
+        private List<String> preferredLanguages;
+    }
+
+    @Schema(name = "GuideRecommendResponseMatchRequestDraft", description = "매칭 요청 폼 재사용용 AI 초안")
+    @Getter
+    @Builder
+    public static class MatchRequestDraft {
+        @Schema(description = "목적지 기본값")
+        private String destination;
+        @Schema(description = "가이드에게 전달할 컨셉 원문 초안")
+        private String concept;
+        @Schema(description = "가이드에게 보여줄 요약 문장")
+        private String conceptSummary;
+        @Schema(description = "예산 힌트(낮음/중간/높음)")
+        private String budgetHint;
+        private Integer headcount;
+        private Integer durationDays;
+        private String travelStyle;
+        private String companionType;
+        private List<String> activityTags;
+        private List<String> excludedActivityTags;
         private List<String> preferredLanguages;
     }
 }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
@@ -88,6 +88,7 @@ public class PromptRecommendationService {
                 GuideRecommendResponse out = GuideRecommendResponse.builder()
                         .conceptSummary(ConceptSummaryGenerator.generate(parsed))
                         .keywords(keywordsFrom(parsed))
+                        .matchRequestDraft(matchRequestDraftFrom(parsed))
                         .notice(NOTICE_REGION_REQUIRED)
                         .noticeCodes(List.of(RecommendationNoticeCodes.REGION_REQUIRED))
                         .policyVersion(POLICY_VERSION)
@@ -173,6 +174,7 @@ public class PromptRecommendationService {
             GuideRecommendResponse out = GuideRecommendResponse.builder()
                     .conceptSummary(ConceptSummaryGenerator.generate(parsed))
                     .keywords(keywordsFrom(parsed))
+                    .matchRequestDraft(matchRequestDraftFrom(parsed))
                     .notice(notice)
                     .noticeCodes(noticeCodes)
                     .policyVersion(POLICY_VERSION)
@@ -204,6 +206,22 @@ public class PromptRecommendationService {
                 .activityTags(request.getActivityTags())
                 .excludedActivityTags(request.getExcludedActivityTags())
                 .softPenaltyActivityTags(request.getSoftPenaltyActivityTags())
+                .preferredLanguages(request.getPreferredLanguages())
+                .build();
+    }
+
+    private static GuideRecommendResponse.MatchRequestDraft matchRequestDraftFrom(GuideRecommendRequest request) {
+        return GuideRecommendResponse.MatchRequestDraft.builder()
+                .destination(request.getRegion())
+                .concept(ConceptSummaryGenerator.generateMatchRequestConcept(request))
+                .conceptSummary(ConceptSummaryGenerator.generate(request))
+                .budgetHint(request.getBudgetLevel())
+                .headcount(request.getHeadcount())
+                .durationDays(request.getDurationDays())
+                .travelStyle(request.getTravelStyle())
+                .companionType(request.getCompanionType())
+                .activityTags(request.getActivityTags())
+                .excludedActivityTags(request.getExcludedActivityTags())
                 .preferredLanguages(request.getPreferredLanguages())
                 .build();
     }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/ConceptSummaryGenerator.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/ConceptSummaryGenerator.java
@@ -1,8 +1,11 @@
 package com.team6.module.ai.support;
 
 import com.team6.module.ai.dto.request.GuideRecommendRequest;
+import com.team6.module.ai.parser.KeywordNormalizer;
 
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.StringJoiner;
 
 public final class ConceptSummaryGenerator {
@@ -71,6 +74,80 @@ public final class ConceptSummaryGenerator {
         return result.isBlank() ? null : result;
     }
 
+    public static String generateMatchRequestConcept(GuideRecommendRequest req) {
+        if (req == null) {
+            return null;
+        }
+
+        List<String> parts = new java.util.ArrayList<>();
+        if (notBlank(req.getRegion())) {
+            parts.add(req.getRegion().trim() + " 여행");
+        }
+        if (req.getDurationDays() != null) {
+            parts.add(req.getDurationDays() + "일 일정");
+        }
+        if (req.getHeadcount() != null) {
+            parts.add(req.getHeadcount() + "명");
+        }
+        if (notBlank(req.getCompanionType())) {
+            parts.add(req.getCompanionType().trim() + " 여행");
+        }
+        if (notBlank(req.getTravelStyle())) {
+            parts.add(req.getTravelStyle().trim() + " 스타일");
+        }
+        if (notBlank(req.getBudgetLevel())) {
+            parts.add("예산 " + req.getBudgetLevel().trim());
+        }
+        List<String> preferredActivities = preferredActivities(req);
+        if (!preferredActivities.isEmpty()) {
+            parts.add("희망 활동 " + join(preferredActivities));
+        }
+        if (req.getExcludedActivityTags() != null && !req.getExcludedActivityTags().isEmpty()) {
+            parts.add("제외 활동 " + join(req.getExcludedActivityTags()));
+        }
+        if (req.getPreferredLanguages() != null && !req.getPreferredLanguages().isEmpty()) {
+            parts.add("희망 언어 " + join(req.getPreferredLanguages()));
+        }
+
+        String result = String.join(" / ", parts).trim();
+        return result.isBlank() ? null : result;
+    }
+
+    private static List<String> preferredActivities(GuideRecommendRequest req) {
+        if (req.getActivityTags() == null || req.getActivityTags().isEmpty()) {
+            return List.of();
+        }
+        Set<String> excluded = normalizeSet(req.getExcludedActivityTags());
+        Set<String> softPenalty = normalizeSet(req.getSoftPenaltyActivityTags());
+
+        return req.getActivityTags().stream()
+                .filter(ConceptSummaryGenerator::notBlank)
+                .map(String::trim)
+                .filter(tag -> {
+                    String normalized = KeywordNormalizer.normalizeTag(tag);
+                    return normalized != null && !excluded.contains(normalized) && !softPenalty.contains(normalized);
+                })
+                .distinct()
+                .toList();
+    }
+
+    private static Set<String> normalizeSet(List<String> values) {
+        if (values == null || values.isEmpty()) {
+            return Set.of();
+        }
+        LinkedHashSet<String> normalized = new LinkedHashSet<>();
+        for (String value : values) {
+            if (!notBlank(value)) {
+                continue;
+            }
+            String tag = KeywordNormalizer.normalizeTag(value.trim());
+            if (tag != null && !tag.isBlank()) {
+                normalized.add(tag);
+            }
+        }
+        return normalized;
+    }
+
     private static String join(List<String> values) {
         if (values == null || values.isEmpty()) {
             return null;
@@ -88,4 +165,3 @@ public final class ConceptSummaryGenerator {
         return s != null && !s.isBlank();
     }
 }
-

--- a/backend/module-ai/src/test/java/com/team6/module/ai/service/PromptRecommendationServiceTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/service/PromptRecommendationServiceTest.java
@@ -73,11 +73,18 @@ class PromptRecommendationServiceTest {
 
         assertThat(response.getConceptSummary()).isNotBlank();
         assertThat(response.getKeywords()).isNotNull();
+        assertThat(response.getMatchRequestDraft()).isNotNull();
         assertThat(response.getKeywords().getRegion()).isEqualTo("제주");
         assertThat(response.getKeywords().getDurationDays()).isEqualTo(3);
         assertThat(response.getKeywords().getHeadcount()).isEqualTo(4);
         assertThat(response.getKeywords().getActivityTags()).contains("바다", "맛집");
         assertThat(response.getKeywords().getExcludedActivityTags()).contains("술집");
+        assertThat(response.getMatchRequestDraft().getDestination()).isEqualTo("제주");
+        assertThat(response.getMatchRequestDraft().getConceptSummary()).isEqualTo(response.getConceptSummary());
+        assertThat(response.getMatchRequestDraft().getConcept()).contains("제주 여행");
+        assertThat(response.getMatchRequestDraft().getConcept()).contains("희망 활동");
+        assertThat(response.getMatchRequestDraft().getConcept()).contains("맛집");
+        assertThat(response.getMatchRequestDraft().getConcept()).contains("바다");
         assertThat(response.getPolicyVersion()).isEqualTo(AiRecommendationTuning.POLICY_VERSION);
         assertThat(response.getNotice()).contains("한 분뿐");
         assertThat(response.getNoticeCodes()).contains(
@@ -108,6 +115,9 @@ class PromptRecommendationServiceTest {
         assertThat(response.getRecommendations()).isEmpty();
         assertThat(response.getTotalCount()).isEqualTo(0);
         assertThat(response.getNotice()).contains("지역");
+        assertThat(response.getMatchRequestDraft()).isNotNull();
+        assertThat(response.getMatchRequestDraft().getDestination()).isNull();
+        assertThat(response.getMatchRequestDraft().getConcept()).contains("희망 활동 카페");
         assertThat(response.getNoticeCodes()).containsExactly(RecommendationNoticeCodes.REGION_REQUIRED);
         assertThat(response.getPolicyVersion()).isEqualTo(AiRecommendationTuning.POLICY_VERSION);
     }
@@ -143,4 +153,3 @@ class PromptRecommendationServiceTest {
         assertThat(response.getRecommendations().get(0).getGuideId()).isEqualTo(99L);
     }
 }
-


### PR DESCRIPTION
## 🔗 이슈 번호

- Closes #138

---

## 💡 주요 변경 사항

- AI 추천 응답에 매칭 요청 화면 재사용용 `matchRequestDraft` 필드 추가
- conceptSummary/keywords와 함께 destination, concept, budgetHint, 인원/기간/활동/언어 정보를 한 번 더 정리해 프론트가 매칭 요청 폼 기본값으로 쓰기 쉽게 보강
- 매칭 요청용 concept 초안 생성 시 제외/부담 태그가 희망 활동에 섞이지 않도록 요약 로직 정리
- PromptRecommendationService 테스트에 응답 draft 필드 검증 추가

---

## ⚠️ 주의 사항 / 질문

- 이번 작업은 AI 모듈 내부 응답 계약 강화에만 집중했고 matching 모듈 DTO/서비스는 변경하지 않았습니다.
- 실제 매칭 요청 API에 어떤 필드를 보낼지는 프론트에서 `matchRequestDraft`를 선택적으로 매핑하는 방식으로 활용하면 됩니다.

---

## ✅ 체크리스트

- [x] 빌드가 정상적으로 되는가?
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [x] .gitignore에 설정 파일이 잘 포함되었는가?
- [x] 관련 테스트를 추가하거나 갱신했는가?