### PR TITLE
가이드 스케줄 연동(pending/paid-confirm/cancel) 및 scheduleId JSON 호환

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -4,6 +4,7 @@
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/LocalGuest.iml" filepath="$PROJECT_DIR$/.idea/LocalGuest.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/api-server/backend.api-server.main.iml" filepath="$PROJECT_DIR$/.idea/modules/api-server/backend.api-server.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/module-ai-integration/backend.module-ai-integration.main.iml" filepath="$PROJECT_DIR$/.idea/modules/module-ai-integration/backend.module-ai-integration.main.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/module-ai/backend.module-ai.main.iml" filepath="$PROJECT_DIR$/.idea/modules/module-ai/backend.module-ai.main.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/module-chat/backend.module-chat.main.iml" filepath="$PROJECT_DIR$/.idea/modules/module-chat/backend.module-chat.main.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/module-common/backend.module-common.main.iml" filepath="$PROJECT_DIR$/.idea/modules/module-common/backend.module-common.main.iml" />

--- a/.idea/modules/module-ai-integration/backend.module-ai-integration.main.iml
+++ b/.idea/modules/module-ai-integration/backend.module-ai-integration.main.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="AdditionalModuleElements">
+    <content url="file://$MODULE_DIR$/../../../backend/module-ai-integration/build/generated/sources/annotationProcessor/java/main">
+      <sourceFolder url="file://$MODULE_DIR$/../../../backend/module-ai-integration/build/generated/sources/annotationProcessor/java/main" isTestSource="false" generated="true" />
+    </content>
+  </component>
+</module>

--- a/backend/api-server/src/main/java/com/team6/apiserver/config/OpenApiSecurityConfig.java
+++ b/backend/api-server/src/main/java/com/team6/apiserver/config/OpenApiSecurityConfig.java
@@ -1,0 +1,22 @@
+package com.team6.apiserver.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+        security = @SecurityRequirement(name = "bearerAuth")
+)
+@SecurityScheme(
+        name = "bearerAuth",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT",
+        in = SecuritySchemeIn.HEADER
+)
+public class OpenApiSecurityConfig {
+}

--- a/backend/module-domain/src/main/java/com/team6/domain/guide/controller/GuideScheduleController.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/controller/GuideScheduleController.java
@@ -131,7 +131,7 @@ public class GuideScheduleController {
         return ResponseEntity.ok(guideScheduleService.markAsBooked(scheduleId, guideId));
     }
 
-    // [matching 연동] 결제 완료 확정 — matching 도메인이 PAID 전환 시 호출, courseDetail 잠금 해제
+    // [matching 연동] BOOKED 스케줄 결제 확정 — isPaid=true, courseDetail 잠금 해제 (가이드 수락 후 결제 흐름)
     @PatchMapping("/{scheduleId}/paid-confirm")
     public ResponseEntity<GuideScheduleResponse> markAsPaid(
             @PathVariable Long guideId,
@@ -140,7 +140,7 @@ public class GuideScheduleController {
         return ResponseEntity.ok(guideScheduleService.markAsPaid(scheduleId, guideId));
     }
 
-    // [matching 연동] BOOKED → AVAILABLE 복구 — matching 도메인이 취소 시 호출 (F05-01/02)
+    // [matching 연동] PENDING·BOOKED → AVAILABLE — 매칭 거절/취소 시 matching 도메인이 호출 (F03/F05)
     @PatchMapping("/{scheduleId}/cancel")
     public ResponseEntity<GuideScheduleResponse> cancelToAvailable(
             @PathVariable Long guideId,

--- a/backend/module-domain/src/main/java/com/team6/domain/guide/entity/GuideSchedule.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/entity/GuideSchedule.java
@@ -94,10 +94,19 @@ public class GuideSchedule extends BaseTimeEntity {
         this.matchRequestId = matchRequestId;
     }
 
-    // 결제 완료 처리 — matching 도메인이 PAID 전환 시 호출
-    // PROPOSED → BOOKED 전환 + isPaid = true 동시 처리, courseDetail 잠금 해제
+    /**
+     * 결제 완료 처리 — 가이드 수락 등으로 이미 BOOKED인 경우 isPaid만 true로 설정해 courseDetail 잠금을 해제한다.
+     */
     public void markAsPaid() {
-        this.status = GuideScheduleStatus.BOOKED;
         this.isPaid = true;
+    }
+
+    /**
+     * 매칭 취소·거절 시 스케줄을 다시 예약 가능하게 복구한다. PENDING·BOOKED 모두 허용.
+     */
+    public void releaseMatchToAvailable() {
+        this.status = GuideScheduleStatus.AVAILABLE;
+        this.matchRequestId = null;
+        this.isPaid = false;
     }
 }

--- a/backend/module-domain/src/main/java/com/team6/domain/guide/exception/GuideErrorCode.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/exception/GuideErrorCode.java
@@ -24,6 +24,7 @@ public enum GuideErrorCode {
     SCHEDULE_NOT_AVAILABLE(409, "예약 가능 상태인 스케줄이 아닙니다"),
     SCHEDULE_NOT_PENDING(409, "대기 중인 스케줄이 아닙니다"),
     SCHEDULE_NOT_BOOKED(409, "예약 확정 상태인 스케줄이 아닙니다"),
+    SCHEDULE_MATCH_RELEASE_INVALID(409, "매칭 대기(PENDING) 또는 예약 확정(BOOKED) 상태의 스케줄만 복구할 수 있습니다"),
     SCHEDULE_INVALID_TIME(400, "시작 시간은 종료 시간보다 이전이어야 합니다"),
     SCHEDULE_STATUS_INVALID(400, "AVAILABLE 또는 BLOCKED 상태로만 변경할 수 있습니다"),
 

--- a/backend/module-domain/src/main/java/com/team6/domain/guide/service/GuideProfileService.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/service/GuideProfileService.java
@@ -17,6 +17,8 @@ import com.team6.domain.guide.repository.GuideCareerRepository;
 import com.team6.domain.guide.repository.GuideFeedRepository;
 import com.team6.domain.guide.repository.GuideImageRepository;
 import com.team6.domain.guide.repository.GuideProfileRepository;
+import com.team6.domain.matching.entity.enums.PaymentStatus;
+import com.team6.domain.matching.repository.PaymentRepository;
 import com.team6.domain.member.entity.Member;
 import com.team6.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -38,6 +40,7 @@ public class GuideProfileService {
     private final GuideFeedRepository guideFeedRepository;
     private final GuideCareerRepository guideCareerRepository;
     private final GuideImageRepository guideImageRepository;
+    private final PaymentRepository paymentRepository;
 
     // 가이드 프로필 등록 (F06-01)
     @Transactional
@@ -130,11 +133,16 @@ public class GuideProfileService {
             throw new GuideException(GuideErrorCode.GUIDE_UNAUTHORIZED);
         }
 
-        // TODO: matching 도메인 Payment 확정 후 실제 정산 로직으로 교체
+        BigDecimal expected = paymentRepository
+                .findByMatchRequest_GuideIdAndStatus(guideId, PaymentStatus.COMPLETED)
+                .stream()
+                .map(p -> BigDecimal.valueOf(p.getAmount()))
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
         return GuideSettlementResponse.builder()
                 .guideId(guideId)
-                .expectedAmount(BigDecimal.ZERO)
-                .description("정산 기능 준비 중입니다")
+                .expectedAmount(expected)
+                .description("매칭 결제 완료(COMPLETED) 금액 합계(플랫폼 수수료·정산 규칙 적용 전)")
                 .build();
     }
 

--- a/backend/module-domain/src/main/java/com/team6/domain/guide/service/GuideScheduleService.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/service/GuideScheduleService.java
@@ -237,34 +237,30 @@ public class GuideScheduleService {
         return GuideScheduleResponse.from(schedule);
     }
 
-    // [matching 연동] 결제 완료 확정 — matching 도메인이 PAID 전환 시 호출
-    // PENDING → BOOKED + isPaid = true 동시 처리, courseDetail 잠금 해제
+    // [matching 연동] 결제 완료 확정 — acceptSchedule 등으로 이미 BOOKED인 경우 isPaid만 true (courseDetail 잠금 해제)
     @Transactional
     public GuideScheduleResponse markAsPaid(Long scheduleId, Long guideId) {
         GuideSchedule schedule = getVerifiedSchedule(scheduleId, guideId);
 
-        if (schedule.getStatus() != GuideScheduleStatus.PENDING) {
-            throw new GuideException(GuideErrorCode.SCHEDULE_NOT_PENDING);
+        if (schedule.getStatus() != GuideScheduleStatus.BOOKED) {
+            throw new GuideException(GuideErrorCode.SCHEDULE_NOT_BOOKED);
         }
 
         schedule.markAsPaid();
         return GuideScheduleResponse.from(schedule);
     }
 
-    // [matching 연동] PENDING → AVAILABLE 복구 — matching 도메인이 취소 시 호출
+    // [matching 연동] PENDING 또는 BOOKED → AVAILABLE — 매칭 거절·취소 시 matching 도메인이 호출 (F03/F05)
     @Transactional
     public GuideScheduleResponse cancelToAvailable(Long scheduleId, Long guideId) {
-        // 스케줄 조회
         GuideSchedule schedule = getVerifiedSchedule(scheduleId, guideId);
 
-        // PENDING 상태인지 확인 (복구는 대기 중 상태에서만 허용)
-        if (schedule.getStatus() != GuideScheduleStatus.PENDING) {
-            throw new GuideException(GuideErrorCode.SCHEDULE_NOT_PENDING);
+        if (schedule.getStatus() != GuideScheduleStatus.PENDING
+                && schedule.getStatus() != GuideScheduleStatus.BOOKED) {
+            throw new GuideException(GuideErrorCode.SCHEDULE_MATCH_RELEASE_INVALID);
         }
 
-        // 상태 복구: PENDING → AVAILABLE
-        schedule.changeStatus(GuideScheduleStatus.AVAILABLE);
-
+        schedule.releaseMatchToAvailable();
         return GuideScheduleResponse.from(schedule);
     }
 

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/client/GuideScheduleSyncClient.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/client/GuideScheduleSyncClient.java
@@ -1,0 +1,17 @@
+package com.team6.domain.matching.client;
+
+public interface GuideScheduleSyncClient {
+
+    /**
+     * 스케줄 AVAILABLE → PENDING 및 match_request_id 연결. 가이드 API는 matchRequestId 쿼리 파라미터를 요구한다.
+     */
+    void markPending(Long guideId, Long scheduleId, Long matchRequestId, Long actorMemberId);
+
+    void cancelToAvailable(Long guideId, Long scheduleId, Long actorMemberId);
+
+    /**
+     * 결제 승인 후 가이드 스케줄이 이미 BOOKED인 경우 isPaid=true (paid-confirm).
+     * 가이드가 acceptSchedule로 PENDING→BOOKED 한 뒤 게스트가 결제하는 흐름에 맞춘다.
+     */
+    void confirmPaid(Long guideId, Long scheduleId, Long actorMemberId);
+}

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/client/HttpGuideScheduleSyncClient.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/client/HttpGuideScheduleSyncClient.java
@@ -1,0 +1,69 @@
+package com.team6.domain.matching.client;
+
+import com.team6.domain.matching.exception.MatchingErrorCode;
+import com.team6.domain.matching.exception.MatchingException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class HttpGuideScheduleSyncClient implements GuideScheduleSyncClient {
+
+    private static final String USER_ID_HEADER = "X-User-Id";
+
+    @Value("${matching.guide-sync.base-url:http://localhost:8080/api}")
+    private String guideSyncBaseUrl;
+
+    @Override
+    public void markPending(Long guideId, Long scheduleId, Long matchRequestId, Long actorMemberId) {
+        patch(guideId, scheduleId, "/pending", actorMemberId, matchRequestId);
+    }
+
+    @Override
+    public void cancelToAvailable(Long guideId, Long scheduleId, Long actorMemberId) {
+        patch(guideId, scheduleId, "/cancel", actorMemberId, null);
+    }
+
+    @Override
+    public void confirmPaid(Long guideId, Long scheduleId, Long actorMemberId) {
+        patch(guideId, scheduleId, "/paid-confirm", actorMemberId, null);
+    }
+
+    private void patch(Long guideId, Long scheduleId, String actionPath, Long actorMemberId, Long matchRequestId) {
+        try {
+            String uri = guideSyncBaseUrl + "/guides/" + guideId + "/schedules/" + scheduleId + actionPath;
+            if (matchRequestId != null) {
+                uri = uri + "?matchRequestId=" + matchRequestId;
+            }
+            RestClient.RequestBodySpec req = RestClient.create().patch()
+                    .uri(uri)
+                    .header(HttpHeaders.CONTENT_TYPE, "application/json")
+                    .header(USER_ID_HEADER, String.valueOf(actorMemberId));
+
+            String authHeader = resolveAuthorizationHeader();
+            if (authHeader != null && !authHeader.isBlank()) {
+                req.header(HttpHeaders.AUTHORIZATION, authHeader);
+            }
+
+            req.retrieve().toBodilessEntity();
+        } catch (Exception e) {
+            log.error("[GuideSync] 스케줄 동기화 실패 — guideId={}, scheduleId={}, action={}, actorId={}",
+                    guideId, scheduleId, actionPath, actorMemberId, e);
+            throw new MatchingException(MatchingErrorCode.GUIDE_SCHEDULE_SYNC_FAILED);
+        }
+    }
+
+    private String resolveAuthorizationHeader() {
+        if (!(RequestContextHolder.getRequestAttributes() instanceof ServletRequestAttributes attrs)) {
+            return null;
+        }
+        return attrs.getRequest().getHeader(HttpHeaders.AUTHORIZATION);
+    }
+}

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/client/HttpKakaoPayClient.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/client/HttpKakaoPayClient.java
@@ -1,0 +1,123 @@
+package com.team6.domain.matching.client;
+
+import com.team6.domain.matching.exception.MatchingErrorCode;
+import com.team6.domain.matching.exception.MatchingException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientResponseException;
+
+import java.util.Map;
+import java.util.Objects;
+
+@Slf4j
+@Component
+public class HttpKakaoPayClient implements KakaoPayClient {
+
+    @Value("${kakaopay.base-url:https://open-api.kakaopay.com}")
+    private String baseUrl;
+
+    @Value("${kakaopay.secret-key:}")
+    private String secretKey;
+
+    @Value("${kakaopay.cid:TC0ONETIME}")
+    private String cid;
+
+    @Value("${kakaopay.approval-url:http://localhost:8080/api/matching/payments/kakao/success}")
+    private String approvalUrl;
+
+    @Value("${kakaopay.cancel-url:http://localhost:8080/api/matching/payments/kakao/cancel}")
+    private String cancelUrl;
+
+    @Value("${kakaopay.fail-url:http://localhost:8080/api/matching/payments/kakao/fail}")
+    private String failUrl;
+
+    @Override
+    public ReadyResult ready(String partnerOrderId, String partnerUserId, String itemName, int totalAmount) {
+        validateSecretKey();
+
+        Map<String, Object> body = Map.of(
+                "cid", cid,
+                "partner_order_id", partnerOrderId,
+                "partner_user_id", partnerUserId,
+                "item_name", itemName,
+                "quantity", 1,
+                "total_amount", totalAmount,
+                "tax_free_amount", 0,
+                "approval_url", approvalUrl,
+                "cancel_url", cancelUrl,
+                "fail_url", failUrl
+        );
+
+        try {
+            Map<?, ?> response = RestClient.create().post()
+                    .uri(baseUrl + "/online/v1/payment/ready")
+                    .header(HttpHeaders.AUTHORIZATION, "SECRET_KEY " + secretKey)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .body(body)
+                    .retrieve()
+                    .body(Map.class);
+
+            String tid = getRequiredString(response, "tid");
+            String redirectUrl = getRequiredString(response, "next_redirect_pc_url");
+            return new ReadyResult(tid, redirectUrl);
+        } catch (RestClientResponseException e) {
+            log.error("[KakaoPay] ready 호출 실패 - status={}, body={}", e.getStatusCode(), e.getResponseBodyAsString(), e);
+            throw new MatchingException(MatchingErrorCode.PAYMENT_PG_VERIFICATION_FAILED);
+        } catch (Exception e) {
+            log.error("[KakaoPay] ready 호출 실패 - partnerOrderId={}", partnerOrderId, e);
+            throw new MatchingException(MatchingErrorCode.PAYMENT_PG_VERIFICATION_FAILED);
+        }
+    }
+
+    @Override
+    public ApproveResult approve(String tid, String partnerOrderId, String partnerUserId, String pgToken) {
+        validateSecretKey();
+
+        Map<String, Object> body = Map.of(
+                "cid", cid,
+                "tid", tid,
+                "partner_order_id", partnerOrderId,
+                "partner_user_id", partnerUserId,
+                "pg_token", pgToken
+        );
+
+        try {
+            Map<?, ?> response = RestClient.create().post()
+                    .uri(baseUrl + "/online/v1/payment/approve")
+                    .header(HttpHeaders.AUTHORIZATION, "SECRET_KEY " + secretKey)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .body(body)
+                    .retrieve()
+                    .body(Map.class);
+
+            String aid = getRequiredString(response, "aid");
+            return new ApproveResult(aid);
+        } catch (RestClientResponseException e) {
+            log.error("[KakaoPay] approve 호출 실패 - status={}, body={}", e.getStatusCode(), e.getResponseBodyAsString(), e);
+            throw new MatchingException(MatchingErrorCode.PAYMENT_PG_VERIFICATION_FAILED);
+        } catch (Exception e) {
+            log.error("[KakaoPay] approve 호출 실패 - tid={}, partnerOrderId={}", tid, partnerOrderId, e);
+            throw new MatchingException(MatchingErrorCode.PAYMENT_PG_VERIFICATION_FAILED);
+        }
+    }
+
+    private void validateSecretKey() {
+        if (secretKey == null || secretKey.isBlank()) {
+            throw new MatchingException(MatchingErrorCode.INVALID_REQUEST);
+        }
+    }
+
+    private String getRequiredString(Map<?, ?> response, String key) {
+        Object value = response == null ? null : response.get(key);
+        if (Objects.toString(value, "").isBlank()) {
+            throw new MatchingException(MatchingErrorCode.PAYMENT_PG_VERIFICATION_FAILED);
+        }
+        return Objects.toString(value);
+    }
+}

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/client/KakaoPayClient.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/client/KakaoPayClient.java
@@ -1,0 +1,12 @@
+package com.team6.domain.matching.client;
+
+public interface KakaoPayClient {
+
+    ReadyResult ready(String partnerOrderId, String partnerUserId, String itemName, int totalAmount);
+
+    ApproveResult approve(String tid, String partnerOrderId, String partnerUserId, String pgToken);
+
+    record ReadyResult(String tid, String redirectUrl) {}
+
+    record ApproveResult(String aid) {}
+}

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/dto/request/MatchRequestCreateRequest.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/dto/request/MatchRequestCreateRequest.java
@@ -1,7 +1,10 @@
 package com.team6.domain.matching.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -17,6 +20,17 @@ public class MatchRequestCreateRequest {
      * member.id가 아닌 guide_profiles PK를 전달해야 한다.
      */
     private Long guideId;
+
+    /**
+     * 가이드 스케줄 식별자 (guide_schedules.id)
+     * 매칭 생성 시 해당 슬롯을 PENDING으로 잠그기 위해 전달한다.
+     * JSON: {@code scheduleId} (가이드 API와 동일). {@code guideScheduleId}도 수신 호환.
+     */
+    @NotNull
+    @Positive
+    @JsonProperty("scheduleId")
+    @JsonAlias("guideScheduleId")
+    private Long guideScheduleId;
 
     @NotBlank
     private String destination;

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/dto/request/PaymentConfirmRequest.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/dto/request/PaymentConfirmRequest.java
@@ -19,4 +19,10 @@ public class PaymentConfirmRequest {
     @NotNull
     @Positive
     private Integer amount;
+
+    /**
+     * 카카오페이 승인용 pg_token.
+     * Stub/Fake 결제에서는 비워도 되며, 카카오 결제 모드에서만 사용한다.
+     */
+    private String pgToken;
 }

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/dto/response/MatchRequestCreateResponse.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/dto/response/MatchRequestCreateResponse.java
@@ -1,6 +1,8 @@
 package com.team6.domain.matching.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.team6.domain.matching.entity.MatchRequest;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -14,6 +16,8 @@ public class MatchRequestCreateResponse {
     private Long requestId;
     private Long guestId;
     private Long guideId;
+    @Getter(AccessLevel.NONE)
+    private Long guideScheduleId;
     private String destination;
     private String concept;
     private String conceptSummary;
@@ -24,11 +28,17 @@ public class MatchRequestCreateResponse {
     private String status;
     private LocalDateTime createdAt;
 
+    @JsonProperty("scheduleId")
+    public Long getGuideScheduleId() {
+        return guideScheduleId;
+    }
+
     public static MatchRequestCreateResponse from(MatchRequest entity) {
         return MatchRequestCreateResponse.builder()
                 .requestId(entity.getId())
                 .guestId(entity.getGuestId())
                 .guideId(entity.getGuideId())
+                .guideScheduleId(entity.getGuideScheduleId())
                 .destination(entity.getDestination())
                 .concept(entity.getConcept())
                 .conceptSummary(entity.getConceptSummary())

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/dto/response/PaymentResponseDto.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/dto/response/PaymentResponseDto.java
@@ -16,7 +16,8 @@ public class PaymentResponseDto {
     private String paymentType;          // CHAT/ACCOMPANY/EXTENSION
     private PaymentStatus status;        // 결제 상태
     private String pgOrderNo;            // PG 주문번호 (승인 요청 시 사용)
-    private String pgTransactionId;    // PG 거래 ID (완료 후)
+    private String pgTransactionId;      // PG 거래 ID (완료 후)
+    private String redirectUrl;          // 카카오 결제창 URL (ready 응답)
     private LocalDateTime paidAt;        // 결제 완료일시
     private LocalDateTime refundDeadline; // 환불 마감일시
 
@@ -30,6 +31,21 @@ public class PaymentResponseDto {
                 .status(payment.getStatus())
                 .pgOrderNo(payment.getPgOrderNo())
                 .pgTransactionId(payment.getPgTransactionId())
+                .paidAt(payment.getPaidAt())
+                .refundDeadline(payment.getRefundDeadline())
+                .build();
+    }
+
+    public static PaymentResponseDto from(Payment payment, String redirectUrl) {
+        return PaymentResponseDto.builder()
+                .paymentId(payment.getId())
+                .requestId(payment.getMatchRequest().getId())
+                .amount(payment.getAmount())
+                .paymentType(payment.getPaymentType())
+                .status(payment.getStatus())
+                .pgOrderNo(payment.getPgOrderNo())
+                .pgTransactionId(payment.getPgTransactionId())
+                .redirectUrl(redirectUrl)
                 .paidAt(payment.getPaidAt())
                 .refundDeadline(payment.getRefundDeadline())
                 .build();

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/entity/MatchRequest.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/entity/MatchRequest.java
@@ -43,6 +43,9 @@ public class MatchRequest extends BaseTimeEntity {
     @Column(name = "guide_id", nullable = false)
     private Long guideId;
 
+    @Column(name = "guide_schedule_id", nullable = false)
+    private Long guideScheduleId;
+
     @Column(nullable = false)
     private String destination;         // 여행 목적지
 
@@ -85,6 +88,7 @@ public class MatchRequest extends BaseTimeEntity {
     public static MatchRequest create(
             Long guestId,
             Long guideId,
+            Long guideScheduleId,
             String destination,
             String concept,
             String conceptSummary,
@@ -94,6 +98,7 @@ public class MatchRequest extends BaseTimeEntity {
         return MatchRequest.builder()
                 .guestId(guestId)
                 .guideId(guideId)
+                .guideScheduleId(guideScheduleId)
                 .destination(destination)
                 .concept(concept)
                 .conceptSummary(conceptSummary)
@@ -160,6 +165,18 @@ public class MatchRequest extends BaseTimeEntity {
             this.status = MatchRequestStatus.PAID;
             log.info("[Payment] 매칭 요청 결제 반영 — status=PAID, requestId={}", this.id);
         }
+    }
+
+    /**
+     * 게스트가 가이드 제안(수락 대기)을 거절할 때 — 취소(CANCELLED)와 구분하기 위해 REJECTED로 전이한다.
+     */
+    public void declineProposalByGuest(String reason) {
+        if (this.status != MatchRequestStatus.ACCEPTED) {
+            throw new MatchingException(MatchingErrorCode.MATCH_REQUEST_INVALID_STATUS);
+        }
+        this.status = MatchRequestStatus.REJECTED;
+        this.cancelReason = reason;
+        log.info("[F03-06] 게스트 제안 거절 — status=REJECTED, requestId={}", this.id);
     }
 
     // 게스트 취소 처리 (F05-01)

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/entity/Payment.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/entity/Payment.java
@@ -82,6 +82,11 @@ public class Payment extends BaseTimeEntity {
         this.refundDeadline = this.paidAt.plusHours(2); // 환불 마감 = 결제 완료 + 2시간
     }
 
+    // 승인 전 단계에서 PG 거래 식별자(tid 등)만 임시 저장
+    public void storePgTransactionId(String pgTransactionId) {
+        this.pgTransactionId = pgTransactionId;
+    }
+
     // 취소 처리
     public void cancel() {
         this.status = PaymentStatus.CANCELLED;

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/exception/MatchingErrorCode.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/exception/MatchingErrorCode.java
@@ -21,6 +21,7 @@ public enum MatchingErrorCode {
     PAYMENT_DUPLICATE_TYPE(400, "해당 매칭 요청에 동일 유형의 결제가 이미 존재합니다"),
     PAYMENT_AMOUNT_MISMATCH(400, "결제 금액이 일치하지 않습니다"),
     PAYMENT_PG_VERIFICATION_FAILED(400, "PG 승인 검증에 실패했습니다"),
+    GUIDE_SCHEDULE_SYNC_FAILED(502, "가이드 스케줄 상태 동기화에 실패했습니다"),
 
     // Refund 관련
     REFUND_DEADLINE_EXCEEDED(400, "환불 가능 시간(2시간)이 초과되었습니다"),

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/repository/PaymentRepository.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/repository/PaymentRepository.java
@@ -21,4 +21,7 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
     // 게스트 ID + 상태로 조회
     List<Payment> findByPayerIdAndStatus(Long payerId, PaymentStatus status);
+
+    // 가이드 프로필 ID 기준 완료 결제 — 정산 예정 금액 집계용
+    List<Payment> findByMatchRequest_GuideIdAndStatus(Long guideId, PaymentStatus status);
 }

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/service/MatchRequestService.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/service/MatchRequestService.java
@@ -1,5 +1,7 @@
 package com.team6.domain.matching.service;
 
+import com.team6.domain.guide.repository.GuideProfileRepository;
+import com.team6.domain.matching.client.GuideScheduleSyncClient;
 import com.team6.domain.matching.dto.request.MatchRequestCreateRequest;
 import com.team6.domain.matching.dto.request.MatchRequestDeclineRequest;
 import com.team6.domain.matching.dto.request.MatchRequestProposeRequest;
@@ -25,6 +27,8 @@ import java.util.Locale;
 public class MatchRequestService {
 
     private final MatchRequestRepository matchRequestRepository;
+    private final GuideScheduleSyncClient guideScheduleSyncClient;
+    private final GuideProfileRepository guideProfileRepository;
 
     // 매칭 요청 생성
     public MatchRequestCreateResponse createMatchRequest(Long guestId, MatchRequestCreateRequest request) {
@@ -34,6 +38,7 @@ public class MatchRequestService {
         MatchRequest matchRequest = MatchRequest.create(
                 guestId,
                 request.getGuideId(),
+                request.getGuideScheduleId(),
                 request.getDestination(),
                 request.getConcept(),
                 conceptSummary,
@@ -41,8 +46,11 @@ public class MatchRequestService {
                 request.getDesiredBudget()
         );
 
+        MatchRequest saved = matchRequestRepository.save(matchRequest);
+        Long guideMemberId = resolveGuideMemberId(saved.getGuideId());
+        guideScheduleSyncClient.markPending(saved.getGuideId(), saved.getGuideScheduleId(), saved.getId(), guideMemberId);
         log.info("[F03-04] 매칭 요청 생성 — guestId={}, guideId={}", guestId, request.getGuideId());
-        return MatchRequestCreateResponse.from(matchRequestRepository.save(matchRequest));
+        return MatchRequestCreateResponse.from(saved);
     }
 
     // 가이드의 매칭 요청 목록 조회
@@ -63,6 +71,8 @@ public class MatchRequestService {
         }
 
         matchRequest.reject();
+        Long guideMemberId = resolveGuideMemberId(matchRequest.getGuideId());
+        guideScheduleSyncClient.cancelToAvailable(matchRequest.getGuideId(), matchRequest.getGuideScheduleId(), guideMemberId);
         log.info("[MatchRequest] 가이드 거절 — requestId={}, guideId={}", requestId, guideId);
         return MatchRequestActionResponse.from(matchRequest);
     }
@@ -104,7 +114,9 @@ public class MatchRequestService {
             throw new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED);
         }
 
-        matchRequest.cancelByGuest(request.getReason());
+        matchRequest.declineProposalByGuest(request.getReason());
+        Long guideMemberId = resolveGuideMemberId(matchRequest.getGuideId());
+        guideScheduleSyncClient.cancelToAvailable(matchRequest.getGuideId(), matchRequest.getGuideScheduleId(), guideMemberId);
         log.info("[F03-06] 게스트 최종 거절 — requestId={}, guestId={}", requestId, guestId);
         return MatchRequestActionResponse.from(matchRequest);
     }
@@ -119,6 +131,8 @@ public class MatchRequestService {
         }
 
         matchRequest.cancelByGuest(reason);
+        Long guideMemberId = resolveGuideMemberId(matchRequest.getGuideId());
+        guideScheduleSyncClient.cancelToAvailable(matchRequest.getGuideId(), matchRequest.getGuideScheduleId(), guideMemberId);
         log.info("[F05-01] 게스트 취소 완료 — requestId={}, guestId={}", requestId, guestId);
         return MatchRequestActionResponse.from(matchRequest);
     }
@@ -133,6 +147,8 @@ public class MatchRequestService {
         }
 
         matchRequest.cancelByGuide(reason);
+        Long guideMemberId = resolveGuideMemberId(matchRequest.getGuideId());
+        guideScheduleSyncClient.cancelToAvailable(matchRequest.getGuideId(), matchRequest.getGuideScheduleId(), guideMemberId);
         log.info("[F05-02] 가이드 취소 완료 — requestId={}, guideId={}", requestId, guideId);
         return MatchRequestActionResponse.from(matchRequest);
     }
@@ -196,5 +212,11 @@ public class MatchRequestService {
         }
         NumberFormat nf = NumberFormat.getNumberInstance(Locale.KOREA);
         return nf.format(desiredBudget) + "원";
+    }
+
+    private Long resolveGuideMemberId(Long guideProfileId) {
+        return guideProfileRepository.findById(guideProfileId)
+                .map(guideProfile -> guideProfile.getMemberId())
+                .orElseThrow(() -> new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED));
     }
 }

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/service/PaymentService.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/service/PaymentService.java
@@ -1,6 +1,9 @@
 package com.team6.domain.matching.service;
 
+import com.team6.domain.guide.repository.GuideProfileRepository;
 import com.team6.domain.matching.client.FakePgClient;
+import com.team6.domain.matching.client.GuideScheduleSyncClient;
+import com.team6.domain.matching.client.KakaoPayClient;
 import com.team6.domain.matching.dto.request.PaymentConfirmRequest;
 import com.team6.domain.matching.dto.request.PaymentCreateRequest;
 import com.team6.domain.matching.dto.request.RefundRequestDto;
@@ -19,6 +22,7 @@ import com.team6.domain.matching.repository.PaymentRepository;
 import com.team6.domain.matching.repository.RefundRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,6 +39,12 @@ public class PaymentService {
     private final RefundRepository refundRepository;
     private final MatchRequestRepository matchRequestRepository;
     private final FakePgClient fakePgClient;
+    private final KakaoPayClient kakaoPayClient;
+    private final GuideScheduleSyncClient guideScheduleSyncClient;
+    private final GuideProfileRepository guideProfileRepository;
+
+    @Value("${matching.payment.provider:fake}")
+    private String paymentProvider;
 
     /**
      * 결제 요청 생성 — PENDING, Stub PG 주문번호 발급.
@@ -68,6 +78,18 @@ public class PaymentService {
                 .build();
 
         Payment saved = paymentRepository.save(payment);
+        if (isKakaoProvider()) {
+            String partnerUserId = String.valueOf(guestId);
+            String itemName = "LocalGuest " + request.getPaymentType();
+            KakaoPayClient.ReadyResult readyResult = kakaoPayClient.ready(
+                    saved.getPgOrderNo(),
+                    partnerUserId,
+                    itemName,
+                    saved.getAmount()
+            );
+            saved.storePgTransactionId(readyResult.tid());
+            return PaymentResponseDto.from(saved, readyResult.redirectUrl());
+        }
         log.info("[Payment] 결제 요청 생성 — paymentId={}, requestId={}, guestId={}, type={}, pgOrderNo={}",
                 saved.getId(), matchRequest.getId(), guestId, request.getPaymentType(), pgOrderNo);
         return PaymentResponseDto.from(saved);
@@ -95,11 +117,28 @@ public class PaymentService {
             throw new MatchingException(MatchingErrorCode.PAYMENT_NOT_PENDING);
         }
 
-        String pgTransactionId = fakePgClient.approvePayment(
-                payment.getPgOrderNo(), payment.getAmount(), payment.getId());
+        String pgTransactionId;
+        if (isKakaoProvider()) {
+            if (request.getPgToken() == null || request.getPgToken().isBlank()) {
+                throw new MatchingException(MatchingErrorCode.INVALID_REQUEST);
+            }
+            KakaoPayClient.ApproveResult approveResult = kakaoPayClient.approve(
+                    payment.getPgTransactionId(),
+                    payment.getPgOrderNo(),
+                    String.valueOf(guestId),
+                    request.getPgToken()
+            );
+            pgTransactionId = approveResult.aid();
+        } else {
+            pgTransactionId = fakePgClient.approvePayment(
+                    payment.getPgOrderNo(), payment.getAmount(), payment.getId());
+        }
 
         payment.complete(pgTransactionId);
         payment.getMatchRequest().markAsPaidIfAccepted();
+        Long guideMemberId = resolveGuideMemberId(payment.getMatchRequest().getGuideId());
+        // 가이드 acceptSchedule로 이미 BOOKED인 경우 isPaid만 반영 (book 호출 생략)
+        guideScheduleSyncClient.confirmPaid(payment.getMatchRequest().getGuideId(), payment.getMatchRequest().getGuideScheduleId(), guideMemberId);
 
         log.info("[Payment] Stub PG 승인 완료 — paymentId={}, pgTransactionId={}, paidAt={}, refundDeadline={}",
                 payment.getId(), pgTransactionId, payment.getPaidAt(), payment.getRefundDeadline());
@@ -164,5 +203,15 @@ public class PaymentService {
         log.info("[F05-04] 가이드 불만족 환불 처리 완료 — paymentId={}, guestId={}, refundId={}",
                 payment.getId(), guestId, saved.getId());
         return RefundResponseDto.from(saved);
+    }
+
+    private boolean isKakaoProvider() {
+        return "kakao".equalsIgnoreCase(paymentProvider);
+    }
+
+    private Long resolveGuideMemberId(Long guideProfileId) {
+        return guideProfileRepository.findById(guideProfileId)
+                .map(guideProfile -> guideProfile.getMemberId())
+                .orElseThrow(() -> new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED));
     }
 }

--- a/backend/module-domain/src/test/java/com/team6/domain/matching/service/PaymentServiceTest.java
+++ b/backend/module-domain/src/test/java/com/team6/domain/matching/service/PaymentServiceTest.java
@@ -1,6 +1,10 @@
 package com.team6.domain.matching.service;
 
+import com.team6.domain.guide.entity.GuideProfile;
+import com.team6.domain.guide.repository.GuideProfileRepository;
 import com.team6.domain.matching.client.FakePgClient;
+import com.team6.domain.matching.client.GuideScheduleSyncClient;
+import com.team6.domain.matching.client.KakaoPayClient;
 import com.team6.domain.matching.dto.request.PaymentConfirmRequest;
 import com.team6.domain.matching.dto.request.PaymentCreateRequest;
 import com.team6.domain.matching.dto.request.RefundRequestDto;
@@ -43,7 +47,13 @@ class PaymentServiceTest {
     @Mock
     private MatchRequestRepository matchRequestRepository;
     @Mock
+    private GuideProfileRepository guideProfileRepository;
+    @Mock
     private FakePgClient fakePgClient;
+    @Mock
+    private KakaoPayClient kakaoPayClient;
+    @Mock
+    private GuideScheduleSyncClient guideScheduleSyncClient;
     @InjectMocks
     private PaymentService paymentService;
 
@@ -132,6 +142,7 @@ class PaymentServiceTest {
 
         when(paymentRepository.findByPgOrderNo("LM-FAKE-test-order")).thenReturn(Optional.of(payment));
         when(fakePgClient.approvePayment("LM-FAKE-test-order", 25000, 400L)).thenReturn("FAKE-TXN-400");
+        when(guideProfileRepository.findById(20L)).thenReturn(Optional.of(GuideProfile.builder().id(20L).memberId(2000L).build()));
 
         PaymentResponseDto dto = paymentService.confirmPayment(guestId, confirm);
 
@@ -139,6 +150,7 @@ class PaymentServiceTest {
         assertEquals("FAKE-TXN-400", dto.getPgTransactionId());
         assertEquals(MatchRequestStatus.PAID, mr.getStatus());
         assertEquals(true, dto.getPaidAt() != null && dto.getRefundDeadline() != null);
+        verify(guideScheduleSyncClient).confirmPaid(20L, 900L, 2000L);
     }
 
     @Test
@@ -190,6 +202,7 @@ class PaymentServiceTest {
                 .id(id)
                 .guestId(guestId)
                 .guideId(guideId)
+                .guideScheduleId(900L)
                 .destination("Seoul")
                 .desiredDate(LocalDate.now())
                 .build();
@@ -222,6 +235,7 @@ class PaymentServiceTest {
                 .id(1L)
                 .guestId(payerId)
                 .guideId(2L)
+                .guideScheduleId(901L)
                 .destination("Seoul")
                 .desiredDate(LocalDate.now())
                 .build();


### PR DESCRIPTION
# 🔗 이슈 번호
- Closes #169 

---

💡 주요 변경 사항
- 매칭 도메인: `MatchRequest`에 `guideScheduleId` 저장, 생성 요청 JSON `scheduleId` / `guideScheduleId` 별칭 지원
- `GuideScheduleSyncClient`로 가이드 REST 연동 — 생성 시 `pending?matchRequestId=`, 결제 승인 시 `paid-confirm`, 거절·취소 시 `cancel`
- 결제 승인 시 가이드 `book` 호출 제거 — 스케줄이 이미 `BOOKED`일 때만 `paid-confirm`으로 `isPaid` 반영
- 게스트 제안 거절: `declineProposalByGuest` → `REJECTED` (취소와 구분)
- 가이드 도메인: `markAsPaid`는 `BOOKED` 검증 및 엔티티는 `isPaid`만 설정, `cancelToAvailable`은 PENDING·BOOKED 허용 및 `releaseMatchToAvailable`
- 가이드 정산: `PaymentRepository`로 해당 가이드 COMPLETED 결제 합산
- 카카오페이 Stub 결제 구현

⚠️ 주의 사항 / 질문
- 결제 전 스케줄이 반드시 `BOOKED`여야 `paid-confirm`이 성공 — 프론트/가이드 플로우와 순서 합의 필요
- 연동 PATCH 인증(내부 토큰 vs JWT) 정책 확정 시 `HttpGuideScheduleSyncClient` 헤더만 맞추면 됨
- 환불 시 가이드 스케줄 복구 필요 여부는 미연동 — 정책에 따라 후속 작업
- `GuideSettlementResponse` Javadoc·문구가 구버전이면 설명만 최신화 권장

✅ 체크리스트
- [x] 빌드가 정상적으로 되는가? (`:api-server:build` 기준)
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [x] `.gitignore`에 설정 파일이 잘 포함되었는가? (`application-local.yml` 등)