### PR TITLE
Feat/be#140: 행동 데이터 기반 AI 추천 보정 추가

### DIFF
--- a/backend/module-ai-integration/build.gradle
+++ b/backend/module-ai-integration/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     implementation project(':module-common')
     implementation project(':module-domain')
     implementation project(':module-ai')
+    implementation project(':module-chat')
 
     // module-domain의 implementation 의존성은 전이되지 않으므로, 스프링 컴포넌트 컴파일용으로 명시
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/backend/module-ai-integration/src/main/java/com/team6/integration/ai/DbBackedGuideCandidateProvider.java
+++ b/backend/module-ai-integration/src/main/java/com/team6/integration/ai/DbBackedGuideCandidateProvider.java
@@ -6,8 +6,11 @@ import com.team6.domain.guide.entity.GuideProfile;
 import com.team6.domain.guide.repository.GuideCareerRepository;
 import com.team6.domain.guide.repository.GuideFeedRepository;
 import com.team6.domain.guide.repository.GuideProfileRepository;
+import com.team6.domain.matching.entity.enums.MatchRequestStatus;
 import com.team6.domain.matching.entity.enums.RefundStatus;
+import com.team6.domain.matching.repository.MatchRequestRepository;
 import com.team6.domain.matching.repository.RefundRepository;
+import com.team6.module.chat.repository.mysql.ChatRoomRepository;
 import com.team6.module.ai.dto.request.GuideRecommendRequest;
 import com.team6.module.ai.parser.PromptParser;
 import com.team6.module.ai.support.AiRecommendationTuning;
@@ -35,11 +38,19 @@ import java.util.stream.Collectors;
 public class DbBackedGuideCandidateProvider implements GuideCandidateProvider {
 
     static final int MAX_SERVER_CANDIDATES = 200;
+    private static final List<MatchRequestStatus> PROGRESSED_MATCH_STATUSES = List.of(
+            MatchRequestStatus.ACCEPTED,
+            MatchRequestStatus.PAID,
+            MatchRequestStatus.IN_PROGRESS,
+            MatchRequestStatus.COMPLETED
+    );
 
     private final GuideProfileRepository guideProfileRepository;
     private final GuideFeedRepository guideFeedRepository;
     private final GuideCareerRepository guideCareerRepository;
+    private final MatchRequestRepository matchRequestRepository;
     private final RefundRepository refundRepository;
+    private final ChatRoomRepository chatRoomRepository;
     private final PromptParser promptParser;
 
     @Override
@@ -73,7 +84,7 @@ public class DbBackedGuideCandidateProvider implements GuideCandidateProvider {
         }
         List<GuideRecommendRequest.GuideCandidateDto> mapped =
                 mapProfilesToCandidates(profiles);
-        return mergeApprovedRefundCounts(mapped);
+        return mergeBehaviorSignals(mapped, profiles);
     }
 
     private List<GuideRecommendRequest.GuideCandidateDto> mapProfilesToCandidates(List<GuideProfile> profiles) {
@@ -109,8 +120,9 @@ public class DbBackedGuideCandidateProvider implements GuideCandidateProvider {
                 .toList();
     }
 
-    private List<GuideRecommendRequest.GuideCandidateDto> mergeApprovedRefundCounts(
-            List<GuideRecommendRequest.GuideCandidateDto> candidates
+    private List<GuideRecommendRequest.GuideCandidateDto> mergeBehaviorSignals(
+            List<GuideRecommendRequest.GuideCandidateDto> candidates,
+            List<GuideProfile> profiles
     ) {
         List<Long> guideIds = candidates.stream()
                 .map(GuideRecommendRequest.GuideCandidateDto::getGuideId)
@@ -127,14 +139,46 @@ public class DbBackedGuideCandidateProvider implements GuideCandidateProvider {
             int cnt = ((Number) row[1]).intValue();
             countByGuide.put(gid, cnt);
         }
+
+        Map<Long, Integer> requestCountByGuide = toCountMap(matchRequestRepository.countAllGroupedByGuideId(guideIds));
+        Map<Long, Integer> progressedCountByGuide = toCountMap(
+                matchRequestRepository.countByGuideIdAndStatusInGrouped(guideIds, PROGRESSED_MATCH_STATUSES)
+        );
+        Map<Long, Long> memberIdByGuide = profiles.stream()
+                .filter(profile -> profile.getId() != null && profile.getMemberId() != null)
+                .collect(Collectors.toMap(GuideProfile::getId, GuideProfile::getMemberId));
+        List<Long> memberIds = memberIdByGuide.values().stream().distinct().toList();
+        Map<Long, Integer> chatCountByMember = memberIds.isEmpty()
+                ? Map.of()
+                : toCountMap(chatRoomRepository.countRoomsGroupedByParticipantUserId(memberIds));
+
         return candidates.stream()
-                .map(d -> rebuildWithRefund(d, countByGuide.getOrDefault(d.getGuideId(), 0)))
+                .map(d -> rebuildWithSignals(
+                        d,
+                        countByGuide.getOrDefault(d.getGuideId(), 0),
+                        requestCountByGuide.getOrDefault(d.getGuideId(), 0),
+                        progressedCountByGuide.getOrDefault(d.getGuideId(), 0),
+                        chatCountByMember.getOrDefault(memberIdByGuide.get(d.getGuideId()), 0)
+                ))
                 .toList();
     }
 
-    private static GuideRecommendRequest.GuideCandidateDto rebuildWithRefund(
+    private static Map<Long, Integer> toCountMap(List<Object[]> rows) {
+        Map<Long, Integer> counts = new HashMap<>();
+        for (Object[] row : rows) {
+            Long id = (Long) row[0];
+            int cnt = ((Number) row[1]).intValue();
+            counts.put(id, cnt);
+        }
+        return counts;
+    }
+
+    private static GuideRecommendRequest.GuideCandidateDto rebuildWithSignals(
             GuideRecommendRequest.GuideCandidateDto d,
-            int approvedRefundCount
+            int approvedRefundCount,
+            int matchRequestCount,
+            int progressedMatchCount,
+            int chatStartCount
     ) {
         return GuideRecommendRequest.GuideCandidateDto.builder()
                 .guideId(d.getGuideId())
@@ -147,6 +191,9 @@ public class DbBackedGuideCandidateProvider implements GuideCandidateProvider {
                 .averageRating(d.getAverageRating())
                 .reviewCount(d.getReviewCount())
                 .approvedRefundCount(approvedRefundCount)
+                .matchRequestCount(matchRequestCount)
+                .progressedMatchCount(progressedMatchCount)
+                .chatStartCount(chatStartCount)
                 .build();
     }
 }

--- a/backend/module-ai-integration/src/test/java/com/team6/integration/ai/DbBackedGuideCandidateProviderTest.java
+++ b/backend/module-ai-integration/src/test/java/com/team6/integration/ai/DbBackedGuideCandidateProviderTest.java
@@ -6,8 +6,11 @@ import com.team6.domain.guide.entity.GuideProfile;
 import com.team6.domain.guide.repository.GuideCareerRepository;
 import com.team6.domain.guide.repository.GuideFeedRepository;
 import com.team6.domain.guide.repository.GuideProfileRepository;
+import com.team6.domain.matching.entity.enums.MatchRequestStatus;
 import com.team6.domain.matching.entity.enums.RefundStatus;
+import com.team6.domain.matching.repository.MatchRequestRepository;
 import com.team6.domain.matching.repository.RefundRepository;
+import com.team6.module.chat.repository.mysql.ChatRoomRepository;
 import com.team6.module.ai.config.LocalGuestAiProperties;
 import com.team6.module.ai.dto.request.GuideRecommendRequest;
 import com.team6.module.ai.parser.PromptParser;
@@ -46,6 +49,12 @@ class DbBackedGuideCandidateProviderTest {
     @Mock
     private RefundRepository refundRepository;
 
+    @Mock
+    private MatchRequestRepository matchRequestRepository;
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
     private DbBackedGuideCandidateProvider provider;
 
     @BeforeEach
@@ -54,7 +63,9 @@ class DbBackedGuideCandidateProviderTest {
                 guideProfileRepository,
                 guideFeedRepository,
                 guideCareerRepository,
+                matchRequestRepository,
                 refundRepository,
+                chatRoomRepository,
                 new PromptParser(new LocalGuestAiProperties())
         );
     }
@@ -79,6 +90,9 @@ class DbBackedGuideCandidateProviderTest {
         verify(guideFeedRepository, never()).findByGuideProfile_IdInAndIsDeletedFalse(any());
         verify(guideCareerRepository, never()).findByGuideProfile_IdIn(any());
         verify(refundRepository, never()).countApprovedRefundsGroupedByGuideId(any(), any());
+        verify(matchRequestRepository, never()).countAllGroupedByGuideId(any());
+        verify(matchRequestRepository, never()).countByGuideIdAndStatusInGrouped(any(), any());
+        verify(chatRoomRepository, never()).countRoomsGroupedByParticipantUserId(any());
     }
 
     @Test
@@ -118,6 +132,20 @@ class DbBackedGuideCandidateProviderTest {
                 ));
         when(refundRepository.countApprovedRefundsGroupedByGuideId(any(), eq(RefundStatus.APPROVED)))
                 .thenReturn(List.of());
+        when(matchRequestRepository.countAllGroupedByGuideId(List.of(1L)))
+                .thenReturn(List.<Object[]>of(new Object[]{1L, 4L}));
+        when(matchRequestRepository.countByGuideIdAndStatusInGrouped(
+                eq(List.of(1L)),
+                eq(List.of(
+                        MatchRequestStatus.ACCEPTED,
+                        MatchRequestStatus.PAID,
+                        MatchRequestStatus.IN_PROGRESS,
+                        MatchRequestStatus.COMPLETED
+                ))
+        )).thenReturn(List.<Object[]>of(new Object[]{1L, 2L}));
+
+        when(chatRoomRepository.countRoomsGroupedByParticipantUserId(List.of(10L)))
+                .thenReturn(List.<Object[]>of(new Object[]{10L, 3L}));
 
         List<GuideRecommendRequest.GuideCandidateDto> out =
                 provider.getCandidates("제주에서 힐링하고 싶어요", 3, List.of());
@@ -130,6 +158,9 @@ class DbBackedGuideCandidateProviderTest {
         assertThat(out.get(0).getGuideStyle()).isEqualTo("감성");
         assertThat(out.get(0).getSpecialtyTags()).contains("카페", "바다", "사진", "시장", "야경", "맛집");
         assertThat(out.get(0).getApprovedRefundCount()).isZero();
+        assertThat(out.get(0).getMatchRequestCount()).isEqualTo(4);
+        assertThat(out.get(0).getProgressedMatchCount()).isEqualTo(2);
+        assertThat(out.get(0).getChatStartCount()).isEqualTo(3);
     }
 
     @Test
@@ -155,6 +186,12 @@ class DbBackedGuideCandidateProviderTest {
         when(guideCareerRepository.findByGuideProfile_IdIn(List.of(2L)))
                 .thenReturn(List.of());
         when(refundRepository.countApprovedRefundsGroupedByGuideId(any(), eq(RefundStatus.APPROVED)))
+                .thenReturn(List.of());
+        when(matchRequestRepository.countAllGroupedByGuideId(List.of(2L)))
+                .thenReturn(List.of());
+        when(matchRequestRepository.countByGuideIdAndStatusInGrouped(any(), any()))
+                .thenReturn(List.of());
+        when(chatRoomRepository.countRoomsGroupedByParticipantUserId(List.of(11L)))
                 .thenReturn(List.of());
 
         List<GuideRecommendRequest.GuideCandidateDto> out =
@@ -184,6 +221,12 @@ class DbBackedGuideCandidateProviderTest {
         when(guideCareerRepository.findByGuideProfile_IdIn(List.of(3L)))
                 .thenReturn(List.of());
         when(refundRepository.countApprovedRefundsGroupedByGuideId(any(), eq(RefundStatus.APPROVED)))
+                .thenReturn(List.of());
+        when(matchRequestRepository.countAllGroupedByGuideId(List.of(3L)))
+                .thenReturn(List.of());
+        when(matchRequestRepository.countByGuideIdAndStatusInGrouped(any(), any()))
+                .thenReturn(List.of());
+        when(chatRoomRepository.countRoomsGroupedByParticipantUserId(List.of(12L)))
                 .thenReturn(List.of());
 
         List<GuideRecommendRequest.GuideCandidateDto> out =

--- a/backend/module-ai/src/main/java/com/team6/module/ai/dto/request/GuideRecommendRequest.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/dto/request/GuideRecommendRequest.java
@@ -46,5 +46,11 @@ public class GuideRecommendRequest {
         /** 승인된 환불 건수(가이드 기준). 미전달 시 환불 감점 미적용. */
         @Schema(description = "승인(APPROVED) 환불 건수. 집계해 전달하면 룰 기반 감점에 반영")
         private Integer approvedRefundCount;
+        @Schema(description = "추천 이후 실제 매칭 요청으로 이어진 횟수. 행동 기반 보정에 활용")
+        private Integer matchRequestCount;
+        @Schema(description = "수락/진행 단계까지 이어진 매칭 횟수. 전환 품질 신호로 활용")
+        private Integer progressedMatchCount;
+        @Schema(description = "가이드가 참여한 채팅방 시작 횟수. 추천 이후 실제 대화 연결 신호로 활용")
+        private Integer chatStartCount;
     }
 }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/model/GuideAiProfile.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/model/GuideAiProfile.java
@@ -21,4 +21,10 @@ public class GuideAiProfile {
     private Integer reviewCount;
     /** 승인 환불 건수. null이면 환불 감점 없음. */
     private Integer approvedRefundCount;
+    /** 추천 이후 매칭 요청이 실제로 생성된 횟수. */
+    private Integer matchRequestCount;
+    /** 수락/진행 단계까지 이어진 매칭 횟수. */
+    private Integer progressedMatchCount;
+    /** 실제 채팅방 시작 횟수. */
+    private Integer chatStartCount;
 }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/policy/FeedbackMatchPolicy.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/policy/FeedbackMatchPolicy.java
@@ -8,13 +8,15 @@ import org.springframework.stereotype.Component;
 import java.math.BigDecimal;
 
 /**
- * 리뷰·환불 등 **사후 피드백** 기반 감점. 선호(TravelerPreference)와 무관하게 가이드 신호만 본다.
+ * 리뷰·환불 감점 + 실제 전환 행동 데이터 기반 소폭 가산.
+ * 선호(TravelerPreference)와 무관하게 가이드의 운영 품질/서비스 연결 신호만 본다.
  */
 @Component
 public class FeedbackMatchPolicy {
 
     public int score(TravelerPreference pref, GuideAiProfile guide) {
         int penalty = 0;
+        int bonus = 0;
 
         Integer refunds = guide.getApprovedRefundCount();
         if (refunds != null && refunds > 0) {
@@ -36,6 +38,30 @@ public class FeedbackMatchPolicy {
             }
         }
 
-        return -penalty;
+        Integer matchRequests = guide.getMatchRequestCount();
+        if (matchRequests != null && matchRequests > 0) {
+            bonus += Math.min(
+                    matchRequests * AiRecommendationTuning.FEEDBACK_MATCH_REQUEST_BONUS_PER_COUNT,
+                    AiRecommendationTuning.FEEDBACK_MATCH_REQUEST_BONUS_MAX
+            );
+        }
+
+        Integer progressedMatches = guide.getProgressedMatchCount();
+        if (progressedMatches != null && progressedMatches > 0) {
+            bonus += Math.min(
+                    progressedMatches * AiRecommendationTuning.FEEDBACK_PROGRESS_MATCH_BONUS_PER_COUNT,
+                    AiRecommendationTuning.FEEDBACK_PROGRESS_MATCH_BONUS_MAX
+            );
+        }
+
+        Integer chatStarts = guide.getChatStartCount();
+        if (chatStarts != null && chatStarts > 0) {
+            bonus += Math.min(
+                    chatStarts * AiRecommendationTuning.FEEDBACK_CHAT_START_BONUS_PER_COUNT,
+                    AiRecommendationTuning.FEEDBACK_CHAT_START_BONUS_MAX
+            );
+        }
+
+        return bonus - penalty;
     }
 }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationMapper.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationMapper.java
@@ -60,6 +60,9 @@ public class AiRecommendationMapper {
                         .averageRating(candidate.getAverageRating())
                         .reviewCount(candidate.getReviewCount())
                         .approvedRefundCount(candidate.getApprovedRefundCount())
+                        .matchRequestCount(candidate.getMatchRequestCount())
+                        .progressedMatchCount(candidate.getProgressedMatchCount())
+                        .chatStartCount(candidate.getChatStartCount())
                         .build())
                 .toList();
     }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationTuning.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationTuning.java
@@ -14,7 +14,7 @@ public final class AiRecommendationTuning {
     /**
      * 룰/스코어/Reason/응답 계약이 바뀔 때마다 올린다. 로그·API에서 동일 프롬프트 비교 시 정책 변경 여부를 구분하는 데 쓴다.
      */
-    public static final String POLICY_VERSION = "2026.04.10";
+    public static final String POLICY_VERSION = "2026.04.11";
 
     public static final int DEFAULT_TOP_N = 3;
 
@@ -43,4 +43,12 @@ public final class AiRecommendationTuning {
     public static final int FEEDBACK_LOW_RATING_PENALTY = 10;
     public static final double FEEDBACK_VERY_LOW_RATING_THRESHOLD = 2.5;
     public static final int FEEDBACK_VERY_LOW_RATING_PENALTY = 16;
+
+    /** 실제 행동 데이터 기반 보정(요청/진행/채팅)은 과적합을 피하기 위해 소폭 가산만 적용한다. */
+    public static final int FEEDBACK_MATCH_REQUEST_BONUS_PER_COUNT = 1;
+    public static final int FEEDBACK_MATCH_REQUEST_BONUS_MAX = 5;
+    public static final int FEEDBACK_PROGRESS_MATCH_BONUS_PER_COUNT = 3;
+    public static final int FEEDBACK_PROGRESS_MATCH_BONUS_MAX = 12;
+    public static final int FEEDBACK_CHAT_START_BONUS_PER_COUNT = 2;
+    public static final int FEEDBACK_CHAT_START_BONUS_MAX = 8;
 }

--- a/backend/module-ai/src/test/java/com/team6/module/ai/policy/FeedbackMatchPolicyTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/policy/FeedbackMatchPolicyTest.java
@@ -1,7 +1,6 @@
 package com.team6.module.ai.policy;
 
 import com.team6.module.ai.model.GuideAiProfile;
-import com.team6.module.ai.model.TravelerPreference;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
@@ -14,44 +13,41 @@ class FeedbackMatchPolicyTest {
     private final FeedbackMatchPolicy policy = new FeedbackMatchPolicy();
 
     @Test
-    void no_signal_returns_zero() {
-        TravelerPreference pref = TravelerPreference.builder().region("제주").activityTags(List.of()).build();
+    void score_should_add_bonus_for_behavior_signals() {
         GuideAiProfile guide = GuideAiProfile.builder()
                 .guideId(1L)
-                .guideName("a")
+                .guideName("활성 가이드")
                 .region("제주")
-                .languages(List.of())
-                .specialtyTags(List.of())
+                .guideStyle("감성")
+                .priceLevel("중간")
+                .specialtyTags(List.of("카페"))
+                .languages(List.of("한국어"))
+                .matchRequestCount(4)
+                .progressedMatchCount(2)
+                .chatStartCount(3)
                 .build();
-        assertThat(policy.score(pref, guide)).isZero();
+
+        int score = policy.score(null, guide);
+
+        assertThat(score).isEqualTo(16);
     }
 
     @Test
-    void approved_refunds_apply_penalty_capped() {
-        TravelerPreference pref = TravelerPreference.builder().region("제주").activityTags(List.of()).build();
+    void score_should_offset_bonus_with_penalties() {
         GuideAiProfile guide = GuideAiProfile.builder()
-                .guideId(1L)
-                .guideName("a")
-                .region("제주")
-                .languages(List.of())
-                .specialtyTags(List.of())
-                .approvedRefundCount(5)
-                .build();
-        assertThat(policy.score(pref, guide)).isEqualTo(-24);
-    }
-
-    @Test
-    void low_average_rating_penalty() {
-        TravelerPreference pref = TravelerPreference.builder().region("제주").activityTags(List.of()).build();
-        GuideAiProfile guide = GuideAiProfile.builder()
-                .guideId(1L)
-                .guideName("a")
-                .region("제주")
-                .languages(List.of())
-                .specialtyTags(List.of())
-                .averageRating(new BigDecimal("2.4"))
+                .guideId(2L)
+                .guideName("주의 가이드")
+                .region("부산")
+                .approvedRefundCount(2)
+                .averageRating(BigDecimal.valueOf(3.2))
                 .reviewCount(5)
+                .matchRequestCount(3)
+                .progressedMatchCount(1)
+                .chatStartCount(1)
                 .build();
-        assertThat(policy.score(pref, guide)).isEqualTo(-16);
+
+        int score = policy.score(null, guide);
+
+        assertThat(score).isEqualTo(-18);
     }
 }

--- a/backend/module-chat/src/main/java/com/team6/module/chat/repository/mysql/ChatRoomRepository.java
+++ b/backend/module-chat/src/main/java/com/team6/module/chat/repository/mysql/ChatRoomRepository.java
@@ -6,7 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
@@ -20,4 +19,12 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
             "WHERE p.userId = :userId")
     List<ChatRoom> findAllByUserId(@Param("userId") Long userId);
 
+    @Query("""
+            SELECT p.userId, COUNT(DISTINCT r.id)
+            FROM ChatRoom r
+            JOIN r.participants p
+            WHERE p.userId IN :userIds
+            GROUP BY p.userId
+            """)
+    List<Object[]> countRoomsGroupedByParticipantUserId(@Param("userIds") List<Long> userIds);
 }

--- a/backend/module-chat/src/main/java/com/team6/module/chat/repository/mysql/ChatRoomRepository.java
+++ b/backend/module-chat/src/main/java/com/team6/module/chat/repository/mysql/ChatRoomRepository.java
@@ -19,6 +19,11 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
             "WHERE p.userId = :userId")
     List<ChatRoom> findAllByUserId(@Param("userId") Long userId);
 
+    /**
+     * AI 추천 보정용 집계.
+     * 채팅 도메인에는 가이드 프로필 ID가 직접 없어서, 가이드의 memberId(userId) 기준으로
+     * 실제 대화 시작까지 이어진 채팅방 수를 세어 행동 신호로 사용한다.
+     */
     @Query("""
             SELECT p.userId, COUNT(DISTINCT r.id)
             FROM ChatRoom r

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/repository/MatchRequestRepository.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/repository/MatchRequestRepository.java
@@ -26,6 +26,10 @@ public interface MatchRequestRepository extends JpaRepository<MatchRequest, Long
     // 당일 진행 대상 매칭 조회 (연장 알림/선택 오픈용)
     List<MatchRequest> findByDesiredDateAndStatusIn(LocalDate desiredDate, List<MatchRequestStatus> statuses);
 
+    /**
+     * AI 추천 보정용 집계.
+     * 가이드별로 실제 매칭 요청이 몇 번 생성됐는지 계산해 "추천 이후 실제 선택된 정도"를 반영한다.
+     */
     @Query("""
             SELECT mr.guideId, COUNT(mr)
             FROM MatchRequest mr
@@ -34,6 +38,11 @@ public interface MatchRequestRepository extends JpaRepository<MatchRequest, Long
             """)
     List<Object[]> countAllGroupedByGuideId(@Param("guideIds") List<Long> guideIds);
 
+    /**
+     * AI 추천 보정용 집계.
+     * 요청 생성에서 끝나지 않고 ACCEPTED~COMPLETED 단계까지 이어진 횟수를 세서
+     * "실제 진행으로 연결된 가이드"에 소폭 가산점을 줄 때 사용한다.
+     */
     @Query("""
             SELECT mr.guideId, COUNT(mr)
             FROM MatchRequest mr

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/repository/MatchRequestRepository.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/repository/MatchRequestRepository.java
@@ -3,6 +3,9 @@ package com.team6.domain.matching.repository;
 import com.team6.domain.matching.entity.MatchRequest;
 import com.team6.domain.matching.entity.enums.MatchRequestStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import java.time.LocalDate;
 import java.util.List;
 
@@ -22,4 +25,24 @@ public interface MatchRequestRepository extends JpaRepository<MatchRequest, Long
 
     // 당일 진행 대상 매칭 조회 (연장 알림/선택 오픈용)
     List<MatchRequest> findByDesiredDateAndStatusIn(LocalDate desiredDate, List<MatchRequestStatus> statuses);
+
+    @Query("""
+            SELECT mr.guideId, COUNT(mr)
+            FROM MatchRequest mr
+            WHERE mr.guideId IN :guideIds
+            GROUP BY mr.guideId
+            """)
+    List<Object[]> countAllGroupedByGuideId(@Param("guideIds") List<Long> guideIds);
+
+    @Query("""
+            SELECT mr.guideId, COUNT(mr)
+            FROM MatchRequest mr
+            WHERE mr.guideId IN :guideIds
+              AND mr.status IN :statuses
+            GROUP BY mr.guideId
+            """)
+    List<Object[]> countByGuideIdAndStatusInGrouped(
+            @Param("guideIds") List<Long> guideIds,
+            @Param("statuses") List<MatchRequestStatus> statuses
+    );
 }


### PR DESCRIPTION
## 🔗 이슈 번호

- Closes #140

---

## 💡 주요 변경 사항

- AI 후보 DTO와 프로필 모델에 매칭 요청 수, 진행 단계 전환 수, 채팅 시작 수를 담는 행동 신호 필드를 추가
- DB 기반 후보 생성 시 match_request / chat_rooms 데이터를 집계해 가이드별 행동 데이터를 함께 주입하도록 확장
- FeedbackMatchPolicy가 환불/저평점 감점 외에 실제 서비스 전환 신호에 대한 소폭 가산을 반영하도록 보강
- 행동 데이터 집계와 점수 보정에 대한 테스트를 추가해 추천 점수 계약을 검증

---

## ⚠️ 주의 사항 / 질문

- 클릭 로그는 현재 저장 구조가 없어 이번 작업에서는 제외했고, 이미 존재하는 매칭/채팅 데이터만 반영했습니다.
- 현재 상태 모델에서 `ACCEPTED`가 제안 수락과 최종 수락 구간을 함께 표현하고 있어, 진행 단계 신호는 `ACCEPTED ~ COMPLETED` 구간 전체를 사용했습니다.

---

## ✅ 체크리스트

- [x] 빌드가 정상적으로 되는가?
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [x] .gitignore에 설정 파일이 잘 포함되었는가?
- [x] 관련 테스트를 추가하거나 갱신했는가?