### PR TITLE
Feat/be#177 AI Reason UX(문구 다양화·배지 evidenceSlot)

### DIFF
--- a/backend/module-ai/src/main/java/com/team6/module/ai/dto/response/GuideRecommendItem.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/dto/response/GuideRecommendItem.java
@@ -44,10 +44,15 @@ public class GuideRecommendItem {
     /**
      * 근거 코드별 매칭 값(예: 태그/언어 목록).
      */
-    @Schema(description = "reasonCodes와 동일 순서의 근거별 값(태그·언어 등)")
+    @Schema(
+            description = "reasonCodes와 동일 순서. evidenceSlot으로 matched(배지)·툴팁 매핑 — "
+                    + "com.team6.module.ai.support.RecommendReasonEvidenceSlots 참고"
+    )
     private List<ReasonFact> reasonFacts;
 
-    @Schema(description = "매칭 증거(프론트 배지·툴팁용)")
+    @Schema(
+            description = "매칭 증거(배지). reasonFacts[].evidenceSlot과 1:1로 대응(REGION→region 등)"
+    )
     private MatchedEvidence matched;
 
     @Schema(name = "GuideRecommendReasonFact")
@@ -56,7 +61,16 @@ public class GuideRecommendItem {
     public static class ReasonFact {
         @Schema(description = "ReasonGenerator 코드(예: REGION_MATCH, BUDGET_ADJACENT, FEEDBACK_VERY_LOW_RATING)")
         private String code;
-        @Schema(description = "해당 근거에 대응하는 값 목록")
+        @Schema(
+                description = "matched 배지 매핑 키. REGION/REGION_ADJACENT/ACTIVITY_TAGS/SOFT_PENALTY_TAGS/"
+                        + "STYLE/LANGUAGE/BUDGET/BUDGET_ADJACENT/FEEDBACK_REFUND/FEEDBACK_RATING/GENERAL",
+                allowableValues = {
+                        "REGION", "REGION_ADJACENT", "ACTIVITY_TAGS", "SOFT_PENALTY_TAGS", "STYLE", "LANGUAGE",
+                        "BUDGET", "BUDGET_ADJACENT", "FEEDBACK_REFUND", "FEEDBACK_RATING", "GENERAL"
+                }
+        )
+        private String evidenceSlot;
+        @Schema(description = "해당 근거에 대응하는 값 목록(태그·언어·평점 문자열 등)")
         private List<String> values;
     }
 
@@ -64,22 +78,24 @@ public class GuideRecommendItem {
     @Getter
     @Builder
     public static class MatchedEvidence {
+        @Schema(description = "reasonFacts evidenceSlot=REGION 과 함께 사용")
         private boolean region;
-        @Schema(description = "희망 지역과 정확히 같지는 않지만 인접 지역으로 매칭된 경우")
+        @Schema(description = "reasonFacts evidenceSlot=REGION_ADJACENT. 희망 지역과 정확히 같지는 않지만 인접 지역")
         private boolean regionAdjacent;
+        @Schema(description = "reasonFacts evidenceSlot=STYLE 과 함께 사용")
         private boolean style;
-        @Schema(description = "예산 티어(낮음/중간/높음) 완전 일치")
+        @Schema(description = "reasonFacts evidenceSlot=BUDGET. 예산 티어(낮음/중간/높음) 완전 일치")
         private boolean budget;
-        @Schema(description = "예산 티어가 한 단계만 차이(인접). budget이 true이면 보통 false")
+        @Schema(description = "reasonFacts evidenceSlot=BUDGET_ADJACENT. budget이 true이면 보통 false")
         private boolean budgetAdjacent;
-        @Schema(description = "선호 활동 태그와 가이드 전문 태그 교집합(정규화)")
+        @Schema(description = "reasonFacts evidenceSlot=ACTIVITY_TAGS. 선호 활동 태그∩가이드 전문 태그(정규화)")
         private List<String> tags;
-        @Schema(description = "선호 언어와 가이드 가능 언어 교집합")
+        @Schema(description = "reasonFacts evidenceSlot=LANGUAGE. 선호 언어∩가이드 가능 언어")
         private List<String> languages;
         /**
          * 여행자 soft 부정 태그와 가이드 전문 태그 교집합(배지·툴팁용). 없으면 빈 목록.
          */
-        @Schema(description = "soft 부정 태그 ∩ 가이드 전문 태그(점수 패널티가 난 활동)")
+        @Schema(description = "reasonFacts evidenceSlot=SOFT_PENALTY_TAGS. soft 부정 태그∩가이드 전문 태그")
         private List<String> softPenaltyOverlapTags;
     }
 }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/engine/MatchingEngine.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/engine/MatchingEngine.java
@@ -338,6 +338,7 @@ public class MatchingEngine {
         return bundle.getReasonFacts().stream()
                 .map(f -> GuideRecommendItem.ReasonFact.builder()
                         .code(f.getCode())
+                        .evidenceSlot(f.getEvidenceSlot())
                         .values(f.getValues())
                         .build())
                 .toList();

--- a/backend/module-ai/src/main/java/com/team6/module/ai/engine/ReasonBundle.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/engine/ReasonBundle.java
@@ -19,6 +19,8 @@ public class ReasonBundle {
     @Builder
     public static class Fact {
         private final String code;
+        /** {@link com.team6.module.ai.support.RecommendReasonEvidenceSlots} 값. */
+        private final String evidenceSlot;
         private final List<String> values;
     }
 }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/engine/ReasonGenerator.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/engine/ReasonGenerator.java
@@ -6,6 +6,7 @@ import com.team6.module.ai.model.TravelerPreference;
 import com.team6.module.ai.parser.KeywordNormalizer;
 import com.team6.module.ai.support.AdjacentRegionProvider;
 import com.team6.module.ai.support.BudgetTier;
+import com.team6.module.ai.support.RecommendReasonEvidenceSlots;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -37,6 +38,78 @@ public class ReasonGenerator {
     /** 평균 평점이 매우 낮을 때(정책 임계값은 {@link ScoringPolicySnapshot}). */
     public static final String CODE_FEEDBACK_VERY_LOW_RATING = "FEEDBACK_VERY_LOW_RATING";
 
+    private static final List<String> COPY_REGION_EXACT = List.of(
+            "희망 지역과 가이드 활동 지역이 동일합니다",
+            "요청하신 지역에서 활동 중인 가이드입니다",
+            "지역 조건이 그대로 맞아 떨어집니다"
+    );
+
+    private static final List<String> COPY_REGION_ADJACENT = List.of(
+            "희망 지역과 인접한 지역에서 활동합니다",
+            "바로 옆 지역(인접)에서 안내 가능합니다",
+            "인접 지역 기준으로 추렸습니다"
+    );
+
+    private static final List<String> COPY_ACTIVITY = List.of(
+            "관심 활동 분야가 맞습니다({tags})",
+            "선호 취미·코스와 전문 분야가 겹칩니다({tags})",
+            "가이드 전문과 여행자 관심사가 맞물립니다({tags})"
+    );
+
+    private static final List<String> COPY_SOFT_PENALTY = List.of(
+            "부담되시는 활동이 겹쳐 가중치를 조정했습니다({tags})",
+            "부담 요소가 겹쳐 점수를 보수적으로 반영했습니다({tags})",
+            "선호와 상충하는 전문 분야가 있어 가중치를 낮췄습니다({tags})"
+    );
+
+    private static final List<String> COPY_STYLE = List.of(
+            "여행 스타일이 잘 맞습니다",
+            "여행 톤앤매너가 비슷한 편입니다",
+            "스타일 취향이 잘 맞물립니다"
+    );
+
+    private static final List<String> COPY_LANGUAGE = List.of(
+            "요청하신 언어 안내가 가능합니다({langs})",
+            "아래 언어로 설명을 도와드릴 수 있어요: {langs}",
+            "{langs} 코스 안내가 가능합니다"
+    );
+
+    private static final List<String> COPY_BUDGET_EXACT = List.of(
+            "예산 수준이 동일한 편입니다",
+            "가격대가 잘 맞습니다",
+            "예산 톤이 비슷합니다"
+    );
+
+    private static final List<String> COPY_BUDGET_ADJ = List.of(
+            "예산 수준이 한 단계 차이로 가깝습니다",
+            "가격대가 바로 옆 단계입니다",
+            "예산이 한 단계만 다른 편입니다"
+    );
+
+    private static final List<String> COPY_FEEDBACK_REFUND = List.of(
+            "승인된 환불 이력이 있어 점수에 반영했습니다",
+            "환불 이력을 보수적으로 반영했습니다",
+            "운영 이력(환불)을 근거에 포함했습니다"
+    );
+
+    private static final List<String> COPY_FEEDBACK_VERY_LOW = List.of(
+            "평균 리뷰가 매우 낮아 신중히 반영했습니다",
+            "리뷰 평균이 매우 낮아 가중치를 크게 줄였습니다",
+            "평점 신호가 매우 약해 보수적으로 처리했습니다"
+    );
+
+    private static final List<String> COPY_FEEDBACK_LOW = List.of(
+            "평균 리뷰가 낮은 편이라 보수적으로 반영했습니다",
+            "리뷰 평균이 낮아 점수를 조심스럽게 반영했습니다",
+            "평점이 낮은 편이라 가중치를 낮췄습니다"
+    );
+
+    private static final List<String> COPY_GENERAL_FALLBACK = List.of(
+            "선호 조건과 가이드 프로필을 종합해 매칭했습니다",
+            "프로필과 선호를 함께 보고 골랐습니다",
+            "요청 맥락에 맞춰 후보를 구성했습니다"
+    );
+
     /** 상위 근거 노출 개수(지역·활동·부담·스타일·예산·피드백 등이 겹칠 때 잘리지 않도록 여유). */
     private static final int MAX_DISPLAY_SEGMENTS = 5;
 
@@ -44,11 +117,13 @@ public class ReasonGenerator {
      * @param score 현재는 reason 문구 생성에 직접 쓰지 않지만, 추후 임계값/요약에 활용 가능하도록 유지
      */
     public ReasonBundle generate(TravelerPreference pref, GuideAiProfile guide, int score) {
-        List<Segment> segments = buildSegments(pref, guide);
+        long seed = variantSeed(guide);
+        List<Segment> segments = buildSegments(pref, guide, seed);
         if (segments.isEmpty()) {
             segments = List.of(new Segment(
                     CODE_GENERAL_FALLBACK,
-                    "선호 조건과 가이드 프로필을 종합해 매칭했습니다",
+                    RecommendReasonEvidenceSlots.GENERAL,
+                    pickVariant(seed, CODE_GENERAL_FALLBACK, COPY_GENERAL_FALLBACK),
                     List.of()
             ));
         }
@@ -67,6 +142,7 @@ public class ReasonGenerator {
         List<ReasonBundle.Fact> facts = displayed.stream()
                 .map(s -> ReasonBundle.Fact.builder()
                         .code(s.code)
+                        .evidenceSlot(s.evidenceSlot)
                         .values(s.factValues)
                         .build())
                 .toList();
@@ -82,19 +158,21 @@ public class ReasonGenerator {
      * 우선순위: 지역 → (선호)활동 → soft 부담 → 스타일 → 언어 → 예산 → 피드백(환불·평점).
      * 상위 {@link #MAX_DISPLAY_SEGMENTS}개만 노출된다.
      */
-    private List<Segment> buildSegments(TravelerPreference pref, GuideAiProfile guide) {
+    private List<Segment> buildSegments(TravelerPreference pref, GuideAiProfile guide, long seed) {
         List<Segment> segments = new ArrayList<>();
 
         if (safeEquals(pref.getRegion(), guide.getRegion())) {
             segments.add(new Segment(
                     CODE_REGION_MATCH,
-                    "희망 지역과 가이드 활동 지역이 동일합니다",
+                    RecommendReasonEvidenceSlots.REGION,
+                    pickVariant(seed, CODE_REGION_MATCH, COPY_REGION_EXACT),
                     listNonNull(guide.getRegion())
             ));
         } else if (adjacentRegionProvider.isAdjacentTo(pref.getRegion(), guide.getRegion())) {
             segments.add(new Segment(
                     CODE_REGION_ADJACENT,
-                    "희망 지역과 인접한 지역에서 활동합니다",
+                    RecommendReasonEvidenceSlots.REGION_ADJACENT,
+                    pickVariant(seed, CODE_REGION_ADJACENT, COPY_REGION_ADJACENT),
                     listNonNull(guide.getRegion())
             ));
         }
@@ -115,8 +193,10 @@ public class ReasonGenerator {
             if (!matched.isEmpty()) {
                 String head = matched.stream().limit(3).collect(Collectors.joining("/"));
                 String suffix = matched.size() > 3 ? " 외" : "";
-                String display = "관심 활동 분야가 맞습니다(" + head + suffix + ")";
-                segments.add(new Segment(CODE_ACTIVITY_MATCH, display, matched));
+                String tagToken = head + suffix;
+                String shell = pickVariant(seed, CODE_ACTIVITY_MATCH, COPY_ACTIVITY);
+                String display = shell.replace("{tags}", tagToken);
+                segments.add(new Segment(CODE_ACTIVITY_MATCH, RecommendReasonEvidenceSlots.ACTIVITY_TAGS, display, matched));
             }
         }
 
@@ -136,15 +216,23 @@ public class ReasonGenerator {
             if (!penalized.isEmpty()) {
                 String head = penalized.stream().limit(3).collect(Collectors.joining("/"));
                 String suffix = penalized.size() > 3 ? " 외" : "";
-                String display = "부담되시는 활동이 겹쳐 가중치를 조정했습니다(" + head + suffix + ")";
-                segments.add(new Segment(CODE_SOFT_ACTIVITY_PENALTY, display, penalized));
+                String tagToken = head + suffix;
+                String shell = pickVariant(seed, CODE_SOFT_ACTIVITY_PENALTY, COPY_SOFT_PENALTY);
+                String display = shell.replace("{tags}", tagToken);
+                segments.add(new Segment(
+                        CODE_SOFT_ACTIVITY_PENALTY,
+                        RecommendReasonEvidenceSlots.SOFT_PENALTY_TAGS,
+                        display,
+                        penalized
+                ));
             }
         }
 
         if (safeEquals(pref.getTravelStyle(), guide.getGuideStyle())) {
             segments.add(new Segment(
                     CODE_STYLE_MATCH,
-                    "여행 스타일이 잘 맞습니다",
+                    RecommendReasonEvidenceSlots.STYLE,
+                    pickVariant(seed, CODE_STYLE_MATCH, COPY_STYLE),
                     listNonNull(guide.getGuideStyle())
             ));
         }
@@ -163,9 +251,13 @@ public class ReasonGenerator {
 
             if (!matchedLanguages.isEmpty()) {
                 List<String> langValues = new ArrayList<>(matchedLanguages);
+                String joined = String.join("/", langValues);
+                String shell = pickVariant(seed, CODE_LANGUAGE_MATCH, COPY_LANGUAGE);
+                String display = shell.replace("{langs}", joined);
                 segments.add(new Segment(
                         CODE_LANGUAGE_MATCH,
-                        "요청하신 언어 안내가 가능합니다(" + String.join("/", langValues) + ")",
+                        RecommendReasonEvidenceSlots.LANGUAGE,
+                        display,
                         langValues
                 ));
             }
@@ -174,13 +266,15 @@ public class ReasonGenerator {
         if (safeEquals(pref.getBudgetLevel(), guide.getPriceLevel())) {
             segments.add(new Segment(
                     CODE_BUDGET_MATCH,
-                    "예산 수준이 동일한 편입니다",
+                    RecommendReasonEvidenceSlots.BUDGET,
+                    pickVariant(seed, CODE_BUDGET_MATCH, COPY_BUDGET_EXACT),
                     listNonNull(guide.getPriceLevel())
             ));
         } else if (BudgetTier.adjacentTiers(pref.getBudgetLevel(), guide.getPriceLevel())) {
             segments.add(new Segment(
                     CODE_BUDGET_ADJACENT,
-                    "예산 수준이 한 단계 차이로 가깝습니다",
+                    RecommendReasonEvidenceSlots.BUDGET_ADJACENT,
+                    pickVariant(seed, CODE_BUDGET_ADJACENT, COPY_BUDGET_ADJ),
                     listNonNull(guide.getPriceLevel())
             ));
         }
@@ -188,7 +282,8 @@ public class ReasonGenerator {
         if (guide.getApprovedRefundCount() != null && guide.getApprovedRefundCount() > 0) {
             segments.add(new Segment(
                     CODE_FEEDBACK_REFUND_APPROVED,
-                    "승인된 환불 이력이 있어 점수에 반영했습니다",
+                    RecommendReasonEvidenceSlots.FEEDBACK_REFUND,
+                    pickVariant(seed, CODE_FEEDBACK_REFUND_APPROVED, COPY_FEEDBACK_REFUND),
                     List.of(String.valueOf(guide.getApprovedRefundCount()))
             ));
         }
@@ -199,19 +294,36 @@ public class ReasonGenerator {
             if (a < scoring.feedbackVeryLowRatingThreshold()) {
                 segments.add(new Segment(
                         CODE_FEEDBACK_VERY_LOW_RATING,
-                        "평균 리뷰가 매우 낮아 신중히 반영했습니다",
+                        RecommendReasonEvidenceSlots.FEEDBACK_RATING,
+                        pickVariant(seed, CODE_FEEDBACK_VERY_LOW_RATING, COPY_FEEDBACK_VERY_LOW),
                         List.of(guide.getAverageRating().toPlainString(), String.valueOf(guide.getReviewCount()))
                 ));
             } else if (a < scoring.feedbackLowRatingThreshold()) {
                 segments.add(new Segment(
                         CODE_FEEDBACK_LOW_RATING,
-                        "평균 리뷰가 낮은 편이라 보수적으로 반영했습니다",
+                        RecommendReasonEvidenceSlots.FEEDBACK_RATING,
+                        pickVariant(seed, CODE_FEEDBACK_LOW_RATING, COPY_FEEDBACK_LOW),
                         List.of(guide.getAverageRating().toPlainString(), String.valueOf(guide.getReviewCount()))
                 ));
             }
         }
 
         return segments;
+    }
+
+    /**
+     * 동일 프롬프트 내에서도 가이드마다 문구가 달라지도록 시드로 쓴다(결정적).
+     */
+    private static long variantSeed(GuideAiProfile guide) {
+        return guide != null && guide.getGuideId() != null ? guide.getGuideId() : 0L;
+    }
+
+    private static String pickVariant(long seed, String code, List<String> options) {
+        if (options.isEmpty()) {
+            return "";
+        }
+        int idx = Math.floorMod(Long.hashCode(seed) ^ (31 * code.hashCode()), options.size());
+        return options.get(idx);
     }
 
     private static List<String> listNonNull(String value) {
@@ -225,6 +337,6 @@ public class ReasonGenerator {
         return a != null && a.equalsIgnoreCase(b);
     }
 
-    private record Segment(String code, String displayText, List<String> factValues) {
+    private record Segment(String code, String evidenceSlot, String displayText, List<String> factValues) {
     }
 }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationTuning.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationTuning.java
@@ -14,7 +14,7 @@ public final class AiRecommendationTuning {
     /**
      * 룰/스코어/Reason/응답 계약이 바뀔 때마다 올린다. 로그·API에서 동일 프롬프트 비교 시 정책 변경 여부를 구분하는 데 쓴다.
      */
-    public static final String POLICY_VERSION = "2026.04.17";
+    public static final String POLICY_VERSION = "2026.04.18";
 
     public static final int DEFAULT_TOP_N = 3;
 

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/RecommendReasonEvidenceSlots.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/RecommendReasonEvidenceSlots.java
@@ -1,0 +1,38 @@
+package com.team6.module.ai.support;
+
+import com.team6.module.ai.dto.response.GuideRecommendItem;
+
+/**
+ * {@link GuideRecommendItem.ReasonFact#getEvidenceSlot()}에 쓰이는 고정 키.
+ * 프론트는 이 값으로 {@link GuideRecommendItem.MatchedEvidence} 필드·배지에 바로 매핑할 수 있다.
+ * <ul>
+ *   <li>{@link #REGION} → {@code matched.region}</li>
+ *   <li>{@link #REGION_ADJACENT} → {@code matched.regionAdjacent}</li>
+ *   <li>{@link #ACTIVITY_TAGS} → {@code matched.tags} (교집합, {@code values}는 표시용 부분집합과 동일 정규화)</li>
+ *   <li>{@link #SOFT_PENALTY_TAGS} → {@code matched.softPenaltyOverlapTags}</li>
+ *   <li>{@link #STYLE} → {@code matched.style}</li>
+ *   <li>{@link #LANGUAGE} → {@code matched.languages}</li>
+ *   <li>{@link #BUDGET} → {@code matched.budget}</li>
+ *   <li>{@link #BUDGET_ADJACENT} → {@code matched.budgetAdjacent}</li>
+ *   <li>{@link #FEEDBACK_REFUND}·{@link #FEEDBACK_RATING} → {@code matched}에 대응 불리언 없음,
+ *       툴팁은 {@code reasonFacts.values} 사용</li>
+ *   <li>{@link #GENERAL} → 종합 매칭, {@code matched}는 참고용</li>
+ * </ul>
+ */
+public final class RecommendReasonEvidenceSlots {
+
+    public static final String REGION = "REGION";
+    public static final String REGION_ADJACENT = "REGION_ADJACENT";
+    public static final String ACTIVITY_TAGS = "ACTIVITY_TAGS";
+    public static final String SOFT_PENALTY_TAGS = "SOFT_PENALTY_TAGS";
+    public static final String STYLE = "STYLE";
+    public static final String LANGUAGE = "LANGUAGE";
+    public static final String BUDGET = "BUDGET";
+    public static final String BUDGET_ADJACENT = "BUDGET_ADJACENT";
+    public static final String FEEDBACK_REFUND = "FEEDBACK_REFUND";
+    public static final String FEEDBACK_RATING = "FEEDBACK_RATING";
+    public static final String GENERAL = "GENERAL";
+
+    private RecommendReasonEvidenceSlots() {
+    }
+}

--- a/backend/module-ai/src/test/java/com/team6/module/ai/engine/ReasonGeneratorTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/engine/ReasonGeneratorTest.java
@@ -77,6 +77,26 @@ class ReasonGeneratorTest {
         ReasonBundle bundle = generator().generate(pref, guide, 0);
 
         assertThat(bundle.getReasonCodes()).contains(ReasonGenerator.CODE_ACTIVITY_MATCH);
-        assertThat(bundle.getText()).contains("관심 활동");
+        assertThat(bundle.getText()).contains("카페");
+        var activityFact = bundle.getReasonFacts().stream()
+                .filter(f -> ReasonGenerator.CODE_ACTIVITY_MATCH.equals(f.getCode()))
+                .findFirst();
+        assertThat(activityFact).isPresent();
+        assertThat(activityFact.get().getEvidenceSlot()).isEqualTo("ACTIVITY_TAGS");
+    }
+
+    @Test
+    void generate_should_attach_evidence_slot_parallel_to_code() {
+        TravelerPreference pref = TravelerPreference.builder()
+                .region("서울")
+                .build();
+        GuideAiProfile guide = GuideAiProfile.builder()
+                .region("서울")
+                .build();
+
+        ReasonBundle bundle = generator().generate(pref, guide, 0);
+
+        assertThat(bundle.getReasonFacts()).hasSameSizeAs(bundle.getReasonCodes());
+        assertThat(bundle.getReasonFacts().get(0).getEvidenceSlot()).isEqualTo("REGION");
     }
 }

--- a/backend/module-ai/src/test/java/com/team6/module/ai/regression/AiRecommendationRegressionTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/regression/AiRecommendationRegressionTest.java
@@ -67,6 +67,16 @@ class AiRecommendationRegressionTest {
             assertThat(top1.getReasonCodes().stream().filter(Objects::nonNull).noneMatch(String::isBlank))
                     .as("reasonCodes should not contain blank entries")
                     .isTrue();
+            assertThat(top1.getReasonFacts()).as("reasonFacts for prompt: %s".formatted(s.prompt()))
+                    .isNotNull()
+                    .hasSameSizeAs(top1.getReasonCodes());
+            for (int i = 0; i < top1.getReasonFacts().size(); i++) {
+                assertThat(top1.getReasonFacts().get(i).getEvidenceSlot())
+                        .as("evidenceSlot at %d for prompt: %s".formatted(i, s.prompt()))
+                        .isNotBlank();
+                assertThat(top1.getReasonFacts().get(i).getCode())
+                        .isEqualTo(top1.getReasonCodes().get(i));
+            }
             assertThat(top1.getMatched()).as("matched evidence should be present").isNotNull();
 
             if (s.expectedTag() != null) {

--- a/backend/module-ai/src/test/java/com/team6/module/ai/service/AiRecommendationServiceTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/service/AiRecommendationServiceTest.java
@@ -226,7 +226,7 @@ class AiRecommendationServiceTest {
         GuideRecommendResponse response = aiRecommendationService.recommend(request);
         assertThat(response.getRecommendations()).isNotEmpty();
         assertThat(response.getRecommendations().get(0).getScore()).isGreaterThan(0);
-        assertThat(response.getRecommendations().get(0).getReason()).contains("관심 활동");
+        assertThat(response.getRecommendations().get(0).getReason()).contains("바다");
         assertThat(response.getRecommendations().get(0).getReasonCodes()).contains(ReasonGenerator.CODE_ACTIVITY_MATCH);
         assertThat(response.getRecommendations().get(0).getMatched()).isNotNull();
         assertThat(response.getRecommendations().get(0).getMatched().getTags()).contains("바다");


### PR DESCRIPTION
## 변경 범위
- **Reason 문구 다양화**: 코드·가이드 ID 기반 결정적 변형(동일 가이드는 동일 문구, 카드마다 표현 차이).
- **배지 규격**: `reasonFacts[].evidenceSlot` 추가(REGION, ACTIVITY_TAGS, …). `RecommendReasonEvidenceSlots`에 `matched` 필드 매핑 문서화.
- OpenAPI `@Schema`로 `MatchedEvidence` 필드와 슬롯 대응 명시.
- `POLICY_VERSION` → **2026.04.18**.

## 스키마/API
- 응답 필드 추가: `GuideRecommendItem.ReasonFact.evidenceSlot` (기존 클라이언트는 무시 가능).

## 검증
```bash
./gradlew :module-ai:test :module-ai-integration:test :api-server:compileJava
```

Closes #177

Made with [Cursor](https://cursor.com)