### PR TITLE
Feat/be#175 AI 스코어링·폴백 정책 튜닝(YAML·조합룰·base 개선)

### DIFF
--- a/backend/module-ai/src/main/java/com/team6/module/ai/config/LocalGuestAiProperties.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/config/LocalGuestAiProperties.java
@@ -33,6 +33,11 @@ public class LocalGuestAiProperties {
      */
     private CandidatePoolSettings candidatePool = new CandidatePoolSettings();
 
+    /**
+     * 룰 스코어·피드백·조합 보너스({@code localguest.ai.scoring-policy}).
+     */
+    private ScoringPolicySettings scoringPolicy = new ScoringPolicySettings();
+
     @Getter
     @Setter
     public static class ParserSettings {

--- a/backend/module-ai/src/main/java/com/team6/module/ai/config/ModuleAiConfiguration.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/config/ModuleAiConfiguration.java
@@ -1,9 +1,15 @@
 package com.team6.module.ai.config;
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @EnableConfigurationProperties(LocalGuestAiProperties.class)
 public class ModuleAiConfiguration {
+
+    @Bean
+    public ScoringPolicySnapshot scoringPolicySnapshot(LocalGuestAiProperties properties) {
+        return ScoringPolicySnapshot.from(properties.getScoringPolicy());
+    }
 }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/config/ScoringPolicySettings.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/config/ScoringPolicySettings.java
@@ -1,0 +1,70 @@
+package com.team6.module.ai.config;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 룰 기반 스코어·피드백 가중치(YAML {@code localguest.ai.scoring-policy}).
+ * 기본값은 기존 {@link com.team6.module.ai.policy.ScoreWeight}·{@link com.team6.module.ai.support.AiRecommendationTuning} 상수와 동일하다.
+ */
+@Getter
+@Setter
+public class ScoringPolicySettings {
+
+    private int weightRegion = 30;
+    private int weightRegionAdjacent = 15;
+    private int weightStyle = 25;
+    private int weightBudget = 15;
+    private int weightBudgetAdjacent = 7;
+    private int weightActivity = 10;
+    private int weightLanguage = 10;
+
+    private int softActivityPenaltyPerTag = 6;
+    private int coldStartExplorationBonus = 6;
+
+    private int feedbackRefundPenaltyPerApproved = 8;
+    private int feedbackRefundPenaltyMax = 24;
+    private int feedbackLowRatingMinReviews = 3;
+    private double feedbackLowRatingThreshold = 3.5d;
+    private int feedbackLowRatingPenalty = 10;
+    private double feedbackVeryLowRatingThreshold = 2.5d;
+    private int feedbackVeryLowRatingPenalty = 16;
+
+    private int feedbackMatchRequestBonusPerCount = 1;
+    private int feedbackMatchRequestBonusMax = 5;
+    private int feedbackProgressMatchBonusPerCount = 3;
+    private int feedbackProgressMatchBonusMax = 12;
+    private int feedbackChatStartBonusPerCount = 2;
+    private int feedbackChatStartBonusMax = 8;
+
+    /**
+     * 이 값 미만이면 전략적 폴백(조건 완화)을 시도한다.
+     */
+    private int lowSignalScoreThreshold = 15;
+
+    /**
+     * 완화 후 Top1이 여전히 {@link #lowSignalScoreThreshold} 미만이어도,
+     * 베이스 대비 이만큼 이상 올랐으면 수용한다(0이면 비활성).
+     */
+    private int fallbackMinImprovementOverBase = 4;
+
+    /**
+     * 제품 룰: 예산·스타일·활동 태그 조합 보너스(예: 높음 예산 + 시장).
+     */
+    private List<ComboRuleSetting> comboRules = new ArrayList<>();
+
+    @Getter
+    @Setter
+    public static class ComboRuleSetting {
+        /** 비우면 예산 조건 없음 */
+        private String budgetLevel;
+        /** 비우면 스타일 조건 없음 */
+        private String travelStyle;
+        /** 선호 활동 태그(정규화 전 표기; 매칭 시 {@link com.team6.module.ai.parser.KeywordNormalizer} 적용) */
+        private List<String> requireActivityTagsAll = new ArrayList<>();
+        private int bonusPoints;
+    }
+}

--- a/backend/module-ai/src/main/java/com/team6/module/ai/config/ScoringPolicySnapshot.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/config/ScoringPolicySnapshot.java
@@ -1,0 +1,100 @@
+package com.team6.module.ai.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 런타임에 고정된 스코어링 스냅샷(테스트·빈에서 주입).
+ */
+public record ScoringPolicySnapshot(
+        int weightRegion,
+        int weightRegionAdjacent,
+        int weightStyle,
+        int weightBudget,
+        int weightBudgetAdjacent,
+        int weightActivity,
+        int weightLanguage,
+        int softActivityPenaltyPerTag,
+        int coldStartExplorationBonus,
+        int feedbackRefundPenaltyPerApproved,
+        int feedbackRefundPenaltyMax,
+        int feedbackLowRatingMinReviews,
+        double feedbackLowRatingThreshold,
+        int feedbackLowRatingPenalty,
+        double feedbackVeryLowRatingThreshold,
+        int feedbackVeryLowRatingPenalty,
+        int feedbackMatchRequestBonusPerCount,
+        int feedbackMatchRequestBonusMax,
+        int feedbackProgressMatchBonusPerCount,
+        int feedbackProgressMatchBonusMax,
+        int feedbackChatStartBonusPerCount,
+        int feedbackChatStartBonusMax,
+        int lowSignalScoreThreshold,
+        int fallbackMinImprovementOverBase,
+        List<ComboRule> comboRules
+) {
+    public record ComboRule(
+            String budgetLevel,
+            String travelStyle,
+            List<String> requireActivityTagsAll,
+            int bonusPoints
+    ) {
+    }
+
+    public static ScoringPolicySnapshot from(ScoringPolicySettings s) {
+        if (s == null) {
+            return defaults();
+        }
+        List<ComboRule> rules = new ArrayList<>();
+        if (s.getComboRules() != null) {
+            for (ScoringPolicySettings.ComboRuleSetting cr : s.getComboRules()) {
+                if (cr == null) {
+                    continue;
+                }
+                List<String> tags = cr.getRequireActivityTagsAll() == null
+                        ? List.of()
+                        : List.copyOf(cr.getRequireActivityTagsAll());
+                rules.add(new ComboRule(
+                        cr.getBudgetLevel(),
+                        cr.getTravelStyle(),
+                        tags,
+                        cr.getBonusPoints()
+                ));
+            }
+        }
+        return new ScoringPolicySnapshot(
+                s.getWeightRegion(),
+                s.getWeightRegionAdjacent(),
+                s.getWeightStyle(),
+                s.getWeightBudget(),
+                s.getWeightBudgetAdjacent(),
+                s.getWeightActivity(),
+                s.getWeightLanguage(),
+                s.getSoftActivityPenaltyPerTag(),
+                s.getColdStartExplorationBonus(),
+                s.getFeedbackRefundPenaltyPerApproved(),
+                s.getFeedbackRefundPenaltyMax(),
+                s.getFeedbackLowRatingMinReviews(),
+                s.getFeedbackLowRatingThreshold(),
+                s.getFeedbackLowRatingPenalty(),
+                s.getFeedbackVeryLowRatingThreshold(),
+                s.getFeedbackVeryLowRatingPenalty(),
+                s.getFeedbackMatchRequestBonusPerCount(),
+                s.getFeedbackMatchRequestBonusMax(),
+                s.getFeedbackProgressMatchBonusPerCount(),
+                s.getFeedbackProgressMatchBonusMax(),
+                s.getFeedbackChatStartBonusPerCount(),
+                s.getFeedbackChatStartBonusMax(),
+                s.getLowSignalScoreThreshold(),
+                s.getFallbackMinImprovementOverBase(),
+                List.copyOf(rules)
+        );
+    }
+
+    /**
+     * {@link ScoringPolicySettings} 필드 기본값과 동일한 스냅샷(단위 테스트용).
+     */
+    public static ScoringPolicySnapshot defaults() {
+        return from(new ScoringPolicySettings());
+    }
+}

--- a/backend/module-ai/src/main/java/com/team6/module/ai/engine/ReasonGenerator.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/engine/ReasonGenerator.java
@@ -1,10 +1,10 @@
 package com.team6.module.ai.engine;
 
+import com.team6.module.ai.config.ScoringPolicySnapshot;
 import com.team6.module.ai.model.GuideAiProfile;
 import com.team6.module.ai.model.TravelerPreference;
 import com.team6.module.ai.parser.KeywordNormalizer;
 import com.team6.module.ai.support.AdjacentRegionProvider;
-import com.team6.module.ai.support.AiRecommendationTuning;
 import com.team6.module.ai.support.BudgetTier;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -20,6 +20,7 @@ import java.util.stream.Collectors;
 public class ReasonGenerator {
 
     private final AdjacentRegionProvider adjacentRegionProvider;
+    private final ScoringPolicySnapshot scoring;
 
     public static final String CODE_REGION_MATCH = "REGION_MATCH";
     public static final String CODE_REGION_ADJACENT = "REGION_ADJACENT";
@@ -33,7 +34,7 @@ public class ReasonGenerator {
     public static final String CODE_GENERAL_FALLBACK = "GENERAL_FALLBACK";
     public static final String CODE_FEEDBACK_REFUND_APPROVED = "FEEDBACK_REFUND_APPROVED";
     public static final String CODE_FEEDBACK_LOW_RATING = "FEEDBACK_LOW_RATING";
-    /** 평균 평점이 매우 낮을 때(정책 임계값은 {@link AiRecommendationTuning}). */
+    /** 평균 평점이 매우 낮을 때(정책 임계값은 {@link ScoringPolicySnapshot}). */
     public static final String CODE_FEEDBACK_VERY_LOW_RATING = "FEEDBACK_VERY_LOW_RATING";
 
     /** 상위 근거 노출 개수(지역·활동·부담·스타일·예산·피드백 등이 겹칠 때 잘리지 않도록 여유). */
@@ -193,15 +194,15 @@ public class ReasonGenerator {
         }
 
         if (guide.getAverageRating() != null && guide.getReviewCount() != null
-                && guide.getReviewCount() >= AiRecommendationTuning.FEEDBACK_LOW_RATING_MIN_REVIEWS) {
+                && guide.getReviewCount() >= scoring.feedbackLowRatingMinReviews()) {
             double a = guide.getAverageRating().doubleValue();
-            if (a < AiRecommendationTuning.FEEDBACK_VERY_LOW_RATING_THRESHOLD) {
+            if (a < scoring.feedbackVeryLowRatingThreshold()) {
                 segments.add(new Segment(
                         CODE_FEEDBACK_VERY_LOW_RATING,
                         "평균 리뷰가 매우 낮아 신중히 반영했습니다",
                         List.of(guide.getAverageRating().toPlainString(), String.valueOf(guide.getReviewCount()))
                 ));
-            } else if (a < AiRecommendationTuning.FEEDBACK_LOW_RATING_THRESHOLD) {
+            } else if (a < scoring.feedbackLowRatingThreshold()) {
                 segments.add(new Segment(
                         CODE_FEEDBACK_LOW_RATING,
                         "평균 리뷰가 낮은 편이라 보수적으로 반영했습니다",

--- a/backend/module-ai/src/main/java/com/team6/module/ai/engine/ScoreCalculator.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/engine/ScoreCalculator.java
@@ -4,6 +4,7 @@ import com.team6.module.ai.model.GuideAiProfile;
 import com.team6.module.ai.model.TravelerPreference;
 import com.team6.module.ai.policy.ActivityMatchPolicy;
 import com.team6.module.ai.policy.BudgetMatchPolicy;
+import com.team6.module.ai.policy.ComboMatchPolicy;
 import com.team6.module.ai.policy.FeedbackMatchPolicy;
 import com.team6.module.ai.policy.LanguageMatchPolicy;
 import com.team6.module.ai.policy.RegionMatchPolicy;
@@ -23,6 +24,7 @@ public class ScoreCalculator {
     private final ActivityMatchPolicy activityMatchPolicy;
     private final LanguageMatchPolicy languageMatchPolicy;
     private final FeedbackMatchPolicy feedbackMatchPolicy;
+    private final ComboMatchPolicy comboMatchPolicy;
     private final AiRecommendationMetrics recommendationMetrics;
 
     public int calculate(TravelerPreference pref, GuideAiProfile guide) {
@@ -34,6 +36,7 @@ public class ScoreCalculator {
         score += languageMatchPolicy.score(pref, guide);
         int feedback = feedbackMatchPolicy.score(pref, guide);
         score += feedback;
+        score += comboMatchPolicy.score(pref, guide);
         if (feedback < 0) {
             recommendationMetrics.recordFeedbackPenalty(-feedback, AiRecommendationTuning.POLICY_VERSION);
         }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/policy/ActivityMatchPolicy.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/policy/ActivityMatchPolicy.java
@@ -1,9 +1,10 @@
 package com.team6.module.ai.policy;
 
+import com.team6.module.ai.config.ScoringPolicySnapshot;
 import com.team6.module.ai.model.GuideAiProfile;
 import com.team6.module.ai.model.TravelerPreference;
 import com.team6.module.ai.parser.KeywordNormalizer;
-import com.team6.module.ai.support.AiRecommendationTuning;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -11,7 +12,10 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 @Component
+@RequiredArgsConstructor
 public class ActivityMatchPolicy {
+
+    private final ScoringPolicySnapshot scoring;
 
     public int score(TravelerPreference pref, GuideAiProfile guide) {
         if (guide.getSpecialtyTags() == null) {
@@ -34,7 +38,7 @@ public class ActivityMatchPolicy {
                     .filter(guideTags::contains)
                     .count();
 
-            positive = (int) matchedCount * ScoreWeight.ACTIVITY;
+            positive = (int) matchedCount * scoring.weightActivity();
         }
 
         int penalty = softPenaltyDeduction(pref.getSoftPenaltyActivityTags(), guideTags);
@@ -42,7 +46,7 @@ public class ActivityMatchPolicy {
         return Math.max(0, positive - penalty);
     }
 
-    private static int softPenaltyDeduction(List<String> softPenaltyTags, Set<String> guideTags) {
+    private int softPenaltyDeduction(List<String> softPenaltyTags, Set<String> guideTags) {
         if (softPenaltyTags == null || softPenaltyTags.isEmpty()) {
             return 0;
         }
@@ -51,6 +55,6 @@ public class ActivityMatchPolicy {
                 .filter(s -> s != null && !s.isBlank())
                 .collect(Collectors.toSet());
         long hits = guideTags.stream().filter(soft::contains).count();
-        return (int) hits * AiRecommendationTuning.SOFT_ACTIVITY_PENALTY_PER_TAG;
+        return (int) hits * scoring.softActivityPenaltyPerTag();
     }
 }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/policy/BudgetMatchPolicy.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/policy/BudgetMatchPolicy.java
@@ -1,12 +1,17 @@
 package com.team6.module.ai.policy;
 
+import com.team6.module.ai.config.ScoringPolicySnapshot;
 import com.team6.module.ai.model.GuideAiProfile;
 import com.team6.module.ai.model.TravelerPreference;
 import com.team6.module.ai.support.BudgetTier;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class BudgetMatchPolicy {
+
+    private final ScoringPolicySnapshot scoring;
 
     public int score(TravelerPreference pref, GuideAiProfile guide) {
         if (pref.getBudgetLevel() == null || guide.getPriceLevel() == null) {
@@ -15,8 +20,8 @@ public class BudgetMatchPolicy {
         String p = pref.getBudgetLevel().trim();
         String g = guide.getPriceLevel().trim();
         if (BudgetTier.exactMatch(p, g)) {
-            return ScoreWeight.BUDGET;
+            return scoring.weightBudget();
         }
-        return BudgetTier.adjacentTiers(p, g) ? ScoreWeight.BUDGET_ADJACENT : 0;
+        return BudgetTier.adjacentTiers(p, g) ? scoring.weightBudgetAdjacent() : 0;
     }
 }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/policy/ComboMatchPolicy.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/policy/ComboMatchPolicy.java
@@ -1,0 +1,75 @@
+package com.team6.module.ai.policy;
+
+import com.team6.module.ai.config.ScoringPolicySnapshot;
+import com.team6.module.ai.model.GuideAiProfile;
+import com.team6.module.ai.model.TravelerPreference;
+import com.team6.module.ai.parser.KeywordNormalizer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * 예산·스타일·활동 태그 조합 등 제품 룰 보너스({@link com.team6.module.ai.config.ScoringPolicySettings#getComboRules()}).
+ */
+@Component
+@RequiredArgsConstructor
+public class ComboMatchPolicy {
+
+    private final ScoringPolicySnapshot scoring;
+
+    public int score(TravelerPreference pref, GuideAiProfile guide) {
+        if (pref == null || scoring.comboRules() == null || scoring.comboRules().isEmpty()) {
+            return 0;
+        }
+        int total = 0;
+        for (ScoringPolicySnapshot.ComboRule rule : scoring.comboRules()) {
+            if (rule == null || rule.bonusPoints() == 0) {
+                continue;
+            }
+            if (matchesPreference(pref, rule)) {
+                total += rule.bonusPoints();
+            }
+        }
+        return total;
+    }
+
+    private static boolean matchesPreference(TravelerPreference pref, ScoringPolicySnapshot.ComboRule rule) {
+        if (rule.requireActivityTagsAll() == null || rule.requireActivityTagsAll().isEmpty()) {
+            return false;
+        }
+        if (rule.budgetLevel() != null && !rule.budgetLevel().isBlank()) {
+            if (pref.getBudgetLevel() == null
+                    || !pref.getBudgetLevel().trim().equalsIgnoreCase(rule.budgetLevel().trim())) {
+                return false;
+            }
+        }
+        if (rule.travelStyle() != null && !rule.travelStyle().isBlank()) {
+            if (pref.getTravelStyle() == null
+                    || !pref.getTravelStyle().trim().equalsIgnoreCase(rule.travelStyle().trim())) {
+                return false;
+            }
+        }
+        Set<String> prefTags = toNormalizedTagSet(pref.getActivityTags());
+        for (String required : rule.requireActivityTagsAll()) {
+            String n = KeywordNormalizer.normalizeTag(required);
+            if (n == null || n.isBlank() || !prefTags.contains(n)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static Set<String> toNormalizedTagSet(List<String> tags) {
+        if (tags == null || tags.isEmpty()) {
+            return Set.of();
+        }
+        return tags.stream()
+                .map(KeywordNormalizer::normalizeTag)
+                .filter(s -> s != null && !s.isBlank())
+                .collect(Collectors.toCollection(HashSet::new));
+    }
+}

--- a/backend/module-ai/src/main/java/com/team6/module/ai/policy/FeedbackMatchPolicy.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/policy/FeedbackMatchPolicy.java
@@ -1,18 +1,22 @@
 package com.team6.module.ai.policy;
 
+import com.team6.module.ai.config.ScoringPolicySnapshot;
 import com.team6.module.ai.model.GuideAiProfile;
 import com.team6.module.ai.model.TravelerPreference;
-import com.team6.module.ai.support.AiRecommendationTuning;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.math.BigDecimal;
 
 /**
- * 리뷰·환불 감점 + 실제 전환 행동 데이터 기반 소폭 가산.
+ * 리뷰·환불 감점 + 실제 전환 행동 데이터 기반 소폭 가산 + 콜드스타트 탐색 보너스.
  * 선호(TravelerPreference)와 무관하게 가이드의 운영 품질/서비스 연결 신호만 본다.
  */
 @Component
+@RequiredArgsConstructor
 public class FeedbackMatchPolicy {
+
+    private final ScoringPolicySnapshot scoring;
 
     public int score(TravelerPreference pref, GuideAiProfile guide) {
         int penalty = 0;
@@ -21,49 +25,49 @@ public class FeedbackMatchPolicy {
         Integer refunds = guide.getApprovedRefundCount();
         if (refunds != null && refunds > 0) {
             penalty += Math.min(
-                    refunds * AiRecommendationTuning.FEEDBACK_REFUND_PENALTY_PER_APPROVED,
-                    AiRecommendationTuning.FEEDBACK_REFUND_PENALTY_MAX
+                    refunds * scoring.feedbackRefundPenaltyPerApproved(),
+                    scoring.feedbackRefundPenaltyMax()
             );
         }
 
         BigDecimal avg = guide.getAverageRating();
         Integer reviewCount = guide.getReviewCount();
         if (avg != null && reviewCount != null
-                && reviewCount >= AiRecommendationTuning.FEEDBACK_LOW_RATING_MIN_REVIEWS) {
+                && reviewCount >= scoring.feedbackLowRatingMinReviews()) {
             double a = avg.doubleValue();
-            if (a < AiRecommendationTuning.FEEDBACK_VERY_LOW_RATING_THRESHOLD) {
-                penalty += AiRecommendationTuning.FEEDBACK_VERY_LOW_RATING_PENALTY;
-            } else if (a < AiRecommendationTuning.FEEDBACK_LOW_RATING_THRESHOLD) {
-                penalty += AiRecommendationTuning.FEEDBACK_LOW_RATING_PENALTY;
+            if (a < scoring.feedbackVeryLowRatingThreshold()) {
+                penalty += scoring.feedbackVeryLowRatingPenalty();
+            } else if (a < scoring.feedbackLowRatingThreshold()) {
+                penalty += scoring.feedbackLowRatingPenalty();
             }
         }
 
         Integer matchRequests = guide.getMatchRequestCount();
         if (matchRequests != null && matchRequests > 0) {
             bonus += Math.min(
-                    matchRequests * AiRecommendationTuning.FEEDBACK_MATCH_REQUEST_BONUS_PER_COUNT,
-                    AiRecommendationTuning.FEEDBACK_MATCH_REQUEST_BONUS_MAX
+                    matchRequests * scoring.feedbackMatchRequestBonusPerCount(),
+                    scoring.feedbackMatchRequestBonusMax()
             );
         }
 
         Integer progressedMatches = guide.getProgressedMatchCount();
         if (progressedMatches != null && progressedMatches > 0) {
             bonus += Math.min(
-                    progressedMatches * AiRecommendationTuning.FEEDBACK_PROGRESS_MATCH_BONUS_PER_COUNT,
-                    AiRecommendationTuning.FEEDBACK_PROGRESS_MATCH_BONUS_MAX
+                    progressedMatches * scoring.feedbackProgressMatchBonusPerCount(),
+                    scoring.feedbackProgressMatchBonusMax()
             );
         }
 
         Integer chatStarts = guide.getChatStartCount();
         if (chatStarts != null && chatStarts > 0) {
             bonus += Math.min(
-                    chatStarts * AiRecommendationTuning.FEEDBACK_CHAT_START_BONUS_PER_COUNT,
-                    AiRecommendationTuning.FEEDBACK_CHAT_START_BONUS_MAX
+                    chatStarts * scoring.feedbackChatStartBonusPerCount(),
+                    scoring.feedbackChatStartBonusMax()
             );
         }
 
         if (isColdStartExplorationCandidate(guide)) {
-            bonus += AiRecommendationTuning.COLD_START_EXPLORATION_BONUS;
+            bonus += scoring.coldStartExplorationBonus();
         }
 
         return bonus - penalty;

--- a/backend/module-ai/src/main/java/com/team6/module/ai/policy/LanguageMatchPolicy.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/policy/LanguageMatchPolicy.java
@@ -1,15 +1,20 @@
 package com.team6.module.ai.policy;
 
+import com.team6.module.ai.config.ScoringPolicySnapshot;
 import com.team6.module.ai.model.GuideAiProfile;
 import com.team6.module.ai.model.TravelerPreference;
 import com.team6.module.ai.parser.KeywordNormalizer;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.Set;
 import java.util.stream.Collectors;
 
 @Component
+@RequiredArgsConstructor
 public class LanguageMatchPolicy {
+
+    private final ScoringPolicySnapshot scoring;
 
     public int score(TravelerPreference pref, GuideAiProfile guide) {
         if (pref.getPreferredLanguages() == null || guide.getLanguages() == null) {
@@ -28,6 +33,6 @@ public class LanguageMatchPolicy {
 
         boolean matched = prefLang.stream().anyMatch(guideLang::contains);
 
-        return matched ? ScoreWeight.LANGUAGE : 0;
+        return matched ? scoring.weightLanguage() : 0;
     }
 }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/policy/RegionMatchPolicy.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/policy/RegionMatchPolicy.java
@@ -1,5 +1,6 @@
 package com.team6.module.ai.policy;
 
+import com.team6.module.ai.config.ScoringPolicySnapshot;
 import com.team6.module.ai.model.GuideAiProfile;
 import com.team6.module.ai.model.TravelerPreference;
 import com.team6.module.ai.support.AdjacentRegionProvider;
@@ -11,16 +12,17 @@ import org.springframework.stereotype.Component;
 public class RegionMatchPolicy {
 
     private final AdjacentRegionProvider adjacentRegionProvider;
+    private final ScoringPolicySnapshot scoring;
 
     public int score(TravelerPreference pref, GuideAiProfile guide) {
         if (pref.getRegion() == null || guide.getRegion() == null) {
             return 0;
         }
         if (pref.getRegion().equalsIgnoreCase(guide.getRegion())) {
-            return ScoreWeight.REGION;
+            return scoring.weightRegion();
         }
         return adjacentRegionProvider.isAdjacentTo(pref.getRegion(), guide.getRegion())
-                ? ScoreWeight.REGION_ADJACENT
+                ? scoring.weightRegionAdjacent()
                 : 0;
     }
 }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/policy/ScoreWeight.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/policy/ScoreWeight.java
@@ -1,5 +1,10 @@
 package com.team6.module.ai.policy;
 
+/**
+ * @deprecated 런타임 가중치는 {@link com.team6.module.ai.config.ScoringPolicySnapshot}·
+ * {@code localguest.ai.scoring-policy}를 사용한다. 회귀·문서용 기본값 참고만 한다.
+ */
+@Deprecated
 public final class ScoreWeight {
 
     private ScoreWeight() {

--- a/backend/module-ai/src/main/java/com/team6/module/ai/policy/StyleMatchPolicy.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/policy/StyleMatchPolicy.java
@@ -1,16 +1,21 @@
 package com.team6.module.ai.policy;
 
+import com.team6.module.ai.config.ScoringPolicySnapshot;
 import com.team6.module.ai.model.GuideAiProfile;
 import com.team6.module.ai.model.TravelerPreference;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class StyleMatchPolicy {
+
+    private final ScoringPolicySnapshot scoring;
 
     public int score(TravelerPreference pref, GuideAiProfile guide) {
         if (pref.getTravelStyle() == null || guide.getGuideStyle() == null) {
             return 0;
         }
-        return pref.getTravelStyle().equalsIgnoreCase(guide.getGuideStyle()) ? ScoreWeight.STYLE : 0;
+        return pref.getTravelStyle().equalsIgnoreCase(guide.getGuideStyle()) ? scoring.weightStyle() : 0;
     }
 }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
@@ -2,6 +2,7 @@ package com.team6.module.ai.service;
 
 import com.team6.module.ai.dto.request.GuideRecommendRequest;
 import com.team6.module.ai.dto.response.GuideRecommendResponse;
+import com.team6.module.ai.config.ScoringPolicySnapshot;
 import com.team6.module.ai.parser.PromptParser;
 import com.team6.module.ai.support.AdjacentRegionProvider;
 import com.team6.module.ai.support.AiRecommendationMetrics;
@@ -33,17 +34,20 @@ public class PromptRecommendationService {
     private final AiRecommendationService aiRecommendationService;
     private final AdjacentRegionProvider adjacentRegionProvider;
     private final AiRecommendationMetrics metrics;
+    private final ScoringPolicySnapshot scoringPolicy;
 
     public PromptRecommendationService(
             PromptParser promptParser,
             AiRecommendationService aiRecommendationService,
             AdjacentRegionProvider adjacentRegionProvider,
-            AiRecommendationMetrics metrics
+            AiRecommendationMetrics metrics,
+            ScoringPolicySnapshot scoringPolicy
     ) {
         this.promptParser = promptParser;
         this.aiRecommendationService = aiRecommendationService;
         this.adjacentRegionProvider = adjacentRegionProvider;
         this.metrics = metrics;
+        this.scoringPolicy = scoringPolicy;
     }
 
     private static final String NOTICE_REGION_REQUIRED =
@@ -462,7 +466,7 @@ public class PromptRecommendationService {
 
         boolean noResults = base == null || base.getTotalCount() == 0;
         int score = topScore(base);
-        boolean lowScore = !noResults && score < AiRecommendationTuning.LOW_SIGNAL_SCORE_THRESHOLD;
+        boolean lowScore = !noResults && score < scoringPolicy.lowSignalScoreThreshold();
         if (!noResults && !lowScore) {
             return FallbackOutcome.noRelax(base);
         }
@@ -474,7 +478,7 @@ public class PromptRecommendationService {
                 ? "활동·스타일·지역 순으로 조건을 단계적으로 완화해 찾아봤어요."
                 : "활동·스타일·지역 순으로 조건을 단계적으로 완화해 추천을 다시 구성해 봤어요.";
 
-        StrategicChainResult chain = runStrategicRelaxationChain(effective, base);
+        StrategicChainResult chain = runStrategicRelaxationChain(effective, base, scoringPolicy);
         boolean improved = chain.winningStage() != RelaxStage.NONE;
         GuideRecommendResponse finalResp = improved ? chain.bestResponse() : base;
         boolean exhausted = !improved;
@@ -494,7 +498,8 @@ public class PromptRecommendationService {
 
     private StrategicChainResult runStrategicRelaxationChain(
             GuideRecommendRequest languageAnchor,
-            GuideRecommendResponse baseline
+            GuideRecommendResponse baseline,
+            ScoringPolicySnapshot scoring
     ) {
         GuideRecommendRequest current = languageAnchor;
         for (RelaxStage step : STRATEGIC_RELAX_ORDER) {
@@ -503,17 +508,35 @@ public class PromptRecommendationService {
             }
             current = applyStrategicRelaxStep(languageAnchor, current, step);
             GuideRecommendResponse retried = aiRecommendationService.recommend(current);
-            if (acceptsStrategicRetry(retried)) {
+            if (acceptsStrategicRetry(retried, baseline, scoring)) {
                 return new StrategicChainResult(retried, step);
             }
         }
         return new StrategicChainResult(baseline, RelaxStage.NONE);
     }
 
-    private static boolean acceptsStrategicRetry(GuideRecommendResponse resp) {
-        return resp != null
-                && resp.getTotalCount() > 0
-                && topScore(resp) >= AiRecommendationTuning.LOW_SIGNAL_SCORE_THRESHOLD;
+    private static boolean acceptsStrategicRetry(
+            GuideRecommendResponse retried,
+            GuideRecommendResponse baseline,
+            ScoringPolicySnapshot scoring
+    ) {
+        if (retried == null || retried.getTotalCount() == 0) {
+            return false;
+        }
+        int top = topScore(retried);
+        int threshold = scoring.lowSignalScoreThreshold();
+        if (top >= threshold) {
+            return true;
+        }
+        int minGain = scoring.fallbackMinImprovementOverBase();
+        if (minGain <= 0) {
+            return false;
+        }
+        int baseTop = topScore(baseline);
+        if (baseline == null || baseline.getTotalCount() == 0) {
+            return top >= threshold;
+        }
+        return top >= baseTop + minGain;
     }
 
     private static boolean isStrategicRelaxApplicable(GuideRecommendRequest req, RelaxStage step) {

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationTuning.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationTuning.java
@@ -1,10 +1,10 @@
 package com.team6.module.ai.support;
 
 /**
- * 룰 기반 추천의 기본 튜닝 값(yml 없이 코드로 고정). 변경 시 회귀 테스트를 함께 점검한다.
+ * 룰 기반 추천의 공통 튜닝(스코어 가중·피드백 수치는 {@link com.team6.module.ai.config.ScoringPolicySettings}).
  * <p>
  * Diversity rerank 가중치는 {@link com.team6.module.ai.engine.DiversityRerankConstants},
- * 정책별 점수 가중은 {@link com.team6.module.ai.policy.ScoreWeight}를 참고한다.
+ * 정책별 점수 가중은 {@link com.team6.module.ai.config.ScoringPolicySnapshot}를 참고한다.
  */
 public final class AiRecommendationTuning {
 
@@ -14,50 +14,16 @@ public final class AiRecommendationTuning {
     /**
      * 룰/스코어/Reason/응답 계약이 바뀔 때마다 올린다. 로그·API에서 동일 프롬프트 비교 시 정책 변경 여부를 구분하는 데 쓴다.
      */
-    public static final String POLICY_VERSION = "2026.04.16";
+    public static final String POLICY_VERSION = "2026.04.17";
 
     public static final int DEFAULT_TOP_N = 3;
 
     /** 추천 카드·응답에 실을 공개 피드 썸네일 URL 상한(최신순). */
     public static final int PUBLIC_FEED_THUMBNAIL_MAX = 4;
 
-    /** 이 점수 미만이면 기존 조건 완화(fallback) 재시도를 시도한다. */
-    public static final int LOW_SIGNAL_SCORE_THRESHOLD = 15;
-
     /**
      * 요청 지역과 정확히 일치하는 가이드 수가 이 값 이상이면, 해당 지역 가이드만으로 후보를 제한한다.
      * 미만이면 {@link AdjacentRegionMap} 기반으로 인접 지역까지 후보를 넓힌다.
      */
     public static final int MIN_EXACT_REGION_CANDIDATES = 2;
-
-    /**
-     * 가이드 전문 태그가 {@link com.team6.module.ai.model.TravelerPreference#getSoftPenaltyActivityTags()}
-     * 와 겹칠 때마다 활동 점수에서 차감하는 값(한 태그당, {@link com.team6.module.ai.policy.ScoreWeight#ACTIVITY}와 동일 스케일).
-     */
-    public static final int SOFT_ACTIVITY_PENALTY_PER_TAG = 6;
-
-    /**
-     * 리뷰·매칭·채팅 등 운영 신호가 거의 없는 가이드에 부여하는 탐색 보너스(콜드스타트 노출 완화).
-     * {@link com.team6.module.ai.policy.FeedbackMatchPolicy}에서만 적용.
-     */
-    public static final int COLD_START_EXPLORATION_BONUS = 6;
-
-    /** 승인 환불 1건당 감점(상한 {@link #FEEDBACK_REFUND_PENALTY_MAX}). */
-    public static final int FEEDBACK_REFUND_PENALTY_PER_APPROVED = 8;
-    public static final int FEEDBACK_REFUND_PENALTY_MAX = 24;
-
-    /** 평균 평점 감점: 최소 리뷰 수(노이즈 완화). */
-    public static final int FEEDBACK_LOW_RATING_MIN_REVIEWS = 3;
-    public static final double FEEDBACK_LOW_RATING_THRESHOLD = 3.5;
-    public static final int FEEDBACK_LOW_RATING_PENALTY = 10;
-    public static final double FEEDBACK_VERY_LOW_RATING_THRESHOLD = 2.5;
-    public static final int FEEDBACK_VERY_LOW_RATING_PENALTY = 16;
-
-    /** 실제 행동 데이터 기반 보정(요청/진행/채팅)은 과적합을 피하기 위해 소폭 가산만 적용한다. */
-    public static final int FEEDBACK_MATCH_REQUEST_BONUS_PER_COUNT = 1;
-    public static final int FEEDBACK_MATCH_REQUEST_BONUS_MAX = 5;
-    public static final int FEEDBACK_PROGRESS_MATCH_BONUS_PER_COUNT = 3;
-    public static final int FEEDBACK_PROGRESS_MATCH_BONUS_MAX = 12;
-    public static final int FEEDBACK_CHAT_START_BONUS_PER_COUNT = 2;
-    public static final int FEEDBACK_CHAT_START_BONUS_MAX = 8;
 }

--- a/backend/module-ai/src/test/java/com/team6/module/ai/engine/MatchingEngineDiversityTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/engine/MatchingEngineDiversityTest.java
@@ -1,6 +1,8 @@
 package com.team6.module.ai.engine;
 
 import com.team6.module.ai.config.LocalGuestAiProperties;
+import com.team6.module.ai.config.ScoringPolicySnapshot;
+import com.team6.module.ai.policy.ComboMatchPolicy;
 import com.team6.module.ai.dto.response.GuideRecommendResponse;
 import com.team6.module.ai.model.GuideAiProfile;
 import com.team6.module.ai.model.TravelerPreference;
@@ -27,17 +29,19 @@ class MatchingEngineDiversityTest {
 
     private static MatchingEngine engine() {
         LocalGuestAiProperties aiProps = new LocalGuestAiProperties();
+        ScoringPolicySnapshot scoring = ScoringPolicySnapshot.defaults();
         AdjacentRegionProvider adjacent = new AdjacentRegionProvider(aiProps);
         ScoreCalculator scoreCalculator = new ScoreCalculator(
-                new RegionMatchPolicy(adjacent),
-                new StyleMatchPolicy(),
-                new BudgetMatchPolicy(),
-                new ActivityMatchPolicy(),
-                new LanguageMatchPolicy(),
-                new FeedbackMatchPolicy(),
+                new RegionMatchPolicy(adjacent, scoring),
+                new StyleMatchPolicy(scoring),
+                new BudgetMatchPolicy(scoring),
+                new ActivityMatchPolicy(scoring),
+                new LanguageMatchPolicy(scoring),
+                new FeedbackMatchPolicy(scoring),
+                new ComboMatchPolicy(scoring),
                 new AiRecommendationMetrics(new SimpleMeterRegistry())
         );
-        return new MatchingEngine(scoreCalculator, new ReasonGenerator(adjacent), adjacent);
+        return new MatchingEngine(scoreCalculator, new ReasonGenerator(adjacent, scoring), adjacent);
     }
 
     @Test

--- a/backend/module-ai/src/test/java/com/team6/module/ai/engine/ReasonGeneratorTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/engine/ReasonGeneratorTest.java
@@ -1,10 +1,10 @@
 package com.team6.module.ai.engine;
 
 import com.team6.module.ai.config.LocalGuestAiProperties;
+import com.team6.module.ai.config.ScoringPolicySnapshot;
 import com.team6.module.ai.model.GuideAiProfile;
 import com.team6.module.ai.model.TravelerPreference;
 import com.team6.module.ai.support.AdjacentRegionProvider;
-import com.team6.module.ai.support.AiRecommendationTuning;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
@@ -15,7 +15,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ReasonGeneratorTest {
 
     private static ReasonGenerator generator() {
-        return new ReasonGenerator(new AdjacentRegionProvider(new LocalGuestAiProperties()));
+        ScoringPolicySnapshot scoring = ScoringPolicySnapshot.defaults();
+        return new ReasonGenerator(new AdjacentRegionProvider(new LocalGuestAiProperties()), scoring);
     }
 
     @Test
@@ -41,7 +42,7 @@ class ReasonGeneratorTest {
         GuideAiProfile guide = GuideAiProfile.builder()
                 .region("제주")
                 .averageRating(BigDecimal.valueOf(2.0))
-                .reviewCount(AiRecommendationTuning.FEEDBACK_LOW_RATING_MIN_REVIEWS)
+                .reviewCount(ScoringPolicySnapshot.defaults().feedbackLowRatingMinReviews())
                 .build();
 
         ReasonBundle bundle = generator().generate(pref, guide, 0);

--- a/backend/module-ai/src/test/java/com/team6/module/ai/engine/ScoreCalculatorFeedbackMetricsTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/engine/ScoreCalculatorFeedbackMetricsTest.java
@@ -7,6 +7,8 @@ import com.team6.module.ai.policy.BudgetMatchPolicy;
 import com.team6.module.ai.policy.FeedbackMatchPolicy;
 import com.team6.module.ai.policy.LanguageMatchPolicy;
 import com.team6.module.ai.config.LocalGuestAiProperties;
+import com.team6.module.ai.config.ScoringPolicySnapshot;
+import com.team6.module.ai.policy.ComboMatchPolicy;
 import com.team6.module.ai.policy.RegionMatchPolicy;
 import com.team6.module.ai.policy.StyleMatchPolicy;
 import com.team6.module.ai.support.AdjacentRegionProvider;
@@ -26,14 +28,16 @@ class ScoreCalculatorFeedbackMetricsTest {
     void calculate_records_feedback_penalty_metrics() {
         SimpleMeterRegistry registry = new SimpleMeterRegistry();
         AiRecommendationMetrics metrics = new AiRecommendationMetrics(registry);
+        ScoringPolicySnapshot scoring = ScoringPolicySnapshot.defaults();
         AdjacentRegionProvider adjacent = new AdjacentRegionProvider(new LocalGuestAiProperties());
         ScoreCalculator calculator = new ScoreCalculator(
-                new RegionMatchPolicy(adjacent),
-                new StyleMatchPolicy(),
-                new BudgetMatchPolicy(),
-                new ActivityMatchPolicy(),
-                new LanguageMatchPolicy(),
-                new FeedbackMatchPolicy(),
+                new RegionMatchPolicy(adjacent, scoring),
+                new StyleMatchPolicy(scoring),
+                new BudgetMatchPolicy(scoring),
+                new ActivityMatchPolicy(scoring),
+                new LanguageMatchPolicy(scoring),
+                new FeedbackMatchPolicy(scoring),
+                new ComboMatchPolicy(scoring),
                 metrics
         );
 

--- a/backend/module-ai/src/test/java/com/team6/module/ai/policy/ActivityMatchPolicyTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/policy/ActivityMatchPolicyTest.java
@@ -1,5 +1,6 @@
 package com.team6.module.ai.policy;
 
+import com.team6.module.ai.config.ScoringPolicySnapshot;
 import com.team6.module.ai.model.GuideAiProfile;
 import com.team6.module.ai.model.TravelerPreference;
 import org.junit.jupiter.api.Test;
@@ -10,7 +11,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class ActivityMatchPolicyTest {
 
-    private final ActivityMatchPolicy policy = new ActivityMatchPolicy();
+    private final ScoringPolicySnapshot scoring = ScoringPolicySnapshot.defaults();
+    private final ActivityMatchPolicy policy = new ActivityMatchPolicy(scoring);
 
     @Test
     void score_should_reduce_when_guide_matches_soft_penalty_tag() {
@@ -25,8 +27,7 @@ class ActivityMatchPolicyTest {
                 .build();
 
         int score = policy.score(pref, guide);
-        // 카페 매칭 10, 등산 soft 패널티 -6 -> 4
-        assertThat(score).isEqualTo(4);
+        assertThat(score).isEqualTo(scoring.weightActivity() - scoring.softActivityPenaltyPerTag());
     }
 
     @Test

--- a/backend/module-ai/src/test/java/com/team6/module/ai/policy/BudgetMatchPolicyTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/policy/BudgetMatchPolicyTest.java
@@ -1,5 +1,6 @@
 package com.team6.module.ai.policy;
 
+import com.team6.module.ai.config.ScoringPolicySnapshot;
 import com.team6.module.ai.model.GuideAiProfile;
 import com.team6.module.ai.model.TravelerPreference;
 import org.junit.jupiter.api.Test;
@@ -8,7 +9,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class BudgetMatchPolicyTest {
 
-    private final BudgetMatchPolicy policy = new BudgetMatchPolicy();
+    private final ScoringPolicySnapshot scoring = ScoringPolicySnapshot.defaults();
+    private final BudgetMatchPolicy policy = new BudgetMatchPolicy(scoring);
 
     @Test
     void score_should_be_full_when_exact_tier_match() {
@@ -16,7 +18,7 @@ class BudgetMatchPolicyTest {
                 TravelerPreference.builder().budgetLevel("중간").build(),
                 GuideAiProfile.builder().priceLevel("중간").build()
         );
-        assertThat(s).isEqualTo(ScoreWeight.BUDGET);
+        assertThat(s).isEqualTo(scoring.weightBudget());
     }
 
     @Test
@@ -29,8 +31,8 @@ class BudgetMatchPolicyTest {
                 TravelerPreference.builder().budgetLevel("중간").build(),
                 GuideAiProfile.builder().priceLevel("높음").build()
         );
-        assertThat(lowMid).isEqualTo(ScoreWeight.BUDGET_ADJACENT);
-        assertThat(midHigh).isEqualTo(ScoreWeight.BUDGET_ADJACENT);
+        assertThat(lowMid).isEqualTo(scoring.weightBudgetAdjacent());
+        assertThat(midHigh).isEqualTo(scoring.weightBudgetAdjacent());
     }
 
     @Test

--- a/backend/module-ai/src/test/java/com/team6/module/ai/policy/ComboMatchPolicyTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/policy/ComboMatchPolicyTest.java
@@ -1,0 +1,52 @@
+package com.team6.module.ai.policy;
+
+import com.team6.module.ai.config.ScoringPolicySettings;
+import com.team6.module.ai.config.ScoringPolicySnapshot;
+import com.team6.module.ai.model.GuideAiProfile;
+import com.team6.module.ai.model.TravelerPreference;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ComboMatchPolicyTest {
+
+    @Test
+    void score_adds_bonus_when_budget_and_activity_tags_match_rule() {
+        ScoringPolicySettings settings = new ScoringPolicySettings();
+        ScoringPolicySettings.ComboRuleSetting rule = new ScoringPolicySettings.ComboRuleSetting();
+        rule.setBudgetLevel("높음");
+        rule.setRequireActivityTagsAll(List.of("시장"));
+        rule.setBonusPoints(7);
+        settings.getComboRules().add(rule);
+        ScoringPolicySnapshot scoring = ScoringPolicySnapshot.from(settings);
+        ComboMatchPolicy policy = new ComboMatchPolicy(scoring);
+
+        TravelerPreference pref = TravelerPreference.builder()
+                .budgetLevel("높음")
+                .activityTags(List.of("시장", "맛집"))
+                .build();
+        GuideAiProfile guide = GuideAiProfile.builder().guideId(1L).region("서울").build();
+
+        assertThat(policy.score(pref, guide)).isEqualTo(7);
+    }
+
+    @Test
+    void score_zero_when_required_tag_missing() {
+        ScoringPolicySettings settings = new ScoringPolicySettings();
+        ScoringPolicySettings.ComboRuleSetting rule = new ScoringPolicySettings.ComboRuleSetting();
+        rule.setBudgetLevel("높음");
+        rule.setRequireActivityTagsAll(List.of("시장"));
+        rule.setBonusPoints(7);
+        settings.getComboRules().add(rule);
+        ComboMatchPolicy policy = new ComboMatchPolicy(ScoringPolicySnapshot.from(settings));
+
+        TravelerPreference pref = TravelerPreference.builder()
+                .budgetLevel("높음")
+                .activityTags(List.of("맛집"))
+                .build();
+
+        assertThat(policy.score(pref, GuideAiProfile.builder().guideId(1L).build())).isZero();
+    }
+}

--- a/backend/module-ai/src/test/java/com/team6/module/ai/policy/FeedbackMatchPolicyTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/policy/FeedbackMatchPolicyTest.java
@@ -1,5 +1,6 @@
 package com.team6.module.ai.policy;
 
+import com.team6.module.ai.config.ScoringPolicySnapshot;
 import com.team6.module.ai.model.GuideAiProfile;
 import org.junit.jupiter.api.Test;
 
@@ -10,7 +11,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class FeedbackMatchPolicyTest {
 
-    private final FeedbackMatchPolicy policy = new FeedbackMatchPolicy();
+    private final ScoringPolicySnapshot scoring = ScoringPolicySnapshot.defaults();
+    private final FeedbackMatchPolicy policy = new FeedbackMatchPolicy(scoring);
 
     @Test
     void score_should_add_bonus_for_behavior_signals() {
@@ -66,6 +68,6 @@ class FeedbackMatchPolicyTest {
 
         int score = policy.score(null, guide);
 
-        assertThat(score).isEqualTo(6);
+        assertThat(score).isEqualTo(scoring.coldStartExplorationBonus());
     }
 }

--- a/backend/module-ai/src/test/java/com/team6/module/ai/policy/RegionMatchPolicyTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/policy/RegionMatchPolicyTest.java
@@ -1,6 +1,7 @@
 package com.team6.module.ai.policy;
 
 import com.team6.module.ai.config.LocalGuestAiProperties;
+import com.team6.module.ai.config.ScoringPolicySnapshot;
 import com.team6.module.ai.model.GuideAiProfile;
 import com.team6.module.ai.model.TravelerPreference;
 import com.team6.module.ai.support.AdjacentRegionProvider;
@@ -14,26 +15,29 @@ class RegionMatchPolicyTest {
 
     @Test
     void score_exact_region_full_weight() {
+        ScoringPolicySnapshot scoring = ScoringPolicySnapshot.defaults();
         AdjacentRegionProvider adjacent = new AdjacentRegionProvider(new LocalGuestAiProperties());
-        RegionMatchPolicy policy = new RegionMatchPolicy(adjacent);
+        RegionMatchPolicy policy = new RegionMatchPolicy(adjacent, scoring);
         TravelerPreference pref = TravelerPreference.builder().region("부산").build();
         GuideAiProfile guide = GuideAiProfile.builder().region("부산").build();
-        assertThat(policy.score(pref, guide)).isEqualTo(ScoreWeight.REGION);
+        assertThat(policy.score(pref, guide)).isEqualTo(scoring.weightRegion());
     }
 
     @Test
     void score_adjacent_region_partial_weight() {
+        ScoringPolicySnapshot scoring = ScoringPolicySnapshot.defaults();
         AdjacentRegionProvider adjacent = new AdjacentRegionProvider(new LocalGuestAiProperties());
-        RegionMatchPolicy policy = new RegionMatchPolicy(adjacent);
+        RegionMatchPolicy policy = new RegionMatchPolicy(adjacent, scoring);
         TravelerPreference pref = TravelerPreference.builder().region("강릉").build();
         GuideAiProfile guide = GuideAiProfile.builder().region("속초").build();
-        assertThat(policy.score(pref, guide)).isEqualTo(ScoreWeight.REGION_ADJACENT);
+        assertThat(policy.score(pref, guide)).isEqualTo(scoring.weightRegionAdjacent());
     }
 
     @Test
     void score_non_adjacent_zero() {
+        ScoringPolicySnapshot scoring = ScoringPolicySnapshot.defaults();
         AdjacentRegionProvider adjacent = new AdjacentRegionProvider(new LocalGuestAiProperties());
-        RegionMatchPolicy policy = new RegionMatchPolicy(adjacent);
+        RegionMatchPolicy policy = new RegionMatchPolicy(adjacent, scoring);
         TravelerPreference pref = TravelerPreference.builder().region("제주").build();
         GuideAiProfile guide = GuideAiProfile.builder().region("부산").build();
         assertThat(policy.score(pref, guide)).isZero();
@@ -43,10 +47,11 @@ class RegionMatchPolicyTest {
     void score_yaml_adjacent_overrides_builtin() {
         LocalGuestAiProperties props = new LocalGuestAiProperties();
         props.getAdjacentRegions().put("테스트시", List.of("테스트동"));
+        ScoringPolicySnapshot scoring = ScoringPolicySnapshot.defaults();
         AdjacentRegionProvider adjacent = new AdjacentRegionProvider(props);
-        RegionMatchPolicy policy = new RegionMatchPolicy(adjacent);
+        RegionMatchPolicy policy = new RegionMatchPolicy(adjacent, scoring);
         TravelerPreference pref = TravelerPreference.builder().region("테스트시").build();
         GuideAiProfile guide = GuideAiProfile.builder().region("테스트동").build();
-        assertThat(policy.score(pref, guide)).isEqualTo(ScoreWeight.REGION_ADJACENT);
+        assertThat(policy.score(pref, guide)).isEqualTo(scoring.weightRegionAdjacent());
     }
 }

--- a/backend/module-ai/src/test/java/com/team6/module/ai/regression/AiRecommendationRegressionTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/regression/AiRecommendationRegressionTest.java
@@ -1,6 +1,8 @@
 package com.team6.module.ai.regression;
 
 import com.team6.module.ai.config.LocalGuestAiProperties;
+import com.team6.module.ai.config.ScoringPolicySnapshot;
+import com.team6.module.ai.policy.ComboMatchPolicy;
 import com.team6.module.ai.support.AdjacentRegionProvider;
 import com.team6.module.ai.dto.request.GuideRecommendRequest;
 import com.team6.module.ai.dto.response.GuideRecommendResponse;
@@ -271,17 +273,19 @@ class AiRecommendationRegressionTest {
 
     private AiRecommendationService createService() {
         LocalGuestAiProperties aiProps = new LocalGuestAiProperties();
+        ScoringPolicySnapshot scoring = ScoringPolicySnapshot.defaults();
         AdjacentRegionProvider adjacent = new AdjacentRegionProvider(aiProps);
         ScoreCalculator scoreCalculator = new ScoreCalculator(
-                new RegionMatchPolicy(adjacent),
-                new StyleMatchPolicy(),
-                new BudgetMatchPolicy(),
-                new ActivityMatchPolicy(),
-                new LanguageMatchPolicy(),
-                new FeedbackMatchPolicy(),
+                new RegionMatchPolicy(adjacent, scoring),
+                new StyleMatchPolicy(scoring),
+                new BudgetMatchPolicy(scoring),
+                new ActivityMatchPolicy(scoring),
+                new LanguageMatchPolicy(scoring),
+                new FeedbackMatchPolicy(scoring),
+                new ComboMatchPolicy(scoring),
                 new AiRecommendationMetrics(new SimpleMeterRegistry())
         );
-        ReasonGenerator reasonGenerator = new ReasonGenerator(adjacent);
+        ReasonGenerator reasonGenerator = new ReasonGenerator(adjacent, scoring);
 
         return new AiRecommendationServiceImpl(new MatchingEngine(scoreCalculator, reasonGenerator, adjacent));
     }

--- a/backend/module-ai/src/test/java/com/team6/module/ai/service/AiRecommendationServiceTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/service/AiRecommendationServiceTest.java
@@ -10,6 +10,8 @@ import com.team6.module.ai.policy.BudgetMatchPolicy;
 import com.team6.module.ai.policy.FeedbackMatchPolicy;
 import com.team6.module.ai.policy.LanguageMatchPolicy;
 import com.team6.module.ai.config.LocalGuestAiProperties;
+import com.team6.module.ai.config.ScoringPolicySnapshot;
+import com.team6.module.ai.policy.ComboMatchPolicy;
 import com.team6.module.ai.policy.RegionMatchPolicy;
 import com.team6.module.ai.policy.StyleMatchPolicy;
 import com.team6.module.ai.support.AdjacentRegionProvider;
@@ -27,17 +29,19 @@ class AiRecommendationServiceTest {
 
     private AiRecommendationService createService() {
         LocalGuestAiProperties aiProps = new LocalGuestAiProperties();
+        ScoringPolicySnapshot scoring = ScoringPolicySnapshot.defaults();
         AdjacentRegionProvider adjacent = new AdjacentRegionProvider(aiProps);
         ScoreCalculator scoreCalculator = new ScoreCalculator(
-                new RegionMatchPolicy(adjacent),
-                new StyleMatchPolicy(),
-                new BudgetMatchPolicy(),
-                new ActivityMatchPolicy(),
-                new LanguageMatchPolicy(),
-                new FeedbackMatchPolicy(),
+                new RegionMatchPolicy(adjacent, scoring),
+                new StyleMatchPolicy(scoring),
+                new BudgetMatchPolicy(scoring),
+                new ActivityMatchPolicy(scoring),
+                new LanguageMatchPolicy(scoring),
+                new FeedbackMatchPolicy(scoring),
+                new ComboMatchPolicy(scoring),
                 new AiRecommendationMetrics(new SimpleMeterRegistry())
         );
-        ReasonGenerator reasonGenerator = new ReasonGenerator(adjacent);
+        ReasonGenerator reasonGenerator = new ReasonGenerator(adjacent, scoring);
 
         return new AiRecommendationServiceImpl(
                 new MatchingEngine(scoreCalculator, reasonGenerator, adjacent)

--- a/backend/module-ai/src/test/java/com/team6/module/ai/service/PromptRecommendationServiceTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/service/PromptRecommendationServiceTest.java
@@ -6,8 +6,10 @@ import com.team6.module.ai.engine.MatchingEngine;
 import com.team6.module.ai.engine.ReasonGenerator;
 import com.team6.module.ai.engine.ScoreCalculator;
 import com.team6.module.ai.config.LocalGuestAiProperties;
+import com.team6.module.ai.config.ScoringPolicySnapshot;
 import com.team6.module.ai.parser.PromptParser;
 import com.team6.module.ai.policy.ActivityMatchPolicy;
+import com.team6.module.ai.policy.ComboMatchPolicy;
 import com.team6.module.ai.support.AdjacentRegionProvider;
 import com.team6.module.ai.support.RecommendationNoticeCodes;
 import com.team6.module.ai.policy.BudgetMatchPolicy;
@@ -29,17 +31,19 @@ class PromptRecommendationServiceTest {
     private PromptRecommendationService createService() {
         SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
         LocalGuestAiProperties aiProps = new LocalGuestAiProperties();
+        ScoringPolicySnapshot scoring = ScoringPolicySnapshot.defaults();
         AdjacentRegionProvider adjacent = new AdjacentRegionProvider(aiProps);
         ScoreCalculator scoreCalculator = new ScoreCalculator(
-                new RegionMatchPolicy(adjacent),
-                new StyleMatchPolicy(),
-                new BudgetMatchPolicy(),
-                new ActivityMatchPolicy(),
-                new LanguageMatchPolicy(),
-                new FeedbackMatchPolicy(),
+                new RegionMatchPolicy(adjacent, scoring),
+                new StyleMatchPolicy(scoring),
+                new BudgetMatchPolicy(scoring),
+                new ActivityMatchPolicy(scoring),
+                new LanguageMatchPolicy(scoring),
+                new FeedbackMatchPolicy(scoring),
+                new ComboMatchPolicy(scoring),
                 new AiRecommendationMetrics(meterRegistry)
         );
-        ReasonGenerator reasonGenerator = new ReasonGenerator(adjacent);
+        ReasonGenerator reasonGenerator = new ReasonGenerator(adjacent, scoring);
         AiRecommendationService aiRecommendationService =
                 new AiRecommendationServiceImpl(new MatchingEngine(scoreCalculator, reasonGenerator, adjacent));
 
@@ -47,7 +51,8 @@ class PromptRecommendationServiceTest {
                 new PromptParser(aiProps),
                 aiRecommendationService,
                 adjacent,
-                new AiRecommendationMetrics(meterRegistry)
+                new AiRecommendationMetrics(meterRegistry),
+                scoring
         );
     }
 


### PR DESCRIPTION
## 변경 범위
- `localguest.ai.scoring-policy`(YAML)로 가중치·피드백/콜드스타트/soft 패널티·low-signal 임계·폴백 base 대비 최소 개선량·조합 보너스 룰을 튜닝 가능하게 함.
- `ScoringPolicySnapshot` 주입으로 Region/Style/Budget/Activity/Language/Feedback 정책이 동일 스냅샷 사용. `ComboMatchPolicy`로 예산·스타일·활동 태그 조합 보너스.
- 전략 재시도 수용: Top1 점수 임계 **또는** base 대비 `fallbackMinImprovementOverBase` 이상 개선 시 수용.
- `AiRecommendationTuning`은 POLICY_VERSION·TopN 등 비스코어 상수만 유지. `POLICY_VERSION` → 2026.04.17.

## 스키마 영향
없음 (설정만).

## 검증
```bash
./gradlew :module-ai:test :module-ai-integration:test :api-server:compileJava
```

Closes #175

Made with [Cursor](https://cursor.com)