### PR TITLE
Feat/be#188 프롬프트 파싱 튜닝 신호 로그 추가

### DIFF
--- a/backend/module-ai/src/main/java/com/team6/module/ai/parser/PromptParser.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/parser/PromptParser.java
@@ -69,6 +69,19 @@ public class PromptParser {
     private static final Pattern DATE_RANGE_DAY_ONLY = Pattern.compile("(\\d{1,2})\\s*일\\s*(?:~|\\-|부터)\\s*(\\d{1,2})\\s*일");
     private static final int NEGATION_AFTER_WINDOW = 12;
 
+    /**
+     * 운영 로그에서 “실패/모호 패턴”을 모아 yml/내장 키워드를 주기적으로 보강하기 위한 신호 묶음.
+     * <p>
+     * 프롬프트 원문을 그대로 남기지 않고도(민감정보 최소화) “어떤 힌트가 있었는데 결과가 비었는지”를
+     * 판별할 수 있도록, 매칭된 트리거만 요약한다.
+     */
+    public record ParseSignals(
+            List<String> matchedExclusionIntentKeywords,
+            boolean hasBudgetHint,
+            boolean hasDurationHint
+    ) {
+    }
+
     public GuideRecommendRequest parse(
             String prompt,
             Integer topN,
@@ -113,6 +126,42 @@ public class PromptParser {
                 .guideCandidates(guideCandidates)
                 .parserNoticeCodes(parserNotices.isEmpty() ? null : List.copyOf(parserNotices))
                 .build();
+    }
+
+    /**
+     * 파싱 실패/모호함 튜닝용 신호를 추출한다(로깅/관측용).
+     * <p>
+     * - 제외 의도: {@code localguest.ai.parser.exclusion-intent-keywords} + 내장 기본값을 합쳐 탐지
+     * - 예산/일정 힌트: 숫자 패턴 및 대표 키워드로 “언급은 있었다” 정도만 판별
+     */
+    public ParseSignals signals(String prompt) {
+        String normalized = normalize(prompt);
+        List<String> exclusionIntents = findAllMatchedKeywordsMerged(
+                normalized,
+                aiProperties.getParser().getExclusionIntentKeywords(),
+                DEFAULT_EXCLUSION_INTENT_KEYWORDS
+        );
+
+        boolean hasBudgetHint = containsAny(
+                normalized,
+                "예산", "원", "만원", "가성비", "저렴", "싸게", "럭셔리", "고급", "프리미엄", "비싸"
+        ) || BUDGET_WON.matcher(normalized).find()
+                || BUDGET_RANGE_WON.matcher(normalized).find()
+                || BUDGET_MANWON_ROUGH.matcher(normalized).find()
+                || BUDGET_MANWON_RANGE.matcher(normalized).find()
+                || BUDGET_MANWON_BAND.matcher(normalized).find();
+
+        boolean hasDurationHint = containsAny(normalized, "일정", "며칠", "박", "일", "주")
+                || DURATION_NIGHTS_DAYS.matcher(normalized).find()
+                || DURATION_NIGHTS_ONLY.matcher(normalized).find()
+                || DURATION_RANGE_DAYS.matcher(normalized).find()
+                || DURATION_DAYS_SUFFIX.matcher(normalized).find()
+                || DURATION_DAYS.matcher(normalized).find()
+                || DURATION_WEEKS.matcher(normalized).find()
+                || DATE_RANGE_MONTH_DAY.matcher(normalized).find()
+                || DATE_RANGE_DAY_ONLY.matcher(normalized).find();
+
+        return new ParseSignals(exclusionIntents, hasBudgetHint, hasDurationHint);
     }
 
     private String normalize(String prompt) {
@@ -574,6 +623,21 @@ public class PromptParser {
             }
         }
         return new ArrayList<>(merged);
+    }
+
+    private List<String> findAllMatchedKeywordsMerged(String prompt, List<String> yaml, String[] defaults) {
+        List<String> merged = mergeKeywordList(yaml, defaults);
+        LinkedHashSet<String> matched = new LinkedHashSet<>();
+        for (String keyword : merged) {
+            if (keyword == null || keyword.isBlank()) {
+                continue;
+            }
+            String k = keyword.trim().toLowerCase(Locale.ROOT);
+            if (!k.isEmpty() && prompt.contains(k)) {
+                matched.add(keyword.trim());
+            }
+        }
+        return new ArrayList<>(matched);
     }
 
     private boolean containsAnyMerged(String prompt, List<String> yaml, String[] defaults) {

--- a/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
@@ -143,6 +143,7 @@ public class PromptRecommendationService {
         String parseConfidence = computePromptParseConfidence(parsed);
         List<String> ambiguityCodes = collectAmbiguityNoticeCodes(prompt, parsed);
         List<String> parserHints = parsed.getParserNoticeCodes() == null ? List.of() : parsed.getParserNoticeCodes();
+        logParserTuningSignals(prompt, parsed, parseConfidence, ambiguityCodes, parserHints);
 
         String notice = fallback.fallbackNotice();
         if (expansion.expansionUsed()) {
@@ -205,6 +206,62 @@ public class PromptRecommendationService {
         } finally {
             metrics.recordRecommendationLatencyNanos(System.nanoTime() - startNs, POLICY_VERSION);
         }
+    }
+
+    /**
+     * 운영 로그에서 파싱 실패/모호함 패턴을 수집하기 위한 신호 로그.
+     * 프롬프트 원문은 남기지 않고, {@code promptHash}와 “언급 힌트/추출 결과”만 남긴다.
+     */
+    private void logParserTuningSignals(
+            String prompt,
+            GuideRecommendRequest parsed,
+            String parseConfidence,
+            List<String> ambiguityCodes,
+            List<String> parserHints
+    ) {
+        try {
+            boolean hasAmbiguity = ambiguityCodes != null && !ambiguityCodes.isEmpty();
+            boolean hasParserHints = parserHints != null && !parserHints.isEmpty();
+            boolean lowConfidence = "LOW".equalsIgnoreCase(parseConfidence);
+
+            var signals = promptParser.signals(prompt);
+            boolean exclusionIntentButNoExcluded =
+                    signals != null
+                            && signals.matchedExclusionIntentKeywords() != null
+                            && !signals.matchedExclusionIntentKeywords().isEmpty()
+                            && (parsed.getExcludedActivityTags() == null || parsed.getExcludedActivityTags().isEmpty());
+
+            if (!(lowConfidence || hasAmbiguity || hasParserHints || exclusionIntentButNoExcluded)) {
+                return;
+            }
+
+            log.info("[AI_PARSER_TUNE] policyVer={} promptHash={} parseConfidence={} ambiguityCodes={} parserHints={} signals={{exclusionIntents={},budgetHint={},durationHint={}}} extracted={{region={},style={},budget={},durationDays={},tags={},excluded={},langs={},headcount={}}}",
+                    POLICY_VERSION,
+                    promptHash(prompt),
+                    parseConfidence,
+                    ambiguityCodes,
+                    parserHints,
+                    signals == null ? null : signals.matchedExclusionIntentKeywords(),
+                    signals != null && signals.hasBudgetHint(),
+                    signals != null && signals.hasDurationHint(),
+                    parsed.getRegion(),
+                    parsed.getTravelStyle(),
+                    parsed.getBudgetLevel(),
+                    parsed.getDurationDays(),
+                    parsed.getActivityTags(),
+                    parsed.getExcludedActivityTags(),
+                    parsed.getPreferredLanguages(),
+                    parsed.getHeadcount()
+            );
+        } catch (Exception e) {
+            log.debug("[AI_PARSER_TUNE] logging skipped: {}", e.toString());
+        }
+    }
+
+    private static int promptHash(String prompt) {
+        return Objects.toString(prompt, "").getBytes(StandardCharsets.UTF_8).length == 0
+                ? 0
+                : Objects.toString(prompt, "").hashCode();
     }
 
     private void recordDistributionMetrics(GuideRecommendResponse response, int effectivePoolSize) {
@@ -621,9 +678,7 @@ public class PromptRecommendationService {
             int expansionExactCount
     ) {
         try {
-            int promptHash = Objects.toString(prompt, "").getBytes(StandardCharsets.UTF_8).length == 0
-                    ? 0
-                    : Objects.toString(prompt, "").hashCode();
+            int promptHash = promptHash(prompt);
             int candidateCount = guideCandidates == null ? 0 : guideCandidates.size();
             int baseTopScore = topScore(base);
             int finalTopScore = topScore(finalBase);

--- a/backend/module-ai/src/test/java/com/team6/module/ai/parser/PromptParserTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/parser/PromptParserTest.java
@@ -221,6 +221,14 @@ class PromptParserTest {
     }
 
     @Test
+    void signals_should_detect_exclusion_intent_keywords_and_budget_duration_hints() {
+        PromptParser.ParseSignals s = promptParser.signals("제주 2박3일로 예산은 20만 안으로, 술집은 말고 추천해줘");
+        assertThat(s.matchedExclusionIntentKeywords()).contains("말고");
+        assertThat(s.hasBudgetHint()).isTrue();
+        assertThat(s.hasDurationHint()).isTrue();
+    }
+
+    @Test
     void parse_should_extract_solo_companion_and_insta_style_and_marine_activity() {
         GuideRecommendRequest r = promptParser.parse("부산 솔로 여행 인스타 핫플 카페", 3, List.of());
         assertThat(r.getCompanionType()).isEqualTo("혼자");


### PR DESCRIPTION
## Summary
- 프롬프트 원문을 남기지 않고도(민감정보 최소화) 파싱 실패/모호 패턴을 수집할 수 있도록, 튜닝 신호 로그를 추가했습니다.
- `PromptParser.signals()`로 제외 의도 키워드 매칭/예산 힌트/일정 힌트를 요약하고, `PromptRecommendationService`에서 특정 조건(LOW/모호 코드/파서 힌트/제외의도-미추출)일 때만 `[AI_PARSER_TUNE]` 로그를 남깁니다.

## Scope
- `module-ai`

## Test
- `./gradlew :module-ai:test`
- `./gradlew :api-server:compileJava`

Closes #188

Made with [Cursor](https://cursor.com)