### PR TITLE
Feat/be#179 AI 다양성 랭킹(유사도·λ YAML·중복 방지)

### DIFF
--- a/backend/module-ai/src/main/java/com/team6/module/ai/config/DiversityRerankSettings.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/config/DiversityRerankSettings.java
@@ -1,0 +1,24 @@
+package com.team6.module.ai.config;
+
+import com.team6.module.ai.engine.DiversityRerankConstants;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * YAML 바인딩: {@code localguest.ai.diversity-rerank}.
+ */
+@Getter
+@Setter
+public class DiversityRerankSettings {
+
+    private double diversityLambda = DiversityRerankConstants.DIVERSITY_LAMBDA;
+    private double regionSimWeight = DiversityRerankConstants.REGION_SIM_WEIGHT;
+    private double regionClusterSimilarityRatio = DiversityRerankConstants.REGION_CLUSTER_SIMILARITY_RATIO;
+    private double styleSimWeight = DiversityRerankConstants.STYLE_SIM_WEIGHT;
+    private double tagSimWeight = DiversityRerankConstants.TAG_SIM_WEIGHT;
+    private double languageSimWeight = DiversityRerankConstants.LANGUAGE_SIM_WEIGHT;
+    private double priceTierSimWeight = DiversityRerankConstants.PRICE_TIER_SIM_WEIGHT;
+    private double priceAdjacentSimilarityRatio = DiversityRerankConstants.DEFAULT_PRICE_ADJACENT_SIMILARITY_RATIO;
+    private double tagNearDuplicateThreshold = DiversityRerankConstants.DEFAULT_TAG_NEAR_DUP_THRESHOLD;
+    private double tagNearDuplicateBoost = DiversityRerankConstants.DEFAULT_TAG_NEAR_DUP_BOOST;
+}

--- a/backend/module-ai/src/main/java/com/team6/module/ai/config/DiversityRerankSnapshot.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/config/DiversityRerankSnapshot.java
@@ -1,0 +1,61 @@
+package com.team6.module.ai.config;
+
+import com.team6.module.ai.engine.DiversityRerankConstants;
+
+/**
+ * Top-N 다양성 패널티에 쓰는 스냅샷({@code localguest.ai.diversity-rerank}).
+ * <p>
+ * 유사도는 대략 0~1로 정규화한 뒤 {@code diversityLambda}를 곱해 점수에서 뺀다.
+ * 가중치 합으로 나누어 스케일을 맞춘다.
+ */
+public record DiversityRerankSnapshot(
+        double diversityLambda,
+        double regionSimWeight,
+        double regionClusterSimilarityRatio,
+        double styleSimWeight,
+        double tagSimWeight,
+        double languageSimWeight,
+        double priceTierSimWeight,
+        /**
+         * 예산 티어가 정확히 같지 않지만 {@link com.team6.module.ai.support.BudgetTier#adjacentTiers}일 때의 부분 유사도(0~1).
+         */
+        double priceAdjacentSimilarityRatio,
+        /**
+         * 전문 태그 Jaccard가 이 값 이상이면 {@link #tagNearDuplicateBoost}로 유효 Jaccard를 올려 유사 코스 과다 노출을 억제한다.
+         */
+        double tagNearDuplicateThreshold,
+        double tagNearDuplicateBoost
+) {
+    public static DiversityRerankSnapshot from(DiversityRerankSettings s) {
+        if (s == null) {
+            return defaults();
+        }
+        return new DiversityRerankSnapshot(
+                s.getDiversityLambda(),
+                s.getRegionSimWeight(),
+                s.getRegionClusterSimilarityRatio(),
+                s.getStyleSimWeight(),
+                s.getTagSimWeight(),
+                s.getLanguageSimWeight(),
+                s.getPriceTierSimWeight(),
+                s.getPriceAdjacentSimilarityRatio(),
+                s.getTagNearDuplicateThreshold(),
+                s.getTagNearDuplicateBoost()
+        );
+    }
+
+    public static DiversityRerankSnapshot defaults() {
+        return new DiversityRerankSnapshot(
+                DiversityRerankConstants.DIVERSITY_LAMBDA,
+                DiversityRerankConstants.REGION_SIM_WEIGHT,
+                DiversityRerankConstants.REGION_CLUSTER_SIMILARITY_RATIO,
+                DiversityRerankConstants.STYLE_SIM_WEIGHT,
+                DiversityRerankConstants.TAG_SIM_WEIGHT,
+                DiversityRerankConstants.LANGUAGE_SIM_WEIGHT,
+                DiversityRerankConstants.PRICE_TIER_SIM_WEIGHT,
+                DiversityRerankConstants.DEFAULT_PRICE_ADJACENT_SIMILARITY_RATIO,
+                DiversityRerankConstants.DEFAULT_TAG_NEAR_DUP_THRESHOLD,
+                DiversityRerankConstants.DEFAULT_TAG_NEAR_DUP_BOOST
+        );
+    }
+}

--- a/backend/module-ai/src/main/java/com/team6/module/ai/config/LocalGuestAiProperties.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/config/LocalGuestAiProperties.java
@@ -38,6 +38,11 @@ public class LocalGuestAiProperties {
      */
     private ScoringPolicySettings scoringPolicy = new ScoringPolicySettings();
 
+    /**
+     * Top-N 다양성 패널티(λ·유사도 가중, {@code localguest.ai.diversity-rerank}).
+     */
+    private DiversityRerankSettings diversityRerank = new DiversityRerankSettings();
+
     @Getter
     @Setter
     public static class ParserSettings {

--- a/backend/module-ai/src/main/java/com/team6/module/ai/config/ModuleAiConfiguration.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/config/ModuleAiConfiguration.java
@@ -12,4 +12,9 @@ public class ModuleAiConfiguration {
     public ScoringPolicySnapshot scoringPolicySnapshot(LocalGuestAiProperties properties) {
         return ScoringPolicySnapshot.from(properties.getScoringPolicy());
     }
+
+    @Bean
+    public DiversityRerankSnapshot diversityRerankSnapshot(LocalGuestAiProperties properties) {
+        return DiversityRerankSnapshot.from(properties.getDiversityRerank());
+    }
 }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/engine/DiversityRerankConstants.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/engine/DiversityRerankConstants.java
@@ -1,12 +1,12 @@
 package com.team6.module.ai.engine;
 
 /**
- * Diversity rerank(유사도 패널티)에 쓰이는 가중치. {@link MatchingEngine} 전용.
- * <p>
- * 유사도는 대략 0~1로 정규화한 뒤 {@code DIVERSITY_LAMBDA}를 곱해 점수에서 뺀다.
- * 가중치 합({@link #REGION_SIM_WEIGHT}+…+{@link #PRICE_TIER_SIM_WEIGHT})으로 나누어 스케일을 맞춘다.
- * 지역 차원은 동일 지역(1.0) 또는 희망 지역 권역 내 서로 다른 지역 쌍({@link #REGION_CLUSTER_SIMILARITY_RATIO})으로만 채운다.
+ * Diversity rerank 기본 상수(참고용). 런타임 튜닝은
+ * {@code com.team6.module.ai.config.DiversityRerankSnapshot}·{@code localguest.ai.diversity-rerank}를 사용한다.
+ *
+ * @deprecated 새 코드는 {@code DiversityRerankSnapshot#defaults()}를 참고한다.
  */
+@Deprecated
 public final class DiversityRerankConstants {
 
     private DiversityRerankConstants() {
@@ -27,4 +27,19 @@ public final class DiversityRerankConstants {
     public static final double LANGUAGE_SIM_WEIGHT = 0.55;
     /** 두 후보의 가격 티어(낮음/중간/높음)가 같을 때 가산. */
     public static final double PRICE_TIER_SIM_WEIGHT = 0.45;
+
+    /**
+     * 가격 티어가 인접(한 단계 차이)일 때 {@link #PRICE_TIER_SIM_WEIGHT}에 곱하는 유사도(0~1).
+     */
+    public static final double DEFAULT_PRICE_ADJACENT_SIMILARITY_RATIO = 0.38d;
+
+    /**
+     * 전문 태그 Jaccard가 이 값 이상이면 유사 코스로 보고 유효 Jaccard를 추가로 올린다.
+     */
+    public static final double DEFAULT_TAG_NEAR_DUP_THRESHOLD = 0.72d;
+
+    /**
+     * {@link #DEFAULT_TAG_NEAR_DUP_THRESHOLD} 이상 구간에서 Jaccard에 가산하는 부스트(상한 1.0).
+     */
+    public static final double DEFAULT_TAG_NEAR_DUP_BOOST = 0.28d;
 }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/engine/MatchingEngine.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/engine/MatchingEngine.java
@@ -1,5 +1,6 @@
 package com.team6.module.ai.engine;
 
+import com.team6.module.ai.config.DiversityRerankSnapshot;
 import com.team6.module.ai.dto.response.GuideRecommendItem;
 import com.team6.module.ai.dto.response.GuideRecommendResponse;
 import com.team6.module.ai.model.GuideAiProfile;
@@ -26,6 +27,7 @@ public class MatchingEngine {
     private final ScoreCalculator scoreCalculator;
     private final ReasonGenerator reasonGenerator;
     private final AdjacentRegionProvider adjacentRegionProvider;
+    private final DiversityRerankSnapshot diversity;
 
 
     public GuideRecommendResponse recommend(
@@ -68,6 +70,9 @@ public class MatchingEngine {
                 .build();
     }
 
+    /**
+     * 동일 {@code guideId}는 한 번만 선택한다(입력 풀에 중복 ID가 있어도 과다 노출되지 않음).
+     */
     private List<ScoredGuide> pickWithDiversityPenalty(
             List<ScoredGuide> candidates,
             int topN,
@@ -91,7 +96,7 @@ public class MatchingEngine {
                 }
                 double penalty = selected.isEmpty()
                         ? 0.0
-                        : maxSimilarityToSelected(c.guide, selected, preference) * DiversityRerankConstants.DIVERSITY_LAMBDA;
+                        : maxSimilarityToSelected(c.guide, selected, preference) * diversity.diversityLambda();
                 double finalScore = c.baseScore - penalty;
 
                 if (isBetterCandidate(finalScore, c, bestFinal, best)) {
@@ -157,33 +162,63 @@ public class MatchingEngine {
     private double similarity(TravelerPreference preference, GuideAiProfile a, GuideAiProfile b) {
         double sim = 0.0;
 
-        sim += DiversityRerankConstants.REGION_SIM_WEIGHT * regionSimilarityForDiversity(preference, a, b);
+        sim += diversity.regionSimWeight() * regionSimilarityForDiversity(preference, a, b);
 
         if (safeEquals(a.getGuideStyle(), b.getGuideStyle())) {
-            sim += DiversityRerankConstants.STYLE_SIM_WEIGHT;
+            sim += diversity.styleSimWeight();
         }
 
-        double tagSim = tagOverlapRatio(a.getSpecialtyTags(), b.getSpecialtyTags());
-        sim += DiversityRerankConstants.TAG_SIM_WEIGHT * tagSim;
+        double rawTagJaccard = tagOverlapRatio(a.getSpecialtyTags(), b.getSpecialtyTags());
+        double effectiveTagJaccard = boostTagJaccardForNearDuplicate(rawTagJaccard);
+        sim += diversity.tagSimWeight() * effectiveTagJaccard;
 
         double langSim = languageJaccard(a.getLanguages(), b.getLanguages());
-        sim += DiversityRerankConstants.LANGUAGE_SIM_WEIGHT * langSim;
+        sim += diversity.languageSimWeight() * langSim;
 
-        if (safeEquals(a.getPriceLevel(), b.getPriceLevel())) {
-            sim += DiversityRerankConstants.PRICE_TIER_SIM_WEIGHT;
-        }
+        sim += diversity.priceTierSimWeight() * priceTierSimilarity(a.getPriceLevel(), b.getPriceLevel());
 
-        double max = DiversityRerankConstants.REGION_SIM_WEIGHT
-                + DiversityRerankConstants.STYLE_SIM_WEIGHT
-                + DiversityRerankConstants.TAG_SIM_WEIGHT
-                + DiversityRerankConstants.LANGUAGE_SIM_WEIGHT
-                + DiversityRerankConstants.PRICE_TIER_SIM_WEIGHT;
+        double max = diversity.regionSimWeight()
+                + diversity.styleSimWeight()
+                + diversity.tagSimWeight()
+                + diversity.languageSimWeight()
+                + diversity.priceTierSimWeight();
         return max == 0.0 ? 0.0 : (sim / max);
     }
 
     /**
+     * 태그 Jaccard가 높을수록(유사 코스) 유효 유사도를 추가로 올려 Top-N에서 덜 고른다.
+     */
+    private double boostTagJaccardForNearDuplicate(double jaccard) {
+        if (jaccard < diversity.tagNearDuplicateThreshold()) {
+            return jaccard;
+        }
+        double span = 1.0 - diversity.tagNearDuplicateThreshold();
+        if (span <= 0.0) {
+            return jaccard;
+        }
+        double extra = (jaccard - diversity.tagNearDuplicateThreshold()) / span;
+        return Math.min(1.0, jaccard + diversity.tagNearDuplicateBoost() * extra);
+    }
+
+    /**
+     * 0~1. 완전 일치 1, 인접 티어는 {@link DiversityRerankSnapshot#priceAdjacentSimilarityRatio()}, 그 외 0.
+     */
+    private double priceTierSimilarity(String a, String b) {
+        if (a == null || b == null) {
+            return 0.0;
+        }
+        if (a.trim().equalsIgnoreCase(b.trim())) {
+            return 1.0;
+        }
+        if (BudgetTier.adjacentTiers(a, b)) {
+            return diversity.priceAdjacentSimilarityRatio();
+        }
+        return 0.0;
+    }
+
+    /**
      * 가이드 둘의 활동 지역이 같으면 1.0. 다르지만 둘 다 여행자 희망 지역 또는 그 인접 지역이면
-     * {@link DiversityRerankConstants#REGION_CLUSTER_SIMILARITY_RATIO}. 그 외 0.
+     * 스냅샷의 regionClusterSimilarityRatio. 그 외 0.
      */
     private double regionSimilarityForDiversity(TravelerPreference preference, GuideAiProfile a, GuideAiProfile b) {
         String ra = a.getRegion();
@@ -201,7 +236,7 @@ public class MatchingEngine {
         boolean aInTravelZone = tr.equalsIgnoreCase(ra.trim()) || adjacentRegionProvider.isAdjacentTo(tr, ra);
         boolean bInTravelZone = tr.equalsIgnoreCase(rb.trim()) || adjacentRegionProvider.isAdjacentTo(tr, rb);
         if (aInTravelZone && bInTravelZone) {
-            return DiversityRerankConstants.REGION_CLUSTER_SIMILARITY_RATIO;
+            return diversity.regionClusterSimilarityRatio();
         }
         return 0.0;
     }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationTuning.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationTuning.java
@@ -3,7 +3,8 @@ package com.team6.module.ai.support;
 /**
  * 룰 기반 추천의 공통 튜닝(스코어 가중·피드백 수치는 {@link com.team6.module.ai.config.ScoringPolicySettings}).
  * <p>
- * Diversity rerank 가중치는 {@link com.team6.module.ai.engine.DiversityRerankConstants},
+ * Diversity rerank는 {@link com.team6.module.ai.config.DiversityRerankSnapshot}·
+ * {@code localguest.ai.diversity-rerank}(레거시 참고: {@link com.team6.module.ai.engine.DiversityRerankConstants}),
  * 정책별 점수 가중은 {@link com.team6.module.ai.config.ScoringPolicySnapshot}를 참고한다.
  */
 public final class AiRecommendationTuning {
@@ -14,7 +15,7 @@ public final class AiRecommendationTuning {
     /**
      * 룰/스코어/Reason/응답 계약이 바뀔 때마다 올린다. 로그·API에서 동일 프롬프트 비교 시 정책 변경 여부를 구분하는 데 쓴다.
      */
-    public static final String POLICY_VERSION = "2026.04.18";
+    public static final String POLICY_VERSION = "2026.04.19";
 
     public static final int DEFAULT_TOP_N = 3;
 

--- a/backend/module-ai/src/test/java/com/team6/module/ai/engine/MatchingEngineDiversityTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/engine/MatchingEngineDiversityTest.java
@@ -1,8 +1,10 @@
 package com.team6.module.ai.engine;
 
+import com.team6.module.ai.config.DiversityRerankSnapshot;
 import com.team6.module.ai.config.LocalGuestAiProperties;
 import com.team6.module.ai.config.ScoringPolicySnapshot;
 import com.team6.module.ai.policy.ComboMatchPolicy;
+import com.team6.module.ai.dto.response.GuideRecommendItem;
 import com.team6.module.ai.dto.response.GuideRecommendResponse;
 import com.team6.module.ai.model.GuideAiProfile;
 import com.team6.module.ai.model.TravelerPreference;
@@ -41,7 +43,12 @@ class MatchingEngineDiversityTest {
                 new ComboMatchPolicy(scoring),
                 new AiRecommendationMetrics(new SimpleMeterRegistry())
         );
-        return new MatchingEngine(scoreCalculator, new ReasonGenerator(adjacent, scoring), adjacent);
+        return new MatchingEngine(
+                scoreCalculator,
+                new ReasonGenerator(adjacent, scoring),
+                adjacent,
+                DiversityRerankSnapshot.defaults()
+        );
     }
 
     @Test
@@ -90,5 +97,49 @@ class MatchingEngineDiversityTest {
         assertThat(response.getRecommendations().get(0).getGuideId()).isEqualTo(3L);
         assertThat(response.getRecommendations().get(0).getScore())
                 .isGreaterThanOrEqualTo(response.getRecommendations().get(1).getScore());
+    }
+
+    @Test
+    void recommend_should_not_pick_same_guide_id_twice_when_pool_contains_duplicates() {
+        TravelerPreference pref = TravelerPreference.builder()
+                .region("제주")
+                .travelStyle("감성")
+                .budgetLevel("중간")
+                .activityTags(List.of("카페"))
+                .build();
+
+        GuideAiProfile g1 = GuideAiProfile.builder()
+                .guideId(1L)
+                .guideName("A")
+                .region("제주")
+                .guideStyle("감성")
+                .priceLevel("중간")
+                .specialtyTags(List.of("카페"))
+                .languages(List.of("한국어"))
+                .build();
+        GuideAiProfile g1dup = GuideAiProfile.builder()
+                .guideId(1L)
+                .guideName("A중복행")
+                .region("제주")
+                .guideStyle("감성")
+                .priceLevel("중간")
+                .specialtyTags(List.of("카페"))
+                .languages(List.of("한국어"))
+                .build();
+        GuideAiProfile g2 = GuideAiProfile.builder()
+                .guideId(2L)
+                .guideName("B")
+                .region("제주")
+                .guideStyle("로컬")
+                .priceLevel("중간")
+                .specialtyTags(List.of("맛집"))
+                .languages(List.of("한국어"))
+                .build();
+
+        GuideRecommendResponse response = engine().recommend(pref, List.of(g1, g1dup, g2), 3);
+
+        assertThat(response.getRecommendations()).hasSize(2);
+        assertThat(response.getRecommendations().stream().map(GuideRecommendItem::getGuideId).distinct().count())
+                .isEqualTo(2L);
     }
 }

--- a/backend/module-ai/src/test/java/com/team6/module/ai/regression/AiRecommendationRegressionTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/regression/AiRecommendationRegressionTest.java
@@ -1,5 +1,6 @@
 package com.team6.module.ai.regression;
 
+import com.team6.module.ai.config.DiversityRerankSnapshot;
 import com.team6.module.ai.config.LocalGuestAiProperties;
 import com.team6.module.ai.config.ScoringPolicySnapshot;
 import com.team6.module.ai.policy.ComboMatchPolicy;
@@ -297,7 +298,8 @@ class AiRecommendationRegressionTest {
         );
         ReasonGenerator reasonGenerator = new ReasonGenerator(adjacent, scoring);
 
-        return new AiRecommendationServiceImpl(new MatchingEngine(scoreCalculator, reasonGenerator, adjacent));
+        return new AiRecommendationServiceImpl(
+                new MatchingEngine(scoreCalculator, reasonGenerator, adjacent, DiversityRerankSnapshot.defaults()));
     }
 
     private record Scenario(

--- a/backend/module-ai/src/test/java/com/team6/module/ai/service/AiRecommendationServiceTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/service/AiRecommendationServiceTest.java
@@ -9,6 +9,7 @@ import com.team6.module.ai.policy.ActivityMatchPolicy;
 import com.team6.module.ai.policy.BudgetMatchPolicy;
 import com.team6.module.ai.policy.FeedbackMatchPolicy;
 import com.team6.module.ai.policy.LanguageMatchPolicy;
+import com.team6.module.ai.config.DiversityRerankSnapshot;
 import com.team6.module.ai.config.LocalGuestAiProperties;
 import com.team6.module.ai.config.ScoringPolicySnapshot;
 import com.team6.module.ai.policy.ComboMatchPolicy;
@@ -44,7 +45,7 @@ class AiRecommendationServiceTest {
         ReasonGenerator reasonGenerator = new ReasonGenerator(adjacent, scoring);
 
         return new AiRecommendationServiceImpl(
-                new MatchingEngine(scoreCalculator, reasonGenerator, adjacent)
+                new MatchingEngine(scoreCalculator, reasonGenerator, adjacent, DiversityRerankSnapshot.defaults())
         );
     }
 

--- a/backend/module-ai/src/test/java/com/team6/module/ai/service/PromptRecommendationServiceTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/service/PromptRecommendationServiceTest.java
@@ -5,6 +5,7 @@ import com.team6.module.ai.dto.response.GuideRecommendResponse;
 import com.team6.module.ai.engine.MatchingEngine;
 import com.team6.module.ai.engine.ReasonGenerator;
 import com.team6.module.ai.engine.ScoreCalculator;
+import com.team6.module.ai.config.DiversityRerankSnapshot;
 import com.team6.module.ai.config.LocalGuestAiProperties;
 import com.team6.module.ai.config.ScoringPolicySnapshot;
 import com.team6.module.ai.parser.PromptParser;
@@ -45,7 +46,8 @@ class PromptRecommendationServiceTest {
         );
         ReasonGenerator reasonGenerator = new ReasonGenerator(adjacent, scoring);
         AiRecommendationService aiRecommendationService =
-                new AiRecommendationServiceImpl(new MatchingEngine(scoreCalculator, reasonGenerator, adjacent));
+                new AiRecommendationServiceImpl(
+                        new MatchingEngine(scoreCalculator, reasonGenerator, adjacent, DiversityRerankSnapshot.defaults()));
 
         return new PromptRecommendationService(
                 new PromptParser(aiProps),


### PR DESCRIPTION
## 변경 범위
- **유사도**: 가격대는 완전 일치 외 **인접 티어**도 부분 유사도 반영. 태그 Jaccard가 높을수록(유사 코스) **추가 부스트**로 패널티 강화.
- **튜닝**: `localguest.ai.diversity-rerank` → `DiversityRerankSnapshot` (λ, 지역·스타일·태그·언어·가격 가중, 권역 비율, 인접 예산 비율, 유사 코스 태그 임계/부스트).
- **중복**: 동일 `guideId`는 Top-N에서 한 번만 선택(입력 풀 중복 ID 방지) — 테스트 추가.
- `DiversityRerankConstants`는 레거시 참고용 `@Deprecated`.
- `POLICY_VERSION` → **2026.04.19**.

## 스키마
DB 변경 없음.

## 검증
```bash
./gradlew :module-ai:test :module-ai-integration:test :api-server:compileJava
```

Closes #179

Made with [Cursor](https://cursor.com)