### PR TITLE
Feat/be#113: matching JWT 연동·Stub 결제·환불 및 가이드 경로 정리

### DIFF
--- a/backend/module-domain/src/main/java/com/team6/domain/matching/client/FakePgClient.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/client/FakePgClient.java
@@ -1,0 +1,21 @@
+package com.team6.domain.matching.client;
+
+/**
+ * PG 연동 전 로컬/테스트용 Stub 클라이언트.
+ * 실제 PG 도입 시 동일 시그니처를 구현하는 어댑터로 교체한다.
+ */
+public interface FakePgClient {
+
+    /** Stub 결제 생성 시 사용하는 주문번호 접두어 (실 PG 도입 시 제거) */
+    String STUB_PG_ORDER_PREFIX = "LM-FAKE-";
+
+    /**
+     * Stub 승인: 주문번호·금액을 검증하고 합성 거래 ID를 반환한다.
+     *
+     * @param pgOrderNo   결제 생성 시 발급한 PG 주문번호
+     * @param expectedAmount 결제 엔티티에 저장된 금액(원)
+     * @param paymentId  결제 PK (합성 거래 ID 생성에 사용)
+     * @return PG 거래 ID (DB {@code payment.pg_transaction_id} 저장)
+     */
+    String approvePayment(String pgOrderNo, int expectedAmount, Long paymentId);
+}

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/client/StubFakePgClient.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/client/StubFakePgClient.java
@@ -1,0 +1,27 @@
+package com.team6.domain.matching.client;
+
+import com.team6.domain.matching.exception.MatchingErrorCode;
+import com.team6.domain.matching.exception.MatchingException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * 외부 PG 없이 승인 결과만 합성한다. 주문번호는 {@code LM-FAKE-} 접두로 생성된 것만 허용한다.
+ */
+@Slf4j
+@Component
+public class StubFakePgClient implements FakePgClient {
+
+    @Override
+    public String approvePayment(String pgOrderNo, int expectedAmount, Long paymentId) {
+        if (pgOrderNo == null || !pgOrderNo.startsWith(STUB_PG_ORDER_PREFIX)) {
+            throw new MatchingException(MatchingErrorCode.PAYMENT_PG_VERIFICATION_FAILED);
+        }
+        if (expectedAmount <= 0 || paymentId == null) {
+            throw new MatchingException(MatchingErrorCode.INVALID_REQUEST);
+        }
+        String txnId = "FAKE-TXN-" + paymentId;
+        log.info("[FakePG] 승인 Stub — pgOrderNo={}, amount={}, pgTransactionId={}", pgOrderNo, expectedAmount, txnId);
+        return txnId;
+    }
+}

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/controller/PaymentController.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/controller/PaymentController.java
@@ -1,6 +1,10 @@
 package com.team6.domain.matching.controller;
 
+import com.team6.domain.guide.repository.GuideProfileRepository;
+import com.team6.domain.matching.dto.request.PaymentConfirmRequest;
+import com.team6.domain.matching.dto.request.PaymentCreateRequest;
 import com.team6.domain.matching.dto.request.RefundRequestDto;
+import com.team6.domain.matching.dto.response.PaymentResponseDto;
 import com.team6.domain.matching.dto.response.RefundResponseDto;
 import com.team6.domain.matching.exception.MatchingErrorCode;
 import com.team6.domain.matching.exception.MatchingException;
@@ -12,6 +16,8 @@ import com.team6.module.common.global.util.SecurityUtil;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,6 +30,35 @@ public class PaymentController {
 
     private final PaymentService paymentService;
     private final MemberRepository memberRepository;
+    private final GuideProfileRepository guideProfileRepository;
+
+    @PostMapping
+    public ResponseEntity<PaymentResponseDto> createPayment(@RequestBody @Valid PaymentCreateRequest request) {
+        Long guestId = getCurrentMemberId(Role.GUEST);
+        return ResponseEntity.ok(paymentService.createPayment(guestId, request));
+    }
+
+    @PostMapping("/confirm")
+    public ResponseEntity<PaymentResponseDto> confirmPayment(@RequestBody @Valid PaymentConfirmRequest request) {
+        Long guestId = getCurrentMemberId(Role.GUEST);
+        return ResponseEntity.ok(paymentService.confirmPayment(guestId, request));
+    }
+
+    @GetMapping("/{paymentId}")
+    public ResponseEntity<PaymentResponseDto> getPayment(@PathVariable Long paymentId) {
+        Member member = memberRepository.findByEmail(SecurityUtil.getCurrentUserEmail())
+                .orElseThrow(() -> new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED));
+        if (member.getRole() == Role.GUEST) {
+            return ResponseEntity.ok(paymentService.getPaymentForGuest(member.getId(), paymentId));
+        }
+        if (member.getRole() == Role.GUIDE) {
+            Long guideProfileId = guideProfileRepository.findByMemberId(member.getId())
+                    .map(guideProfile -> guideProfile.getId())
+                    .orElseThrow(() -> new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED));
+            return ResponseEntity.ok(paymentService.getPaymentForGuide(guideProfileId, paymentId));
+        }
+        throw new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED);
+    }
 
     @PostMapping("/refunds")
     public ResponseEntity<RefundResponseDto> requestRefund(@RequestBody @Valid RefundRequestDto request) {

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/dto/request/PaymentConfirmRequest.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/dto/request/PaymentConfirmRequest.java
@@ -1,0 +1,22 @@
+package com.team6.domain.matching.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Stub PG 승인 단계: 클라이언트가 발급받은 {@code pgOrderNo}와 금액으로 검증 후 COMPLETED 전이.
+ */
+@Getter
+@NoArgsConstructor
+public class PaymentConfirmRequest {
+
+    @NotBlank
+    private String pgOrderNo;
+
+    @NotNull
+    @Positive
+    private Integer amount;
+}

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/dto/request/PaymentCreateRequest.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/dto/request/PaymentCreateRequest.java
@@ -1,0 +1,25 @@
+package com.team6.domain.matching.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PaymentCreateRequest {
+
+    @NotNull
+    private Long matchRequestId;
+
+    @NotNull
+    @Positive
+    private Integer amount;
+
+    /** DB CHECK 및 {@code payment_type} 유니크 키와 동일: CHAT, ACCOMPANY, EXTENSION */
+    @NotBlank
+    @Pattern(regexp = "CHAT|ACCOMPANY|EXTENSION")
+    private String paymentType;
+}

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/dto/response/PaymentResponseDto.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/dto/response/PaymentResponseDto.java
@@ -15,6 +15,8 @@ public class PaymentResponseDto {
     private Integer amount;              // 결제 금액
     private String paymentType;          // CHAT/ACCOMPANY/EXTENSION
     private PaymentStatus status;        // 결제 상태
+    private String pgOrderNo;            // PG 주문번호 (승인 요청 시 사용)
+    private String pgTransactionId;    // PG 거래 ID (완료 후)
     private LocalDateTime paidAt;        // 결제 완료일시
     private LocalDateTime refundDeadline; // 환불 마감일시
 
@@ -26,6 +28,8 @@ public class PaymentResponseDto {
                 .amount(payment.getAmount())
                 .paymentType(payment.getPaymentType())
                 .status(payment.getStatus())
+                .pgOrderNo(payment.getPgOrderNo())
+                .pgTransactionId(payment.getPgTransactionId())
                 .paidAt(payment.getPaidAt())
                 .refundDeadline(payment.getRefundDeadline())
                 .build();

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/entity/MatchRequest.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/entity/MatchRequest.java
@@ -152,6 +152,16 @@ public class MatchRequest extends BaseTimeEntity {
         this.status = MatchRequestStatus.ACCEPTED;
     }
 
+    /**
+     * 결제 완료 시 매칭 요청을 PAID로 전이한다. 이미 PAID 이후이면 변경하지 않는다(연장 결제 등).
+     */
+    public void markAsPaidIfAccepted() {
+        if (this.status == MatchRequestStatus.ACCEPTED) {
+            this.status = MatchRequestStatus.PAID;
+            log.info("[Payment] 매칭 요청 결제 반영 — status=PAID, requestId={}", this.id);
+        }
+    }
+
     // 게스트 취소 처리 (F05-01)
     public void cancelByGuest(String reason) {
         if (this.status != MatchRequestStatus.ACCEPTED &&

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/exception/MatchingErrorCode.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/exception/MatchingErrorCode.java
@@ -16,6 +16,11 @@ public enum MatchingErrorCode {
     PAYMENT_NOT_FOUND(404, "결제 정보를 찾을 수 없습니다"),
     PAYMENT_ALREADY_CANCELLED(400, "이미 취소된 결제입니다"),
     PAYMENT_NOT_COMPLETED(400, "완료된 결제가 아닙니다"),
+    PAYMENT_NOT_PENDING(400, "대기 중인 결제가 아닙니다"),
+    PAYMENT_ALREADY_COMPLETED(400, "이미 완료된 결제입니다"),
+    PAYMENT_DUPLICATE_TYPE(400, "해당 매칭 요청에 동일 유형의 결제가 이미 존재합니다"),
+    PAYMENT_AMOUNT_MISMATCH(400, "결제 금액이 일치하지 않습니다"),
+    PAYMENT_PG_VERIFICATION_FAILED(400, "PG 승인 검증에 실패했습니다"),
 
     // Refund 관련
     REFUND_DEADLINE_EXCEEDED(400, "환불 가능 시간(2시간)이 초과되었습니다"),

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/repository/PaymentRepository.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/repository/PaymentRepository.java
@@ -8,6 +8,8 @@ import java.util.Optional;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
+    Optional<Payment> findByMatchRequest_IdAndPaymentType(Long matchRequestId, String paymentType);
+
     // 매칭 요청 ID로 결제 목록 조회
     List<Payment> findByMatchRequest_Id(Long requestId);
 

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/service/PaymentService.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/service/PaymentService.java
@@ -1,13 +1,20 @@
 package com.team6.domain.matching.service;
 
+import com.team6.domain.matching.client.FakePgClient;
+import com.team6.domain.matching.dto.request.PaymentConfirmRequest;
+import com.team6.domain.matching.dto.request.PaymentCreateRequest;
 import com.team6.domain.matching.dto.request.RefundRequestDto;
+import com.team6.domain.matching.dto.response.PaymentResponseDto;
 import com.team6.domain.matching.dto.response.RefundResponseDto;
+import com.team6.domain.matching.entity.MatchRequest;
 import com.team6.domain.matching.entity.Payment;
 import com.team6.domain.matching.entity.Refund;
+import com.team6.domain.matching.entity.enums.MatchRequestStatus;
 import com.team6.domain.matching.entity.enums.PaymentStatus;
 import com.team6.domain.matching.entity.enums.RefundType;
 import com.team6.domain.matching.exception.MatchingErrorCode;
 import com.team6.domain.matching.exception.MatchingException;
+import com.team6.domain.matching.repository.MatchRequestRepository;
 import com.team6.domain.matching.repository.PaymentRepository;
 import com.team6.domain.matching.repository.RefundRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +23,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Slf4j
 @Service
@@ -25,6 +33,98 @@ public class PaymentService {
 
     private final PaymentRepository paymentRepository;
     private final RefundRepository refundRepository;
+    private final MatchRequestRepository matchRequestRepository;
+    private final FakePgClient fakePgClient;
+
+    /**
+     * 결제 요청 생성 — PENDING, Stub PG 주문번호 발급.
+     * 매칭 요청이 게스트 소유이며 ACCEPTED 일 때만 가능. (match_request_id, payment_type) 중복 불가.
+     */
+    public PaymentResponseDto createPayment(Long guestId, PaymentCreateRequest request) {
+        MatchRequest matchRequest = matchRequestRepository.findById(request.getMatchRequestId())
+                .orElseThrow(() -> new MatchingException(MatchingErrorCode.MATCH_REQUEST_NOT_FOUND));
+
+        if (!matchRequest.getGuestId().equals(guestId)) {
+            throw new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED);
+        }
+        if (matchRequest.getStatus() != MatchRequestStatus.ACCEPTED) {
+            throw new MatchingException(MatchingErrorCode.MATCH_REQUEST_INVALID_STATUS);
+        }
+
+        if (paymentRepository.findByMatchRequest_IdAndPaymentType(matchRequest.getId(), request.getPaymentType())
+                .isPresent()) {
+            throw new MatchingException(MatchingErrorCode.PAYMENT_DUPLICATE_TYPE);
+        }
+
+        String pgOrderNo = FakePgClient.STUB_PG_ORDER_PREFIX + UUID.randomUUID();
+
+        Payment payment = Payment.builder()
+                .matchRequest(matchRequest)
+                .payerId(guestId)
+                .amount(request.getAmount())
+                .paymentType(request.getPaymentType())
+                .pgOrderNo(pgOrderNo)
+                .status(PaymentStatus.PENDING)
+                .build();
+
+        Payment saved = paymentRepository.save(payment);
+        log.info("[Payment] 결제 요청 생성 — paymentId={}, requestId={}, guestId={}, type={}, pgOrderNo={}",
+                saved.getId(), matchRequest.getId(), guestId, request.getPaymentType(), pgOrderNo);
+        return PaymentResponseDto.from(saved);
+    }
+
+    /**
+     * Stub PG 승인: 주문번호·금액 검증 후 COMPLETED, paidAt/refundDeadline 설정, 매칭 요청 ACCEPTED → PAID 반영.
+     */
+    public PaymentResponseDto confirmPayment(Long guestId, PaymentConfirmRequest request) {
+        Payment payment = paymentRepository.findByPgOrderNo(request.getPgOrderNo())
+                .orElseThrow(() -> new MatchingException(MatchingErrorCode.PAYMENT_NOT_FOUND));
+
+        if (!payment.getPayerId().equals(guestId)) {
+            throw new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED);
+        }
+
+        if (!payment.getAmount().equals(request.getAmount())) {
+            throw new MatchingException(MatchingErrorCode.PAYMENT_AMOUNT_MISMATCH);
+        }
+
+        if (payment.getStatus() == PaymentStatus.COMPLETED) {
+            throw new MatchingException(MatchingErrorCode.PAYMENT_ALREADY_COMPLETED);
+        }
+        if (payment.getStatus() != PaymentStatus.PENDING) {
+            throw new MatchingException(MatchingErrorCode.PAYMENT_NOT_PENDING);
+        }
+
+        String pgTransactionId = fakePgClient.approvePayment(
+                payment.getPgOrderNo(), payment.getAmount(), payment.getId());
+
+        payment.complete(pgTransactionId);
+        payment.getMatchRequest().markAsPaidIfAccepted();
+
+        log.info("[Payment] Stub PG 승인 완료 — paymentId={}, pgTransactionId={}, paidAt={}, refundDeadline={}",
+                payment.getId(), pgTransactionId, payment.getPaidAt(), payment.getRefundDeadline());
+        return PaymentResponseDto.from(payment);
+    }
+
+    @Transactional(readOnly = true)
+    public PaymentResponseDto getPaymentForGuest(Long guestId, Long paymentId) {
+        Payment payment = paymentRepository.findById(paymentId)
+                .orElseThrow(() -> new MatchingException(MatchingErrorCode.PAYMENT_NOT_FOUND));
+        if (!payment.getMatchRequest().getGuestId().equals(guestId)) {
+            throw new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED);
+        }
+        return PaymentResponseDto.from(payment);
+    }
+
+    @Transactional(readOnly = true)
+    public PaymentResponseDto getPaymentForGuide(Long guideProfileId, Long paymentId) {
+        Payment payment = paymentRepository.findById(paymentId)
+                .orElseThrow(() -> new MatchingException(MatchingErrorCode.PAYMENT_NOT_FOUND));
+        if (!payment.getMatchRequest().getGuideId().equals(guideProfileId)) {
+            throw new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED);
+        }
+        return PaymentResponseDto.from(payment);
+    }
 
     // F05-04: 가이드 불만족 환불 신청 및 처리 (결제 후 2시간 이내)
     public RefundResponseDto requestGuestRefund(Long guestId, RefundRequestDto request) {

--- a/backend/module-domain/src/test/java/com/team6/domain/matching/service/PaymentServiceTest.java
+++ b/backend/module-domain/src/test/java/com/team6/domain/matching/service/PaymentServiceTest.java
@@ -1,14 +1,19 @@
 package com.team6.domain.matching.service;
 
+import com.team6.domain.matching.client.FakePgClient;
+import com.team6.domain.matching.dto.request.PaymentConfirmRequest;
+import com.team6.domain.matching.dto.request.PaymentCreateRequest;
 import com.team6.domain.matching.dto.request.RefundRequestDto;
+import com.team6.domain.matching.dto.response.PaymentResponseDto;
 import com.team6.domain.matching.dto.response.RefundResponseDto;
 import com.team6.domain.matching.entity.MatchRequest;
 import com.team6.domain.matching.entity.Payment;
 import com.team6.domain.matching.entity.Refund;
+import com.team6.domain.matching.entity.enums.MatchRequestStatus;
 import com.team6.domain.matching.entity.enums.PaymentStatus;
-import com.team6.domain.matching.entity.enums.RefundType;
 import com.team6.domain.matching.exception.MatchingErrorCode;
 import com.team6.domain.matching.exception.MatchingException;
+import com.team6.domain.matching.repository.MatchRequestRepository;
 import com.team6.domain.matching.repository.PaymentRepository;
 import com.team6.domain.matching.repository.RefundRepository;
 import org.junit.jupiter.api.Test;
@@ -25,6 +30,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -34,6 +40,10 @@ class PaymentServiceTest {
     private PaymentRepository paymentRepository;
     @Mock
     private RefundRepository refundRepository;
+    @Mock
+    private MatchRequestRepository matchRequestRepository;
+    @Mock
+    private FakePgClient fakePgClient;
     @InjectMocks
     private PaymentService paymentService;
 
@@ -81,6 +91,130 @@ class PaymentServiceTest {
         MatchingException ex = assertThrows(MatchingException.class,
                 () -> paymentService.requestGuestRefund(10L, request));
         assertEquals(MatchingErrorCode.REFUND_DEADLINE_EXCEEDED, ex.getErrorCode());
+    }
+
+    @Test
+    void 결제생성_성공_PENDING_및_주문번호() {
+        Long guestId = 5L;
+        Long requestId = 50L;
+        MatchRequest mr = acceptedMatchRequest(requestId, guestId, 20L);
+        PaymentCreateRequest req = paymentCreate(requestId, 30000, "ACCOMPANY");
+
+        when(matchRequestRepository.findById(requestId)).thenReturn(Optional.of(mr));
+        when(paymentRepository.findByMatchRequest_IdAndPaymentType(requestId, "ACCOMPANY"))
+                .thenReturn(Optional.empty());
+        when(paymentRepository.save(any(Payment.class))).thenAnswer(invocation -> {
+            Payment p = invocation.getArgument(0);
+            setField(p, "id", 1000L);
+            return p;
+        });
+
+        PaymentResponseDto dto = paymentService.createPayment(guestId, req);
+
+        assertEquals(1000L, dto.getPaymentId());
+        assertEquals(PaymentStatus.PENDING, dto.getStatus());
+        assertEquals(30000, dto.getAmount());
+        assertEquals("ACCOMPANY", dto.getPaymentType());
+        assertEquals(requestId, dto.getRequestId());
+        assertEquals(true, dto.getPgOrderNo() != null && dto.getPgOrderNo().startsWith(FakePgClient.STUB_PG_ORDER_PREFIX));
+    }
+
+    @Test
+    void 결제승인_성공_ACCEPTED가_PAID로() {
+        Long guestId = 5L;
+        Long requestId = 50L;
+        MatchRequest mr = acceptedMatchRequest(requestId, guestId, 20L);
+        Payment payment = pendingPayment(400L, guestId, mr, "LM-FAKE-test-order", 25000);
+
+        PaymentConfirmRequest confirm = new PaymentConfirmRequest();
+        setField(confirm, "pgOrderNo", "LM-FAKE-test-order");
+        setField(confirm, "amount", 25000);
+
+        when(paymentRepository.findByPgOrderNo("LM-FAKE-test-order")).thenReturn(Optional.of(payment));
+        when(fakePgClient.approvePayment("LM-FAKE-test-order", 25000, 400L)).thenReturn("FAKE-TXN-400");
+
+        PaymentResponseDto dto = paymentService.confirmPayment(guestId, confirm);
+
+        assertEquals(PaymentStatus.COMPLETED, dto.getStatus());
+        assertEquals("FAKE-TXN-400", dto.getPgTransactionId());
+        assertEquals(MatchRequestStatus.PAID, mr.getStatus());
+        assertEquals(true, dto.getPaidAt() != null && dto.getRefundDeadline() != null);
+    }
+
+    @Test
+    void 결제승인_금액불일치면_예외() {
+        Long guestId = 5L;
+        Long requestId = 50L;
+        MatchRequest mr = acceptedMatchRequest(requestId, guestId, 20L);
+        Payment payment = pendingPayment(401L, guestId, mr, "LM-FAKE-x", 25000);
+
+        PaymentConfirmRequest confirm = new PaymentConfirmRequest();
+        setField(confirm, "pgOrderNo", "LM-FAKE-x");
+        setField(confirm, "amount", 1);
+
+        when(paymentRepository.findByPgOrderNo("LM-FAKE-x")).thenReturn(Optional.of(payment));
+
+        MatchingException ex = assertThrows(MatchingException.class,
+                () -> paymentService.confirmPayment(guestId, confirm));
+        assertEquals(MatchingErrorCode.PAYMENT_AMOUNT_MISMATCH, ex.getErrorCode());
+    }
+
+    @Test
+    void 결제조회_게스트_타인건이면_예외() {
+        Payment payment = completedPayment(500L, 99L, LocalDateTime.now().plusMinutes(10));
+        when(paymentRepository.findById(500L)).thenReturn(Optional.of(payment));
+
+        MatchingException ex = assertThrows(MatchingException.class,
+                () -> paymentService.getPaymentForGuest(10L, 500L));
+        assertEquals(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED, ex.getErrorCode());
+    }
+
+    @Test
+    void 결제조회_가이드_본인매칭이면_성공() {
+        Long guideProfileId = 20L;
+        Long guestId = 5L;
+        Long requestId = 50L;
+        MatchRequest mr = acceptedMatchRequest(requestId, guestId, guideProfileId);
+        Payment payment = completedPayment(600L, guestId, LocalDateTime.now().plusMinutes(10));
+        setField(payment, "matchRequest", mr);
+
+        when(paymentRepository.findById(600L)).thenReturn(Optional.of(payment));
+
+        PaymentResponseDto dto = paymentService.getPaymentForGuide(guideProfileId, 600L);
+        assertEquals(600L, dto.getPaymentId());
+        verify(paymentRepository).findById(600L);
+    }
+
+    private MatchRequest acceptedMatchRequest(Long id, Long guestId, Long guideId) {
+        MatchRequest mr = MatchRequest.builder()
+                .id(id)
+                .guestId(guestId)
+                .guideId(guideId)
+                .destination("Seoul")
+                .desiredDate(LocalDate.now())
+                .build();
+        setField(mr, "status", MatchRequestStatus.ACCEPTED);
+        return mr;
+    }
+
+    private Payment pendingPayment(Long paymentId, Long payerId, MatchRequest mr, String pgOrderNo, int amount) {
+        return Payment.builder()
+                .id(paymentId)
+                .matchRequest(mr)
+                .payerId(payerId)
+                .amount(amount)
+                .paymentType("ACCOMPANY")
+                .pgOrderNo(pgOrderNo)
+                .status(PaymentStatus.PENDING)
+                .build();
+    }
+
+    private PaymentCreateRequest paymentCreate(Long matchRequestId, int amount, String type) {
+        PaymentCreateRequest dto = new PaymentCreateRequest();
+        setField(dto, "matchRequestId", matchRequestId);
+        setField(dto, "amount", amount);
+        setField(dto, "paymentType", type);
+        return dto;
     }
 
     private Payment completedPayment(Long paymentId, Long payerId, LocalDateTime refundDeadline) {

--- a/backend/module-domain/src/test/java/com/team6/domain/member/MemberApplicationTest.java
+++ b/backend/module-domain/src/test/java/com/team6/domain/member/MemberApplicationTest.java
@@ -1,7 +1,10 @@
 package com.team6.domain.member;
 
+import com.team6.domain.auth.config.PasswordConfig;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Import;
 
 @SpringBootApplication
+@Import(PasswordConfig.class)
 public class MemberApplicationTest {
 }


### PR DESCRIPTION
# 🔗 이슈 번호
- Closes #113 

---

## 💡 주요 변경 사항
### 1. 인증·인가
- JWT role claim을 Spring Security 권한으로 매핑해 role 기반 인가 동작 보완
- AuthController 로그아웃 시 Authorization 헤더 처리 정리

### 2. 도메인·DB
- Member.socialType에 @Enumerated(EnumType.STRING) 적용 (DB enum과 정합성)
- matching — JWT 연동
- 컨트롤러에서 guestId / guideId 외부 입력 제거, 토큰 기반 member 조회 및 GUEST/GUIDE 역할 검증
- TourExtension 조회 권한 강화(해당 게스트·가이드만)

### 3. matching — Stub 결제(E2E, PG 연동 전)
- FakePgClient / StubFakePgClient로 로컬·테스트 검증
- 결제 요청(PENDING) → 승인(COMPLETED, paidAt, refundDeadline +2h) → 조회 → 환불 흐름 연결
- PaymentService, PaymentController에서 생성·승인·조회·환불 API 제공

### 4. F05-04 환불
- 게스트 환불 신청/처리(결제 후 2시간 이내, 중복 방지, aiProcessed 반영, 신청 즉시 승인 처리)
- 컨트롤러·검증 정리
- MatchRequestCreateRequest.guideId 주석: guide_profiles.id (member.id 아님)
- 가이드 액션: JWT의 member.id → guide_profiles.id 조회 후 사용 (목록, 거절, 제안, 가이드 취소)
- 매칭 생성 시 guideId가 guide_profiles에 존재하는지 검증
- TourExtensionController 조회: 게스트는 member 기준, 가이드는 guide_profiles.id로 변환해 권한과 일치


---

## ⚠️ 주의 사항 / 질문
- 경로 변경: 가이드 목록 조회가 JWT 기준 /matching/requests/guides/me 이면 프론트 엔드포인트 동기화 필요
- 환불: F05-04에 맞춰 신청과 동시에 승인 완료로 처리함 (추후 “신청만 / 관리자 승인” 분리 시 API·상태 설계 논의)
- 보안: @PreAuthorize 등 메서드 단 보안은 아직 없고, 컨트롤러 내부 역할 검증 위주 — 통합 테스트·@PreAuthorize 도입은 후속
- 공개 API: 비로그인 허용 경로는 SecurityConfig의 requestMatchers에만 추가하고, 나머지는 로그인 필요
- 리뷰 시 JWT → member → guide_profiles.id 변환이 모든 가이드 API에 일관되는지, 결제·연장·매칭 권한이 누락 없는지 봐주시면 좋습니다.

---

## ✅ 체크리스트
- [x] 빌드가 정상적으로 되는가?
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [x] .gitignore에 설정 파일이 잘 포함되었는가? (application-local.yml 등)\
- [ ] 로그인 불필요 API는 SecurityConfig에 requestMatchers로 명시했는가? (그 외 경로는 기본 인증 필요)