### PR TITLE
Feat/be#173: AI 후보 풀 전략(지역·콜드스타트·캐시) #173

### DIFF
--- a/backend/module-ai-integration/src/main/java/com/team6/integration/ai/DbBackedGuideCandidateProvider.java
+++ b/backend/module-ai-integration/src/main/java/com/team6/integration/ai/DbBackedGuideCandidateProvider.java
@@ -11,6 +11,7 @@ import com.team6.domain.matching.entity.enums.RefundStatus;
 import com.team6.domain.matching.repository.MatchRequestRepository;
 import com.team6.domain.matching.repository.RefundRepository;
 import com.team6.module.chat.repository.mysql.ChatRoomRepository;
+import com.team6.module.ai.config.LocalGuestAiProperties;
 import com.team6.module.ai.dto.request.GuideRecommendRequest;
 import com.team6.module.ai.parser.PromptParser;
 import com.team6.module.ai.support.AiRecommendationTuning;
@@ -18,18 +19,31 @@ import com.team6.module.ai.support.GuideCandidateProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Primary;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
 /**
  * 클라이언트가 후보를 내려보내지 않은 경우, 승인·활성 {@link GuideProfile}을 DB에서 읽어 AI 후보로 채운다.
+ * <p>
+ * 지역은 <b>정확 일치 → 부분 일치 → 전역</b> 순으로 확보하고, 운영 제외 ID·상한·콜드스타트 비율 샘플링·
+ * 정책버전 키 캐시({@link LocalGuestAiProperties#getCandidatePool()})를 적용한다.
  */
 @Slf4j
 @Component
@@ -37,7 +51,9 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class DbBackedGuideCandidateProvider implements GuideCandidateProvider {
 
-    static final int MAX_SERVER_CANDIDATES = 200;
+    /** {@link LocalGuestAiProperties.CandidatePoolSettings#getMaxFetchSize()} 기본값과 동기화 */
+    public static final int DEFAULT_MAX_FETCH_SIZE = 200;
+
     private static final List<MatchRequestStatus> PROGRESSED_MATCH_STATUSES = List.of(
             MatchRequestStatus.ACCEPTED,
             MatchRequestStatus.PAID,
@@ -52,6 +68,9 @@ public class DbBackedGuideCandidateProvider implements GuideCandidateProvider {
     private final RefundRepository refundRepository;
     private final ChatRoomRepository chatRoomRepository;
     private final PromptParser promptParser;
+    private final LocalGuestAiProperties aiProperties;
+
+    private final ConcurrentHashMap<String, PoolCacheEntry> poolCache = new ConcurrentHashMap<>();
 
     @Override
     public List<GuideRecommendRequest.GuideCandidateDto> getCandidates(
@@ -67,24 +86,202 @@ public class DbBackedGuideCandidateProvider implements GuideCandidateProvider {
         GuideRecommendRequest parsed = promptParser.parse(safePrompt, resolvedTopN, List.of());
         String region = parsed.getRegion();
 
-        Pageable pageable = PageRequest.of(0, MAX_SERVER_CANDIDATES);
-        List<GuideProfile> profiles;
-        if (region != null && !region.isBlank()) {
-            String fragment = region.trim();
-            profiles = guideProfileRepository
-                    .findByIsApprovedTrueAndIsActiveTrueAndRegionContainingIgnoreCase(fragment, pageable)
-                    .getContent();
-            if (profiles.isEmpty()) {
-                log.info("[AI_RECOMMEND] No approved-active guides for region fragment={}, using global pool", fragment);
-                profiles = guideProfileRepository.findByIsApprovedTrueAndIsActiveTrue(pageable).getContent();
+        LocalGuestAiProperties.CandidatePoolSettings pool = aiProperties.getCandidatePool();
+        int ttlSec = pool.getPoolCacheTtlSeconds();
+        String cacheKey = buildPoolCacheKey(region, pool);
+        if (ttlSec > 0) {
+            PoolCacheEntry hit = poolCache.get(cacheKey);
+            if (hit != null && !hit.isExpired()) {
+                log.debug("[AI_POOL] cache hit key={}", cacheKey);
+                return List.copyOf(hit.candidates());
             }
-        } else {
-            log.info("[AI_RECOMMEND] No region in prompt; loading global approved-active guide pool");
-            profiles = guideProfileRepository.findByIsApprovedTrueAndIsActiveTrue(pageable).getContent();
         }
-        List<GuideRecommendRequest.GuideCandidateDto> mapped =
-                mapProfilesToCandidates(profiles);
-        return mergeBehaviorSignals(mapped, profiles);
+
+        List<GuideProfile> profiles = loadProfilesTiered(region, pool);
+        profiles = filterExcludedProfiles(profiles, pool);
+
+        List<GuideRecommendRequest.GuideCandidateDto> mapped = mapProfilesToCandidates(profiles);
+        List<GuideRecommendRequest.GuideCandidateDto> withSignals = mergeBehaviorSignals(mapped, profiles);
+        List<GuideRecommendRequest.GuideCandidateDto> sampled = applyPoolSampling(withSignals, pool);
+
+        if (ttlSec > 0) {
+            long ttlNanos = ttlSec * 1_000_000_000L;
+            long expiresAt = System.nanoTime() + ttlNanos;
+            poolCache.put(cacheKey, new PoolCacheEntry(sampled, expiresAt));
+            log.debug("[AI_POOL] cache put key={} size={}", cacheKey, sampled.size());
+        }
+
+        return sampled;
+    }
+
+    private static String buildPoolCacheKey(String region, LocalGuestAiProperties.CandidatePoolSettings pool) {
+        String regionKey = region == null || region.isBlank() ? "_" : region.trim().toLowerCase(Locale.ROOT);
+        return AiRecommendationTuning.POLICY_VERSION
+                + "|" + pool.getMaxFetchSize()
+                + "|" + pool.getMaxPoolSize()
+                + "|" + pool.getColdStartReserveRatio()
+                + "|" + pool.getExcludedGuideIds()
+                + "|" + regionKey;
+    }
+
+    private List<GuideProfile> loadProfilesTiered(String region, LocalGuestAiProperties.CandidatePoolSettings pool) {
+        int maxFetch = Math.max(1, pool.getMaxFetchSize());
+        Pageable pageable = PageRequest.of(0, maxFetch, Sort.by(Sort.Direction.DESC, "id"));
+
+        if (region == null || region.isBlank()) {
+            log.info("[AI_POOL] no region in prompt; loading global approved-active pool (maxFetch={})", maxFetch);
+            return guideProfileRepository.findByIsApprovedTrueAndIsActiveTrue(pageable).getContent();
+        }
+
+        String fragment = region.trim();
+        List<GuideProfile> tiered = new ArrayList<>();
+        Set<Long> seen = new LinkedHashSet<>();
+
+        Page<GuideProfile> exact = guideProfileRepository.findByIsApprovedTrueAndIsActiveTrueAndRegionEqualsIgnoreCase(
+                fragment,
+                pageable
+        );
+        addUnique(tiered, seen, exact.getContent());
+
+        if (tiered.size() < maxFetch) {
+            Pageable partialPage = PageRequest.of(0, maxFetch - tiered.size(), Sort.by(Sort.Direction.DESC, "id"));
+            Page<GuideProfile> partial = guideProfileRepository
+                    .findByIsApprovedTrueAndIsActiveTrueAndRegionContainingIgnoreCase(fragment, partialPage);
+            addUnique(tiered, seen, partial.getContent());
+        }
+
+        if (tiered.isEmpty()) {
+            log.info("[AI_POOL] no approved-active guides for region fragment={}, using global pool", fragment);
+            tiered.addAll(guideProfileRepository.findByIsApprovedTrueAndIsActiveTrue(pageable).getContent());
+        } else {
+            log.debug("[AI_POOL] region={} tiered size={} (exact+partial)", fragment, tiered.size());
+        }
+
+        return tiered;
+    }
+
+    private static void addUnique(List<GuideProfile> out, Set<Long> seen, List<GuideProfile> chunk) {
+        for (GuideProfile p : chunk) {
+            if (p.getId() == null || seen.contains(p.getId())) {
+                continue;
+            }
+            seen.add(p.getId());
+            out.add(p);
+        }
+    }
+
+    private static List<GuideProfile> filterExcludedProfiles(
+            List<GuideProfile> profiles,
+            LocalGuestAiProperties.CandidatePoolSettings pool
+    ) {
+        List<Long> excluded = pool.getExcludedGuideIds();
+        if (excluded == null || excluded.isEmpty()) {
+            return profiles;
+        }
+        Set<Long> block = excluded.stream().filter(Objects::nonNull).collect(Collectors.toSet());
+        if (block.isEmpty()) {
+            return profiles;
+        }
+        return profiles.stream()
+                .filter(p -> p.getId() == null || !block.contains(p.getId()))
+                .collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    /**
+     * 콜드스타트 후보를 일정 비율 확보한 뒤 무작위 샘플링(상한 {@code maxPoolSize}).
+     */
+    private static List<GuideRecommendRequest.GuideCandidateDto> applyPoolSampling(
+            List<GuideRecommendRequest.GuideCandidateDto> full,
+            LocalGuestAiProperties.CandidatePoolSettings pool
+    ) {
+        int cap = Math.max(1, pool.getMaxPoolSize());
+        if (full.size() <= cap) {
+            return full;
+        }
+
+        double ratio = Math.min(1.0d, Math.max(0.0d, pool.getColdStartReserveRatio()));
+        List<GuideRecommendRequest.GuideCandidateDto> cold = new ArrayList<>();
+        List<GuideRecommendRequest.GuideCandidateDto> warm = new ArrayList<>();
+        for (GuideRecommendRequest.GuideCandidateDto d : full) {
+            if (isColdPoolCandidate(d)) {
+                cold.add(d);
+            } else {
+                warm.add(d);
+            }
+        }
+
+        ThreadLocalRandom rnd = ThreadLocalRandom.current();
+        shuffleInPlace(cold, rnd);
+        shuffleInPlace(warm, rnd);
+
+        int coldTarget = (int) Math.ceil(cap * ratio);
+        coldTarget = Math.min(coldTarget, cold.size());
+        coldTarget = Math.min(coldTarget, cap);
+        int warmTarget = cap - coldTarget;
+        if (warmTarget > warm.size()) {
+            warmTarget = warm.size();
+            coldTarget = Math.min(cap - warmTarget, cold.size());
+        }
+
+        List<GuideRecommendRequest.GuideCandidateDto> out = new ArrayList<>(cap);
+        for (int i = 0; i < coldTarget; i++) {
+            out.add(cold.get(i));
+        }
+        for (int i = 0; i < warmTarget; i++) {
+            out.add(warm.get(i));
+        }
+        if (out.size() < cap) {
+            Set<Long> ids = out.stream()
+                    .map(GuideRecommendRequest.GuideCandidateDto::getGuideId)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toSet());
+            for (GuideRecommendRequest.GuideCandidateDto d : full) {
+                if (out.size() >= cap) {
+                    break;
+                }
+                Long id = d.getGuideId();
+                if (id != null && ids.contains(id)) {
+                    continue;
+                }
+                out.add(d);
+                if (id != null) {
+                    ids.add(id);
+                }
+            }
+        }
+        log.debug("[AI_POOL] sampled {} from {} (coldReserveRatio={})", out.size(), full.size(), ratio);
+        return out;
+    }
+
+    private static boolean isColdPoolCandidate(GuideRecommendRequest.GuideCandidateDto d) {
+        int rc = d.getReviewCount() == null ? 0 : d.getReviewCount();
+        if (rc > 0) {
+            return false;
+        }
+        if (nz(d.getApprovedRefundCount()) > 0) {
+            return false;
+        }
+        if (nz(d.getMatchRequestCount()) + nz(d.getProgressedMatchCount()) + nz(d.getChatStartCount()) > 0) {
+            return false;
+        }
+        return true;
+    }
+
+    private static int nz(Integer v) {
+        return v == null ? 0 : v;
+    }
+
+    private static void shuffleInPlace(List<?> list, ThreadLocalRandom rnd) {
+        for (int i = list.size() - 1; i > 0; i--) {
+            int j = rnd.nextInt(i + 1);
+            Collections.swap(list, i, j);
+        }
+    }
+
+    private record PoolCacheEntry(List<GuideRecommendRequest.GuideCandidateDto> candidates, long expiresAtNanos) {
+        boolean isExpired() {
+            return System.nanoTime() > expiresAtNanos;
+        }
     }
 
     private List<GuideRecommendRequest.GuideCandidateDto> mapProfilesToCandidates(List<GuideProfile> profiles) {

--- a/backend/module-ai-integration/src/test/java/com/team6/integration/ai/DbBackedGuideCandidateProviderTest.java
+++ b/backend/module-ai-integration/src/test/java/com/team6/integration/ai/DbBackedGuideCandidateProviderTest.java
@@ -22,6 +22,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -59,6 +60,8 @@ class DbBackedGuideCandidateProviderTest {
 
     @BeforeEach
     void setUp() {
+        LocalGuestAiProperties aiProps = new LocalGuestAiProperties();
+        aiProps.getCandidatePool().setPoolCacheTtlSeconds(0);
         provider = new DbBackedGuideCandidateProvider(
                 guideProfileRepository,
                 guideFeedRepository,
@@ -66,7 +69,8 @@ class DbBackedGuideCandidateProviderTest {
                 matchRequestRepository,
                 refundRepository,
                 chatRoomRepository,
-                new PromptParser(new LocalGuestAiProperties())
+                new PromptParser(aiProps),
+                aiProps
         );
     }
 
@@ -108,6 +112,10 @@ class DbBackedGuideCandidateProviderTest {
                 .isApproved(true)
                 .isActive(true)
                 .build();
+        when(guideProfileRepository.findByIsApprovedTrueAndIsActiveTrueAndRegionEqualsIgnoreCase(
+                eq("제주"),
+                any(Pageable.class)
+        )).thenReturn(new PageImpl<>(List.of()));
         when(guideProfileRepository.findByIsApprovedTrueAndIsActiveTrueAndRegionContainingIgnoreCase(
                 eq("제주"),
                 any(Pageable.class)
@@ -165,6 +173,10 @@ class DbBackedGuideCandidateProviderTest {
 
     @Test
     void fallsBackToGlobalPoolWhenRegionQueryEmpty() {
+        when(guideProfileRepository.findByIsApprovedTrueAndIsActiveTrueAndRegionEqualsIgnoreCase(
+                eq("제주"),
+                any(Pageable.class)
+        )).thenReturn(new PageImpl<>(List.of()));
         when(guideProfileRepository.findByIsApprovedTrueAndIsActiveTrueAndRegionContainingIgnoreCase(
                 eq("제주"),
                 any(Pageable.class)
@@ -179,8 +191,11 @@ class DbBackedGuideCandidateProviderTest {
                 .isApproved(true)
                 .isActive(true)
                 .build();
-        when(guideProfileRepository.findByIsApprovedTrueAndIsActiveTrue(PageRequest.of(0, DbBackedGuideCandidateProvider.MAX_SERVER_CANDIDATES)))
-                .thenReturn(new PageImpl<>(List.of(p)));
+        when(guideProfileRepository.findByIsApprovedTrueAndIsActiveTrue(PageRequest.of(
+                0,
+                DbBackedGuideCandidateProvider.DEFAULT_MAX_FETCH_SIZE,
+                Sort.by(Sort.Direction.DESC, "id")
+        ))).thenReturn(new PageImpl<>(List.of(p)));
         when(guideFeedRepository.findByGuideProfile_IdInAndIsDeletedFalse(List.of(2L)))
                 .thenReturn(List.of());
         when(guideCareerRepository.findByGuideProfile_IdIn(List.of(2L)))

--- a/backend/module-ai/src/main/java/com/team6/module/ai/config/LocalGuestAiProperties.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/config/LocalGuestAiProperties.java
@@ -28,6 +28,11 @@ public class LocalGuestAiProperties {
      */
     private ParserSettings parser = new ParserSettings();
 
+    /**
+     * DB 후보 풀 조회·샘플링·캐시({@code localguest.ai.candidate-pool}).
+     */
+    private CandidatePoolSettings candidatePool = new CandidatePoolSettings();
+
     @Getter
     @Setter
     public static class ParserSettings {
@@ -49,5 +54,30 @@ public class LocalGuestAiProperties {
          * 키는 소문자로 정규화되어 매칭된다. 내장 영문·로마자 맵 이후에 병합되며 동일 키는 YAML이 덮어쓴다.
          */
         private Map<String, String> regionAliases = new LinkedHashMap<>();
+    }
+
+    @Getter
+    @Setter
+    public static class CandidatePoolSettings {
+        /**
+         * 스코어링에 넘기는 후보 최대 수(샘플링 후 상한).
+         */
+        private int maxPoolSize = 80;
+        /**
+         * DB에서 가져오는 상한(정확 일치 + 부분 일치 단계에서 사용).
+         */
+        private int maxFetchSize = 200;
+        /**
+         * 콜드스타트 후보(리뷰·행동 신호 거의 없음)를 풀에 확보하려는 최소 비율(0~1).
+         */
+        private double coldStartReserveRatio = 0.12d;
+        /**
+         * 후보 풀 캐시 TTL(초). 0 이하면 비활성.
+         */
+        private int poolCacheTtlSeconds = 45;
+        /**
+         * AI 추천 풀에서 제외할 가이드 프로필 ID(운영용).
+         */
+        private List<Long> excludedGuideIds = new ArrayList<>();
     }
 }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/policy/FeedbackMatchPolicy.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/policy/FeedbackMatchPolicy.java
@@ -62,6 +62,34 @@ public class FeedbackMatchPolicy {
             );
         }
 
+        if (isColdStartExplorationCandidate(guide)) {
+            bonus += AiRecommendationTuning.COLD_START_EXPLORATION_BONUS;
+        }
+
         return bonus - penalty;
+    }
+
+    /**
+     * 리뷰·환불·매칭·채팅 신호가 없어 상위 랭크에서 밀리기 쉬운 상태(콜드스타트)로 본다.
+     */
+    private static boolean isColdStartExplorationCandidate(GuideAiProfile guide) {
+        Integer rc = guide.getReviewCount();
+        if (rc != null && rc > 0) {
+            return false;
+        }
+        Integer refunds = guide.getApprovedRefundCount();
+        if (refunds != null && refunds > 0) {
+            return false;
+        }
+        Integer mr = guide.getMatchRequestCount();
+        if (mr != null && mr > 0) {
+            return false;
+        }
+        Integer pm = guide.getProgressedMatchCount();
+        if (pm != null && pm > 0) {
+            return false;
+        }
+        Integer cs = guide.getChatStartCount();
+        return cs == null || cs == 0;
     }
 }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationTuning.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationTuning.java
@@ -14,7 +14,7 @@ public final class AiRecommendationTuning {
     /**
      * 룰/스코어/Reason/응답 계약이 바뀔 때마다 올린다. 로그·API에서 동일 프롬프트 비교 시 정책 변경 여부를 구분하는 데 쓴다.
      */
-    public static final String POLICY_VERSION = "2026.04.15";
+    public static final String POLICY_VERSION = "2026.04.16";
 
     public static final int DEFAULT_TOP_N = 3;
 
@@ -35,6 +35,12 @@ public final class AiRecommendationTuning {
      * 와 겹칠 때마다 활동 점수에서 차감하는 값(한 태그당, {@link com.team6.module.ai.policy.ScoreWeight#ACTIVITY}와 동일 스케일).
      */
     public static final int SOFT_ACTIVITY_PENALTY_PER_TAG = 6;
+
+    /**
+     * 리뷰·매칭·채팅 등 운영 신호가 거의 없는 가이드에 부여하는 탐색 보너스(콜드스타트 노출 완화).
+     * {@link com.team6.module.ai.policy.FeedbackMatchPolicy}에서만 적용.
+     */
+    public static final int COLD_START_EXPLORATION_BONUS = 6;
 
     /** 승인 환불 1건당 감점(상한 {@link #FEEDBACK_REFUND_PENALTY_MAX}). */
     public static final int FEEDBACK_REFUND_PENALTY_PER_APPROVED = 8;

--- a/backend/module-ai/src/test/java/com/team6/module/ai/policy/FeedbackMatchPolicyTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/policy/FeedbackMatchPolicyTest.java
@@ -50,4 +50,22 @@ class FeedbackMatchPolicyTest {
 
         assertThat(score).isEqualTo(-18);
     }
+
+    @Test
+    void score_should_add_cold_start_exploration_bonus_when_no_signals() {
+        GuideAiProfile guide = GuideAiProfile.builder()
+                .guideId(99L)
+                .guideName("신규")
+                .region("제주")
+                .reviewCount(0)
+                .approvedRefundCount(0)
+                .matchRequestCount(0)
+                .progressedMatchCount(0)
+                .chatStartCount(0)
+                .build();
+
+        int score = policy.score(null, guide);
+
+        assertThat(score).isEqualTo(6);
+    }
 }

--- a/backend/module-domain/src/main/java/com/team6/domain/guide/repository/GuideProfileRepository.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/repository/GuideProfileRepository.java
@@ -25,6 +25,12 @@ public interface GuideProfileRepository extends JpaRepository<GuideProfile, Long
     /** 승인·활성 가이드만 (AI 후보 풀 등) */
     Page<GuideProfile> findByIsApprovedTrueAndIsActiveTrue(Pageable pageable);
 
+    /** 지역 문자열 완전 일치(대소문자 무시) — 파싱 지역과 동일 표기 우선 */
+    Page<GuideProfile> findByIsApprovedTrueAndIsActiveTrueAndRegionEqualsIgnoreCase(
+            String region,
+            Pageable pageable
+    );
+
     /** 지역 문자열 부분 일치(대소문자 무시) — 파서 산출 지역과 DB 표기 차이 완화 */
     Page<GuideProfile> findByIsApprovedTrueAndIsActiveTrueAndRegionContainingIgnoreCase(
             String regionFragment,


### PR DESCRIPTION
## 🔗 이슈 번호

Closes #173

## 💡 주요 변경 사항

- `GuideProfileRepository`: 지역 **정확 일치(대소문자 무시)** 조회 메서드 추가
- `DbBackedGuideCandidateProvider`: **정확 일치 → 부분 일치 → 전역** 순으로 후보 로드, `id` 내림차순 정렬, 운영용 **제외 가이드 ID** 필터, **콜드스타트 비율 샘플링**·풀 상한, **정책버전·설정 키 기반** 인메모리 캐시(TTL)
- `LocalGuestAiProperties`: `localguest.ai.candidate-pool` 설정 블록 (`max-pool-size`, `max-fetch-size`, `cold-start-reserve-ratio`, `pool-cache-ttl-seconds`, `excluded-guide-ids`)
- `FeedbackMatchPolicy` + `AiRecommendationTuning`: 리뷰·행동·환불 신호가 없을 때 **콜드스타트 탐색 보너스** (`COLD_START_EXPLORATION_BONUS`), `POLICY_VERSION` 상향
- 단위 테스트 보강 (`DbBackedGuideCandidateProviderTest`, `FeedbackMatchPolicyTest`)

## ⚠️ 주의 사항 / 질문

- 후보 풀 캐시는 **동일 JVM 인메모리**이며, 행동 집계(매칭·환불 수)는 TTL(기본 45초) 내 스냅샷일 수 있음. 운영에서 TTL·상한은 YAML로 조정
- DB 스키마 변경 없음. 노출 제한은 현재 **제외 ID 목록**으로만 지원(추후 프로필 플래그와 연동 가능)

## ✅ 체크리스트

- [x] 빌드가 정상적으로 되는가? (`./gradlew :module-ai:test :module-ai-integration:test :api-server:compileJava`)
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가? (`Feat/be#173: …`)
- [x] `.gitignore`에 설정 파일이 잘 포함되었는가? (로컬 시크릿 미커밋)
