### PR TITLE
Feat/be#171: module-ai 프롬프트 파싱 품질 개선 #171

### DIFF
--- a/backend/module-ai/src/main/java/com/team6/module/ai/controller/AiController.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/controller/AiController.java
@@ -44,7 +44,7 @@ public class AiController {
             headers = @Header(
                     name = RecommendationHttpHeaders.X_RECOMMENDATION_POLICY,
                     description = "룰 정책 버전(응답 body의 policyVersion과 동일). 캐시 키·디버깅에 활용 가능.",
-                    schema = @Schema(implementation = String.class, example = "2026.04.10")
+                    schema = @Schema(implementation = String.class, example = "2026.04.15")
             ),
             content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = GuideRecommendResponse.class))
     )

--- a/backend/module-ai/src/main/java/com/team6/module/ai/dto/request/GuideRecommendRequest.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/dto/request/GuideRecommendRequest.java
@@ -1,5 +1,6 @@
 package com.team6.module.ai.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -26,6 +27,12 @@ public class GuideRecommendRequest {
     private List<String> softPenaltyActivityTags;
     private Integer topN;
     private List<GuideCandidateDto> guideCandidates;
+
+    /**
+     * 파서 전용: 선호/제외 충돌 정리 등 내부 안내 코드. 직렬화·OpenAPI에는 노출하지 않는다.
+     */
+    @JsonIgnore
+    private List<String> parserNoticeCodes;
 
     @Schema(name = "GuideCandidateDto", description = "추천 후보 가이드 프로필")
     @Getter

--- a/backend/module-ai/src/main/java/com/team6/module/ai/dto/response/GuideRecommendResponse.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/dto/response/GuideRecommendResponse.java
@@ -28,6 +28,11 @@ public class GuideRecommendResponse {
      */
     @Schema(description = "룰 기반 추천 정책 버전(동일 프롬프트라도 정책 변경 구분용)", example = "2026.04.10")
     private String policyVersion;
+    /**
+     * 프롬프트에서 뽑은 신호(스타일·예산·활동 등)가 얼마나 풍부한지에 대한 룰 기반 등급.
+     */
+    @Schema(description = "파싱 신호 풍부도(룰 기반). LOW면 추가 질문 권장", allowableValues = {"LOW", "MEDIUM", "HIGH"})
+    private String promptParseConfidence;
     @Schema(description = "추천 항목 개수")
     private int totalCount;
     @Schema(description = "정렬된 추천 목록")

--- a/backend/module-ai/src/main/java/com/team6/module/ai/parser/KeywordNormalizer.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/parser/KeywordNormalizer.java
@@ -85,7 +85,18 @@ public final class KeywordNormalizer {
             Map.entry("슬로프", "스키"),
             Map.entry("폭포", "계곡"),
             Map.entry("바다낚시", "낚시"),
-            Map.entry("패러", "패러글라이딩")
+            Map.entry("패러", "패러글라이딩"),
+            Map.entry("경치", "야경"),
+            Map.entry("전망", "야경"),
+            Map.entry("조망", "야경"),
+            Map.entry("뷰", "야경"),
+            Map.entry("스카이", "야경"),
+            Map.entry("viewpoint", "야경"),
+            Map.entry("scenic", "야경"),
+            Map.entry("실내", "전시"),
+            Map.entry("우천", "전시"),
+            Map.entry("장마", "전시"),
+            Map.entry("비오는날", "전시")
     );
 
     public static String normalizeTag(String tag) {

--- a/backend/module-ai/src/main/java/com/team6/module/ai/parser/PromptParser.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/parser/PromptParser.java
@@ -2,6 +2,7 @@ package com.team6.module.ai.parser;
 
 import com.team6.module.ai.config.LocalGuestAiProperties;
 import com.team6.module.ai.dto.request.GuideRecommendRequest;
+import com.team6.module.ai.support.RecommendationNoticeCodes;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -79,15 +80,23 @@ public class PromptParser {
         String travelStyle = extractTravelStyle(normalizedPrompt);
         String budgetLevel = extractBudgetLevel(normalizedPrompt);
         String companionType = extractCompanionType(normalizedPrompt);
-        List<String> excludedActivityTags = extractExcludedActivityTags(normalizedPrompt);
+        List<String> excludedRaw = extractExcludedActivityTags(normalizedPrompt);
+        List<String> excludedActivityTags = relaxExcludedWhenExplicitlyRequired(normalizedPrompt, excludedRaw);
         List<String> softPenaltyActivityTags = extractSoftPenaltyActivityTags(normalizedPrompt);
-        List<String> activityTags = stripActivityTagsOverlappingSoft(
+        List<String> activityBeforeExcluded = stripActivityTagsOverlappingSoft(
                 extractActivityTags(normalizedPrompt),
                 softPenaltyActivityTags
         );
+        List<String> activityTags = stripActivityTagsOverlappingExcluded(activityBeforeExcluded, excludedActivityTags);
         List<String> preferredLanguages = extractLanguages(normalizedPrompt);
         Integer headcount = extractHeadcount(normalizedPrompt);
         Integer durationDays = extractDurationDays(normalizedPrompt);
+
+        List<String> parserNotices = new ArrayList<>();
+        if (excludedActivityTags.size() < excludedRaw.size()
+                || activityTags.size() < activityBeforeExcluded.size()) {
+            parserNotices.add(RecommendationNoticeCodes.PROMPT_PREFERENCE_CONFLICT_RESOLVED);
+        }
 
         return GuideRecommendRequest.builder()
                 .region(region)
@@ -102,6 +111,7 @@ public class PromptParser {
                 .softPenaltyActivityTags(softPenaltyActivityTags)
                 .topN(topN)
                 .guideCandidates(guideCandidates)
+                .parserNoticeCodes(parserNotices.isEmpty() ? null : List.copyOf(parserNotices))
                 .build();
     }
 
@@ -257,7 +267,10 @@ public class PromptParser {
         Map<String, List<String>> styleKeywords = Map.of(
                 "감성", List.of("감성", "감성적인", "감성샷", "핫플", "인스타", "인스타그램"),
                 "액티비티", List.of("액티비티", "활동적인", "신나게", "역동적인", "익스트림", "스릴", "짜릿"),
-                "힐링", List.of("조용", "힐링", "편안", "여유", "쉬고", "한적"),
+                "힐링", List.of(
+                        "조용", "조용한", "힐링", "편안", "여유", "쉬고", "한적", "고즈넉", "한산",
+                        "사람 적", "사람적", "적은 곳", "한적하게"
+                ),
                 "로컬", List.of("로컬", "현지", "동네", "시장", "골목", "문화", "역사", "유적", "문화재", "유네스코")
         );
         Map<String, Integer> scores = new LinkedHashMap<>();
@@ -351,7 +364,10 @@ public class PromptParser {
     private String extractCompanionType(String prompt) {
         if (containsAny(prompt, "혼자", "혼행", "1인", "솔로")) return "혼자";
         if (containsAny(prompt, "친구", "친구랑", "우정", "동창")) return "친구";
-        if (containsAny(prompt, "가족", "부모님", "엄마", "아빠", "아이", "애기")) return "가족";
+        if (containsAny(prompt,
+                "가족", "부모님", "엄마", "아빠", "아이", "애기",
+                "아이랑", "애랑", "아기랑", "키즈", "유아", "육아", "아동", "토들러", "영유아"
+        )) return "가족";
         if (containsAny(prompt, "반려견", "강아지", "댕댕이", "반려동물")) return "반려견";
         if (containsAny(prompt, "연인", "커플", "데이트", "여자친구", "남자친구")) return "연인";
         if (containsAny(prompt, "단체", "워크샵", "워크숍", "회사", "동호회", "모임")) return "단체";
@@ -362,7 +378,23 @@ public class PromptParser {
         Set<String> tags = new LinkedHashSet<>();
 
         addTagIfMentioned(prompt, tags, "카페", "카페");
-        addTagIfMentioned(prompt, tags, "야경", "야경", "밤거리");
+        addTagIfMentioned(
+                prompt,
+                tags,
+                "야경",
+                "야경",
+                "밤거리",
+                "경치",
+                "전망",
+                "조망",
+                "뷰",
+                "루프탑",
+                "전망대",
+                "sky",
+                "view",
+                "scenic",
+                "viewpoint"
+        );
         addTagIfMentioned(prompt, tags, "맛집", "맛집", "먹방", "음식", "식도락");
         addTagIfMentioned(prompt, tags, "산책", "산책", "걷기", "걷고");
         addTagIfMentioned(prompt, tags, "등산", "등산", "트레킹");
@@ -370,7 +402,26 @@ public class PromptParser {
         addTagIfMentioned(prompt, tags, "쇼핑", "쇼핑");
         addTagIfMentioned(prompt, tags, "바다", "바다", "해변", "오션뷰", "해수욕장", "스노클링", "다이빙", "스쿠버");
         addTagIfMentioned(prompt, tags, "일몰", "일몰", "노을", "야경명소");
-        addTagIfMentioned(prompt, tags, "전시", "박물관", "미술관", "전시");
+        addTagIfMentioned(
+                prompt,
+                tags,
+                "전시",
+                "박물관",
+                "미술관",
+                "전시",
+                "실내",
+                "우천",
+                "뮤지엄",
+                "갤러리",
+                "indoor",
+                "rainy",
+                "비오는날",
+                "비오는",
+                "비 오는",
+                "장마철",
+                "장마",
+                "폭우"
+        );
         addTagIfMentioned(prompt, tags, "시장", "시장", "전통시장", "로컬시장", "야시장");
         addTagIfMentioned(prompt, tags, "술집", "술집", "클럽", "바");
         addTagIfMentioned(prompt, tags, "브런치", "브런치", "카페투어");
@@ -429,6 +480,7 @@ public class PromptParser {
         addExcludedIfNegated(prompt, excluded, "맛집", "맛집", "먹방", "식도락");
         addExcludedIfNegated(prompt, excluded, "카페", "카페", "브런치", "카페투어");
         addExcludedIfNegated(prompt, excluded, "바다", "바다", "해변", "오션뷰", "해수욕장");
+        addExcludedIfNegated(prompt, excluded, "전시", "전시", "박물관", "미술관", "뮤지엄", "갤러리");
         LinkedHashSet<String> normalized = excluded.stream()
                 .map(KeywordNormalizer::normalizeTag)
                 .filter(Objects::nonNull)
@@ -762,5 +814,94 @@ public class PromptParser {
             case "액티비티" -> 1;
             default -> 0;
         };
+    }
+
+    /**
+     * 제외 목록과 겹치는 선호 활동은 제외를 우선한다(요청 일관성).
+     */
+    private List<String> stripActivityTagsOverlappingExcluded(List<String> activityTags, List<String> excluded) {
+        if (activityTags == null || activityTags.isEmpty() || excluded == null || excluded.isEmpty()) {
+            return activityTags == null ? List.of() : activityTags;
+        }
+        Set<String> ex = excluded.stream()
+                .map(KeywordNormalizer::normalizeTag)
+                .filter(Objects::nonNull)
+                .filter(s -> !s.isBlank())
+                .collect(Collectors.toSet());
+        return activityTags.stream()
+                .filter(a -> !ex.contains(KeywordNormalizer.normalizeTag(a)))
+                .collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    /**
+     * 같은 활동에 대해 ‘빼고’로 제외됐다가 뒤에서 ‘꼭/위주’로 다시 선호하는 경우, 제외를 완화한다.
+     */
+    private List<String> relaxExcludedWhenExplicitlyRequired(String prompt, List<String> excluded) {
+        if (excluded == null || excluded.isEmpty()) {
+            return excluded == null ? List.of() : excluded;
+        }
+        LinkedHashSet<String> out = new LinkedHashSet<>();
+        for (String tag : excluded) {
+            String normalizedTag = KeywordNormalizer.normalizeTag(tag);
+            if (normalizedTag == null || normalizedTag.isBlank()) {
+                continue;
+            }
+            if (exclusionOverriddenByExplicitRequirement(prompt, normalizedTag)) {
+                continue;
+            }
+            out.add(normalizedTag);
+        }
+        return new ArrayList<>(out);
+    }
+
+    private boolean exclusionOverriddenByExplicitRequirement(String prompt, String normalizedTag) {
+        String[][] groups = {
+                {"술집", "술집", "클럽"},
+                {"등산", "등산", "트레킹"},
+                {"쇼핑", "쇼핑", "쇼핑몰", "아울렛"},
+                {"맛집", "맛집", "먹방", "식도락"},
+                {"카페", "카페", "브런치", "카페투어"},
+                {"바다", "바다", "해변", "오션뷰", "해수욕장"},
+                {"전시", "전시", "박물관", "미술관", "뮤지엄", "갤러리"}
+        };
+        for (String[] g : groups) {
+            if (!normalizedTag.equals(KeywordNormalizer.normalizeTag(g[0]))) {
+                continue;
+            }
+            for (int i = 1; i < g.length; i++) {
+                if (keywordHasStrongRequirement(prompt, g[i])) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * ‘위주’만으로는 앞선 ‘빼고’와 충돌하는 경우가 많아, 제외 완화는 강한 의도 표현에만 적용한다.
+     */
+    private boolean keywordHasStrongRequirement(String prompt, String keyword) {
+        if (keyword == null || keyword.length() < 2) {
+            return false;
+        }
+        String kw = keyword.toLowerCase(Locale.ROOT);
+        int idx = prompt.indexOf(kw);
+        while (idx >= 0) {
+            if (isNegatedAround(prompt, idx, kw.length())) {
+                idx = prompt.indexOf(kw, idx + kw.length());
+                continue;
+            }
+            int start = Math.max(0, idx - 18);
+            int end = Math.min(prompt.length(), idx + kw.length() + 18);
+            String win = prompt.substring(start, end);
+            if (containsAny(win,
+                    "꼭", "반드시", "필수",
+                    "가고 싶", "가고싶", "가야", "잡아주", "가보고 싶", "가보고싶"
+            )) {
+                return true;
+            }
+            idx = prompt.indexOf(kw, idx + kw.length());
+        }
+        return false;
     }
 }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
@@ -18,7 +18,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static com.team6.module.ai.support.AiRecommendationTuning.POLICY_VERSION;
@@ -51,6 +53,14 @@ public class PromptRecommendationService {
     /** API로 넘어온 후보·지역 필터 후 풀에 가이드가 한 명뿐일 때 */
     private static final String NOTICE_SPARSE_GUIDE_POOL =
             "이 조건에 맞는 가이드가 한 분뿐이라 추천 선택 폭이 좁을 수 있어요.";
+    private static final String NOTICE_PARSE_LOW =
+            "지역 외 조건 신호가 적어 해석 여지가 있어요. 예산·일정·원하는 활동을 조금만 더 적어주시면 정확해져요.";
+    private static final String NOTICE_BUDGET_VAGUE =
+            "예산과 관련된 표현이 있는데 구간을 확정하지 못했어요. 금액이나 ‘가성비/럭셔리’처럼 알려주시면 좋아요.";
+    private static final String NOTICE_DURATION_VAGUE =
+            "일정에 대한 말은 있는데 며칠인지 확정하지 못했어요. ‘2박3일’처럼 적어주시면 좋아요.";
+
+    private static final Pattern DURATION_NIGHTS_HINT = Pattern.compile("\\d{1,2}\\s*박");
 
     public GuideRecommendResponse recommendByPrompt(
             String prompt,
@@ -91,6 +101,7 @@ public class PromptRecommendationService {
                         .matchRequestDraft(matchRequestDraftFrom(parsed))
                         .notice(NOTICE_REGION_REQUIRED)
                         .noticeCodes(List.of(RecommendationNoticeCodes.REGION_REQUIRED))
+                        .promptParseConfidence("LOW")
                         .policyVersion(POLICY_VERSION)
                         .totalCount(0)
                         .recommendations(List.of())
@@ -125,6 +136,10 @@ public class PromptRecommendationService {
         FallbackOutcome fallback = resolveFallbackWithStrategicRelaxation(effective, base);
         GuideRecommendResponse finalBase = fallback.responseAfterFallback();
 
+        String parseConfidence = computePromptParseConfidence(parsed);
+        List<String> ambiguityCodes = collectAmbiguityNoticeCodes(prompt, parsed);
+        List<String> parserHints = parsed.getParserNoticeCodes() == null ? List.of() : parsed.getParserNoticeCodes();
+
         String notice = fallback.fallbackNotice();
         if (expansion.expansionUsed()) {
             notice = mergeNotice(NOTICE_ADJACENT_INCLUDED, notice);
@@ -135,6 +150,7 @@ public class PromptRecommendationService {
             notice = mergeNotice(NOTICE_SPARSE_GUIDE_POOL, notice);
             metrics.recordSparsePoolNotice();
         }
+        notice = enrichNoticeForParseQuality(notice, parseConfidence, ambiguityCodes);
 
         if (fallback.attemptedRelaxChain()) {
             String metricStage = fallback.winningRelaxStage() != RelaxStage.NONE
@@ -147,7 +163,10 @@ public class PromptRecommendationService {
                     fallback,
                     expansion.expansionUsed(),
                     effectivePoolSizeForNotice,
-                    finalBase.getTotalCount()
+                    finalBase.getTotalCount(),
+                    parserHints,
+                    ambiguityCodes,
+                    parseConfidence
             );
             metrics.recordOutcome(finalBase.getTotalCount() > 0 ? "success" : "empty");
 
@@ -170,6 +189,7 @@ public class PromptRecommendationService {
                     .matchRequestDraft(matchRequestDraftFrom(parsed))
                     .notice(notice)
                     .noticeCodes(noticeCodes)
+                    .promptParseConfidence(parseConfidence)
                     .policyVersion(POLICY_VERSION)
                     .totalCount(finalBase.getTotalCount())
                     .recommendations(finalBase.getRecommendations())
@@ -234,7 +254,10 @@ public class PromptRecommendationService {
             FallbackOutcome fallback,
             boolean expansionUsed,
             int effectivePoolSize,
-            int resultCount
+            int resultCount,
+            List<String> parserHints,
+            List<String> ambiguityCodes,
+            String parseConfidence
     ) {
         LinkedHashSet<String> codes = new LinkedHashSet<>();
         if (fallback.coreNoticeCodes() != null) {
@@ -253,7 +276,123 @@ public class PromptRecommendationService {
         if (effectivePoolSize == 1 && resultCount > 0) {
             codes.add(RecommendationNoticeCodes.SPARSE_GUIDE_POOL);
         }
+        if (parserHints != null) {
+            for (String h : parserHints) {
+                if (h != null && !h.isBlank()) {
+                    codes.add(h);
+                }
+            }
+        }
+        if (ambiguityCodes != null) {
+            for (String a : ambiguityCodes) {
+                if (a != null && !a.isBlank()) {
+                    codes.add(a);
+                }
+            }
+        }
+        if ("LOW".equals(parseConfidence)) {
+            codes.add(RecommendationNoticeCodes.PROMPT_PARSE_CONFIDENCE_LOW);
+        }
         return new ArrayList<>(codes);
+    }
+
+    private static String enrichNoticeForParseQuality(
+            String notice,
+            String parseConfidence,
+            List<String> ambiguityCodes
+    ) {
+        String out = notice;
+        if (ambiguityCodes != null && ambiguityCodes.contains(RecommendationNoticeCodes.PROMPT_BUDGET_AMBIGUOUS)) {
+            out = mergeNotice(out, NOTICE_BUDGET_VAGUE);
+        }
+        if (ambiguityCodes != null && ambiguityCodes.contains(RecommendationNoticeCodes.PROMPT_DURATION_AMBIGUOUS)) {
+            out = mergeNotice(out, NOTICE_DURATION_VAGUE);
+        }
+        if ("LOW".equals(parseConfidence)) {
+            out = mergeNotice(out, NOTICE_PARSE_LOW);
+        }
+        return out;
+    }
+
+    private static String normalizeForAmbiguityScan(String prompt) {
+        if (prompt == null || prompt.isBlank()) {
+            return "";
+        }
+        return prompt.trim().toLowerCase(Locale.ROOT).replaceAll("\\s+", " ");
+    }
+
+    private static List<String> collectAmbiguityNoticeCodes(String prompt, GuideRecommendRequest parsed) {
+        String p = normalizeForAmbiguityScan(prompt);
+        List<String> codes = new ArrayList<>();
+        if (!notBlank(parsed.getBudgetLevel()) && budgetMentionedAmbiguous(p)) {
+            codes.add(RecommendationNoticeCodes.PROMPT_BUDGET_AMBIGUOUS);
+        }
+        if (parsed.getDurationDays() == null && durationMentionedAmbiguous(p)) {
+            codes.add(RecommendationNoticeCodes.PROMPT_DURATION_AMBIGUOUS);
+        }
+        return codes;
+    }
+
+    private static boolean budgetMentionedAmbiguous(String p) {
+        return p.contains("예산")
+                || p.contains("비용")
+                || p.contains("경비")
+                || p.contains("가격")
+                || p.contains("1인당")
+                || p.contains("총액")
+                || p.contains("얼마나 들");
+    }
+
+    private static boolean durationMentionedAmbiguous(String p) {
+        return p.contains("며칠")
+                || p.contains("기간")
+                || p.contains("일정")
+                || p.contains("체류")
+                || DURATION_NIGHTS_HINT.matcher(p).find();
+    }
+
+    /**
+     * 지역은 파싱됐을 때, 그 외 신호가 얼마나 풍부한지에 대한 룰 기반 등급.
+     */
+    private static String computePromptParseConfidence(GuideRecommendRequest p) {
+        int dims = 0;
+        if (notBlank(p.getRegion())) {
+            dims++;
+        }
+        if (notBlank(p.getTravelStyle())) {
+            dims++;
+        }
+        if (notBlank(p.getBudgetLevel())) {
+            dims++;
+        }
+        if (notBlank(p.getCompanionType())) {
+            dims++;
+        }
+        if (p.getActivityTags() != null && !p.getActivityTags().isEmpty()) {
+            dims++;
+        }
+        if (p.getPreferredLanguages() != null && !p.getPreferredLanguages().isEmpty()) {
+            dims++;
+        }
+        if (p.getHeadcount() != null) {
+            dims++;
+        }
+        if (p.getDurationDays() != null) {
+            dims++;
+        }
+        if (p.getExcludedActivityTags() != null && !p.getExcludedActivityTags().isEmpty()) {
+            dims++;
+        }
+        if (p.getSoftPenaltyActivityTags() != null && !p.getSoftPenaltyActivityTags().isEmpty()) {
+            dims++;
+        }
+        if (dims >= 5) {
+            return "HIGH";
+        }
+        if (dims >= 3) {
+            return "MEDIUM";
+        }
+        return "LOW";
     }
 
     private static String noticeCodeForWinningStage(RelaxStage stage) {

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationTuning.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationTuning.java
@@ -14,7 +14,7 @@ public final class AiRecommendationTuning {
     /**
      * 룰/스코어/Reason/응답 계약이 바뀔 때마다 올린다. 로그·API에서 동일 프롬프트 비교 시 정책 변경 여부를 구분하는 데 쓴다.
      */
-    public static final String POLICY_VERSION = "2026.04.13";
+    public static final String POLICY_VERSION = "2026.04.15";
 
     public static final int DEFAULT_TOP_N = 3;
 

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/RecommendationNoticeCodes.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/RecommendationNoticeCodes.java
@@ -13,6 +13,16 @@ public final class RecommendationNoticeCodes {
     public static final String SPARSE_GUIDE_POOL = "SPARSE_GUIDE_POOL";
     public static final String NO_GUIDE_CANDIDATES = "NO_GUIDE_CANDIDATES";
     public static final String PROMPT_DETAIL_REQUESTED = "PROMPT_DETAIL_REQUESTED";
+    /** 지역은 있으나 예산·일정 등 신호가 적을 때(프론트: 추가 질문·낮은 신뢰 UI) */
+    public static final String PROMPT_PARSE_CONFIDENCE_LOW = "PROMPT_PARSE_CONFIDENCE_LOW";
+    /** 금액·티어는 못 잡았는데 예산 관련 표현이 있는 경우 */
+    public static final String PROMPT_BUDGET_AMBIGUOUS = "PROMPT_BUDGET_AMBIGUOUS";
+    /** 기간·일정 관련 표현이 있는데 일수로 확정하지 못한 경우 */
+    public static final String PROMPT_DURATION_AMBIGUOUS = "PROMPT_DURATION_AMBIGUOUS";
+    /**
+     * 선호 활동과 제외 태그가 겹쳐 제외를 우선하거나, 제외 목록을 ‘꼭/위주’ 표현으로 완화한 경우.
+     */
+    public static final String PROMPT_PREFERENCE_CONFLICT_RESOLVED = "PROMPT_PREFERENCE_CONFLICT_RESOLVED";
     public static final String FALLBACK_RELAXED_NO_MATCH = "FALLBACK_RELAXED_NO_MATCH";
     public static final String FALLBACK_LOW_SCORE_RELAXED = "FALLBACK_LOW_SCORE_RELAXED";
     /** 전략적 완화: 활동 태그만 제거한 단계에서 수용 가능한 결과를 얻음 */

--- a/backend/module-ai/src/test/java/com/team6/module/ai/parser/PromptParserTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/parser/PromptParserTest.java
@@ -230,4 +230,41 @@ class PromptParserTest {
         assertThat(r2.getRegion()).isEqualTo("제주");
         assertThat(r2.getActivityTags()).contains("바다");
     }
+
+    @Test
+    void parse_should_map_scenic_and_indoor_weather_intents_to_tags() {
+        GuideRecommendRequest scenic = promptParser.parse("강릉 경치 좋은 전망 위주로 조용히 보고 싶어", 3, List.of());
+        assertThat(scenic.getActivityTags()).contains("야경");
+        assertThat(scenic.getTravelStyle()).isEqualTo("힐링");
+
+        GuideRecommendRequest indoor = promptParser.parse("제주 우천이라 실내 위주로 박물관 갈래", 3, List.of());
+        assertThat(indoor.getActivityTags()).contains("전시");
+    }
+
+    @Test
+    void parse_should_detect_family_with_child_phrases() {
+        GuideRecommendRequest r = promptParser.parse("부산 아이랑 키즈 동반으로 바다 보러", 3, List.of());
+        assertThat(r.getCompanionType()).isEqualTo("가족");
+        assertThat(r.getActivityTags()).contains("바다");
+    }
+
+    @Test
+    void parse_should_strip_activity_when_same_tag_is_excluded_and_notice_conflict() {
+        GuideRecommendRequest r = promptParser.parse("부산 맛집 빼고 맛집 위주로 부탁", 3, List.of());
+        assertThat(r.getExcludedActivityTags()).contains("맛집");
+        assertThat(r.getActivityTags()).doesNotContain("맛집");
+        assertThat(r.getParserNoticeCodes()).contains("PROMPT_PREFERENCE_CONFLICT_RESOLVED");
+    }
+
+    @Test
+    void parse_should_relax_excluded_tag_when_later_explicit_requirement() {
+        GuideRecommendRequest r = promptParser.parse(
+                "부산에서 처음엔 카페는 빼고 싶었는데 결국 카페 꼭 가고 싶어",
+                3,
+                List.of()
+        );
+        assertThat(r.getExcludedActivityTags()).doesNotContain("카페");
+        assertThat(r.getActivityTags()).contains("카페");
+        assertThat(r.getParserNoticeCodes()).contains("PROMPT_PREFERENCE_CONFLICT_RESOLVED");
+    }
 }


### PR DESCRIPTION
## 🔗 이슈 번호

Closes #171

## 💡 주요 변경 사항

- `PromptParser`: 경치·전망·실내·우천 등 태그 키워드 확장, `KeywordNormalizer` 동의어 보강, 선호/제외 겹침 제거·강한 재의도 시 제외 완화
- `PromptRecommendationService`: 예산/일정 모호 시 `noticeCodes`, `promptParseConfidence`, 사용자 안내 문구 병합
- `GuideRecommendResponse` / `RecommendationNoticeCodes` / `AiRecommendationTuning.POLICY_VERSION` 갱신, `GuideRecommendRequest`에 파서 전용 `parserNoticeCodes`(`@JsonIgnore`)
- `PromptParserTest` 등 단위 테스트 보강

## ⚠️ 주의 사항 / 질문

- `promptParseConfidence`·신규 `noticeCodes`는 프론트에서 선택적으로 표시·매핑하면 됨 (기존 클라이언트는 미사용 필드 무시 가능)
- 로컬 전용 설정·시크릿은 커밋하지 않음 (`application.yml` 등)

## ✅ 체크리스트

- [x] 빌드가 정상적으로 되는가? (`./gradlew :module-ai:test :module-ai-integration:test`)
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가? (`Feat/be#171: …`)
- [x] `.gitignore`에 설정 파일이 잘 포함되었는가? (로컬 시크릿은 PR에 미포함)
