### PR TITLE
Feat/be#181 AI 관측·튜닝 루프(Micrometer 폴백 채택·다양성 패널티)

### DIFF
--- a/backend/module-ai/src/main/java/com/team6/module/ai/engine/MatchingEngine.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/engine/MatchingEngine.java
@@ -7,6 +7,7 @@ import com.team6.module.ai.model.GuideAiProfile;
 import com.team6.module.ai.model.TravelerPreference;
 import com.team6.module.ai.parser.KeywordNormalizer;
 import com.team6.module.ai.support.AdjacentRegionProvider;
+import com.team6.module.ai.support.AiRecommendationMetrics;
 import com.team6.module.ai.support.AiRecommendationTuning;
 import com.team6.module.ai.support.BudgetTier;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +29,7 @@ public class MatchingEngine {
     private final ReasonGenerator reasonGenerator;
     private final AdjacentRegionProvider adjacentRegionProvider;
     private final DiversityRerankSnapshot diversity;
+    private final AiRecommendationMetrics recommendationMetrics;
 
 
     public GuideRecommendResponse recommend(
@@ -89,6 +91,7 @@ public class MatchingEngine {
         while (selected.size() < limit) {
             ScoredGuide best = null;
             double bestFinal = Double.NEGATIVE_INFINITY;
+            double bestDiversityPenalty = 0.0;
 
             for (ScoredGuide c : candidates) {
                 if (c.guide.getGuideId() == null || used.contains(c.guide.getGuideId())) {
@@ -102,6 +105,7 @@ public class MatchingEngine {
                 if (isBetterCandidate(finalScore, c, bestFinal, best)) {
                     bestFinal = finalScore;
                     best = c;
+                    bestDiversityPenalty = penalty;
                 }
             }
 
@@ -109,6 +113,12 @@ public class MatchingEngine {
                 break;
             }
 
+            if (!selected.isEmpty()) {
+                recommendationMetrics.recordDiversityPenaltyMagnitude(
+                        bestDiversityPenalty,
+                        AiRecommendationTuning.POLICY_VERSION
+                );
+            }
             selected.add(best);
             used.add(best.guide.getGuideId());
         }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
@@ -161,6 +161,8 @@ public class PromptRecommendationService {
                     ? fallback.winningRelaxStage().name()
                     : "STRATEGIC_EXHAUSTED";
             metrics.recordFallback(metricStage);
+            boolean adopted = fallback.winningRelaxStage() != RelaxStage.NONE;
+            metrics.recordStrategicFallbackOutcome(adopted, POLICY_VERSION);
         }
 
             List<String> noticeCodes = buildNoticeCodes(

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationMetrics.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationMetrics.java
@@ -15,7 +15,8 @@ import java.util.concurrent.TimeUnit;
  *   <li>{@code .no_region_short_circuit} — 지역 미입력 단축</li>
  *   <li>{@code .region_expansion} — 인접 지역 후보 확장 사용</li>
  *   <li>{@code .sparse_pool_notice} — 희소 풀 안내 부착</li>
-     *   <li>{@code .fallback(stage=...)} — 조건 완화 재시도({@code DROP_ACTIVITY_TAGS_ONLY} 등 또는 {@code STRATEGIC_EXHAUSTED})</li>
+ *   <li>{@code .fallback(stage=...)} — 조건 완화 재시도({@code DROP_ACTIVITY_TAGS_ONLY} 등 또는 {@code STRATEGIC_EXHAUSTED})</li>
+ *   <li>{@code .strategic_fallback_outcome(result=adopted|exhausted,policy_version=...)} — 전략 완화 체인 실행 시 최종 채택 여부(대시보드에서 adopted/(adopted+exhausted))</li>
  *   <li>{@code .outcome(type=no_region|empty|success)} — 최종 건수 결과</li>
  *   <li>{@code .feedback_penalty_hits(policy_version=...)} — 후보 1명 스코어링 시
  *       {@link com.team6.module.ai.policy.FeedbackMatchPolicy} 감점이 적용된 횟수(0보다 작은 기여)</li>
@@ -26,6 +27,7 @@ import java.util.concurrent.TimeUnit;
  *   <li>{@code .top1_score} — Top1 룰 점수</li>
  *   <li>{@code .effective_pool_size} — 확장 후 후보 풀 크기</li>
  *   <li>{@code .feedback_penalty_magnitude} — 후보별 피드백 감점 절댓값(룰 점수에서 깎인 양, 단위: 점)</li>
+ *   <li>{@code .diversity_penalty_magnitude} — Top-N에서 2번째 슬롯부터 선택 시 적용된 유사도×λ 패널티(점수 스케일)</li>
  * </ul>
  */
 @Component
@@ -61,6 +63,17 @@ public class AiRecommendationMetrics {
     public void recordFallback(String relaxStage) {
         String stage = relaxStage == null || relaxStage.isBlank() ? "NONE" : relaxStage;
         registry.counter(PREFIX + ".fallback", "stage", stage).increment();
+    }
+
+    /**
+     * 전략적 조건 완화 체인을 실제로 돌린 뒤, 완화된 추천을 채택했는지(adopted) 소진했는지(exhausted).
+     * Prometheus 등에서 {@code sum(rate(...{result="adopted"})) / sum(rate(...{result=~"adopted|exhausted"}))} 로 채택률 근사.
+     */
+    public void recordStrategicFallbackOutcome(boolean adopted, String policyVersion) {
+        String pv = policyVersion == null ? "unknown" : policyVersion;
+        String result = adopted ? "adopted" : "exhausted";
+        registry.counter(PREFIX + ".strategic_fallback_outcome",
+                Tags.of("policy_version", pv, "result", result)).increment();
     }
 
     /**
@@ -108,5 +121,17 @@ public class AiRecommendationMetrics {
         Tags tags = Tags.of("policy_version", pv);
         registry.counter(PREFIX + ".feedback_penalty_hits", tags).increment();
         registry.summary(PREFIX + ".feedback_penalty_magnitude", tags).record(penaltyMagnitude);
+    }
+
+    /**
+     * 다양성 랭킹에서 이미 고른 가이드와의 유사도×λ로 깎인 점수(양수). Top1(첫 슬롯)에는 적용되지 않으므로 기록하지 않는다.
+     */
+    public void recordDiversityPenaltyMagnitude(double penaltyPoints, String policyVersion) {
+        if (penaltyPoints < 0.0) {
+            return;
+        }
+        String pv = policyVersion == null ? "unknown" : policyVersion;
+        registry.summary(PREFIX + ".diversity_penalty_magnitude", Tags.of("policy_version", pv))
+                .record(penaltyPoints);
     }
 }

--- a/backend/module-ai/src/test/java/com/team6/module/ai/engine/MatchingEngineDiversityTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/engine/MatchingEngineDiversityTest.java
@@ -16,6 +16,7 @@ import com.team6.module.ai.policy.RegionMatchPolicy;
 import com.team6.module.ai.policy.StyleMatchPolicy;
 import com.team6.module.ai.support.AdjacentRegionProvider;
 import com.team6.module.ai.support.AiRecommendationMetrics;
+import com.team6.module.ai.support.AiRecommendationTuning;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
 
@@ -29,10 +30,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class MatchingEngineDiversityTest {
 
-    private static MatchingEngine engine() {
+    private static MatchingEngine engine(SimpleMeterRegistry registry) {
         LocalGuestAiProperties aiProps = new LocalGuestAiProperties();
         ScoringPolicySnapshot scoring = ScoringPolicySnapshot.defaults();
         AdjacentRegionProvider adjacent = new AdjacentRegionProvider(aiProps);
+        AiRecommendationMetrics metrics = new AiRecommendationMetrics(registry);
         ScoreCalculator scoreCalculator = new ScoreCalculator(
                 new RegionMatchPolicy(adjacent, scoring),
                 new StyleMatchPolicy(scoring),
@@ -41,13 +43,14 @@ class MatchingEngineDiversityTest {
                 new LanguageMatchPolicy(scoring),
                 new FeedbackMatchPolicy(scoring),
                 new ComboMatchPolicy(scoring),
-                new AiRecommendationMetrics(new SimpleMeterRegistry())
+                metrics
         );
         return new MatchingEngine(
                 scoreCalculator,
                 new ReasonGenerator(adjacent, scoring),
                 adjacent,
-                DiversityRerankSnapshot.defaults()
+                DiversityRerankSnapshot.defaults(),
+                metrics
         );
     }
 
@@ -91,12 +94,16 @@ class MatchingEngineDiversityTest {
                         .build()
         );
 
-        GuideRecommendResponse response = engine().recommend(pref, guides, 2);
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        GuideRecommendResponse response = engine(registry).recommend(pref, guides, 2);
 
         assertThat(response.getRecommendations()).hasSize(2);
         assertThat(response.getRecommendations().get(0).getGuideId()).isEqualTo(3L);
         assertThat(response.getRecommendations().get(0).getScore())
                 .isGreaterThanOrEqualTo(response.getRecommendations().get(1).getScore());
+        assertThat(registry.summary("localguest.ai.recommend.diversity_penalty_magnitude",
+                        "policy_version", AiRecommendationTuning.POLICY_VERSION).count())
+                .isEqualTo(1);
     }
 
     @Test
@@ -136,7 +143,7 @@ class MatchingEngineDiversityTest {
                 .languages(List.of("한국어"))
                 .build();
 
-        GuideRecommendResponse response = engine().recommend(pref, List.of(g1, g1dup, g2), 3);
+        GuideRecommendResponse response = engine(new SimpleMeterRegistry()).recommend(pref, List.of(g1, g1dup, g2), 3);
 
         assertThat(response.getRecommendations()).hasSize(2);
         assertThat(response.getRecommendations().stream().map(GuideRecommendItem::getGuideId).distinct().count())

--- a/backend/module-ai/src/test/java/com/team6/module/ai/regression/AiRecommendationRegressionTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/regression/AiRecommendationRegressionTest.java
@@ -286,6 +286,8 @@ class AiRecommendationRegressionTest {
         LocalGuestAiProperties aiProps = new LocalGuestAiProperties();
         ScoringPolicySnapshot scoring = ScoringPolicySnapshot.defaults();
         AdjacentRegionProvider adjacent = new AdjacentRegionProvider(aiProps);
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        AiRecommendationMetrics metrics = new AiRecommendationMetrics(meterRegistry);
         ScoreCalculator scoreCalculator = new ScoreCalculator(
                 new RegionMatchPolicy(adjacent, scoring),
                 new StyleMatchPolicy(scoring),
@@ -294,12 +296,12 @@ class AiRecommendationRegressionTest {
                 new LanguageMatchPolicy(scoring),
                 new FeedbackMatchPolicy(scoring),
                 new ComboMatchPolicy(scoring),
-                new AiRecommendationMetrics(new SimpleMeterRegistry())
+                metrics
         );
         ReasonGenerator reasonGenerator = new ReasonGenerator(adjacent, scoring);
 
         return new AiRecommendationServiceImpl(
-                new MatchingEngine(scoreCalculator, reasonGenerator, adjacent, DiversityRerankSnapshot.defaults()));
+                new MatchingEngine(scoreCalculator, reasonGenerator, adjacent, DiversityRerankSnapshot.defaults(), metrics));
     }
 
     private record Scenario(

--- a/backend/module-ai/src/test/java/com/team6/module/ai/service/AiRecommendationServiceTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/service/AiRecommendationServiceTest.java
@@ -32,6 +32,8 @@ class AiRecommendationServiceTest {
         LocalGuestAiProperties aiProps = new LocalGuestAiProperties();
         ScoringPolicySnapshot scoring = ScoringPolicySnapshot.defaults();
         AdjacentRegionProvider adjacent = new AdjacentRegionProvider(aiProps);
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        AiRecommendationMetrics metrics = new AiRecommendationMetrics(meterRegistry);
         ScoreCalculator scoreCalculator = new ScoreCalculator(
                 new RegionMatchPolicy(adjacent, scoring),
                 new StyleMatchPolicy(scoring),
@@ -40,12 +42,12 @@ class AiRecommendationServiceTest {
                 new LanguageMatchPolicy(scoring),
                 new FeedbackMatchPolicy(scoring),
                 new ComboMatchPolicy(scoring),
-                new AiRecommendationMetrics(new SimpleMeterRegistry())
+                metrics
         );
         ReasonGenerator reasonGenerator = new ReasonGenerator(adjacent, scoring);
 
         return new AiRecommendationServiceImpl(
-                new MatchingEngine(scoreCalculator, reasonGenerator, adjacent, DiversityRerankSnapshot.defaults())
+                new MatchingEngine(scoreCalculator, reasonGenerator, adjacent, DiversityRerankSnapshot.defaults(), metrics)
         );
     }
 

--- a/backend/module-ai/src/test/java/com/team6/module/ai/service/PromptRecommendationServiceTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/service/PromptRecommendationServiceTest.java
@@ -34,6 +34,7 @@ class PromptRecommendationServiceTest {
         LocalGuestAiProperties aiProps = new LocalGuestAiProperties();
         ScoringPolicySnapshot scoring = ScoringPolicySnapshot.defaults();
         AdjacentRegionProvider adjacent = new AdjacentRegionProvider(aiProps);
+        AiRecommendationMetrics metrics = new AiRecommendationMetrics(meterRegistry);
         ScoreCalculator scoreCalculator = new ScoreCalculator(
                 new RegionMatchPolicy(adjacent, scoring),
                 new StyleMatchPolicy(scoring),
@@ -42,18 +43,19 @@ class PromptRecommendationServiceTest {
                 new LanguageMatchPolicy(scoring),
                 new FeedbackMatchPolicy(scoring),
                 new ComboMatchPolicy(scoring),
-                new AiRecommendationMetrics(meterRegistry)
+                metrics
         );
         ReasonGenerator reasonGenerator = new ReasonGenerator(adjacent, scoring);
         AiRecommendationService aiRecommendationService =
                 new AiRecommendationServiceImpl(
-                        new MatchingEngine(scoreCalculator, reasonGenerator, adjacent, DiversityRerankSnapshot.defaults()));
+                        new MatchingEngine(scoreCalculator, reasonGenerator, adjacent, DiversityRerankSnapshot.defaults(),
+                                metrics));
 
         return new PromptRecommendationService(
                 new PromptParser(aiProps),
                 aiRecommendationService,
                 adjacent,
-                new AiRecommendationMetrics(meterRegistry),
+                metrics,
                 scoring
         );
     }

--- a/backend/module-ai/src/test/java/com/team6/module/ai/support/AiRecommendationMetricsTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/support/AiRecommendationMetricsTest.java
@@ -62,4 +62,23 @@ class AiRecommendationMetricsTest {
         assertThat(registry.counter("localguest.ai.recommend.feedback_penalty_hits", "policy_version", "test-policy")
                 .count()).isZero();
     }
+
+    @Test
+    void strategic_fallback_outcome_should_tag_adopted_and_exhausted() {
+        metrics.recordStrategicFallbackOutcome(true, "pv");
+        metrics.recordStrategicFallbackOutcome(false, "pv");
+
+        assertThat(registry.counter("localguest.ai.recommend.strategic_fallback_outcome",
+                "policy_version", "pv", "result", "adopted").count()).isEqualTo(1);
+        assertThat(registry.counter("localguest.ai.recommend.strategic_fallback_outcome",
+                "policy_version", "pv", "result", "exhausted").count()).isEqualTo(1);
+    }
+
+    @Test
+    void diversity_penalty_magnitude_should_record() {
+        metrics.recordDiversityPenaltyMagnitude(12.5, "pv");
+
+        assertThat(registry.summary("localguest.ai.recommend.diversity_penalty_magnitude", "policy_version", "pv").count())
+                .isEqualTo(1);
+    }
 }


### PR DESCRIPTION
## 변경 범위
- **strategic_fallback_outcome** 카운터: `result=adopted|exhausted` + `policy_version` — 전략 완화 체인 실행 시 최종 채택 여부(채택률 ≈ adopted/(adopted+exhausted)).
- **diversity_penalty_magnitude** Summary: Top-N에서 2번째 슬롯부터 적용된 유사도×λ 패널티(점수 스케일).
- `MatchingEngine`에 `AiRecommendationMetrics` 주입, 테스트는 동일 레지스트리 공유.

## 기존 메트릭
- `top1_score`, `fallback(stage)`, `latency`, `effective_pool_size` 등 유지.

## 검증
```bash
./gradlew :module-ai:test :module-ai-integration:test :api-server:compileJava
```

Closes #181

Made with [Cursor](https://cursor.com)