### PR TITLE
Feat/be#187: 가이드 스케줄 pending/paid-confirm/cancel 연동 수정

### DIFF
--- a/backend/module-domain/src/main/java/com/team6/domain/guide/controller/GuideScheduleController.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/controller/GuideScheduleController.java
@@ -101,6 +101,19 @@ public class GuideScheduleController {
         return ResponseEntity.ok(guideScheduleService.rejectSchedule(scheduleId, guideId, userId));
     }
 
+    // 스케줄 양식 조회 — isPaid=false면 courseDetail null 마스킹, true면 전체 공개 (F06-04)
+    // 가이드·게스트 모두 호출 가능
+    // TODO: 추후 보안 강화 필요
+    // 현재 인증된 사용자라면 누구나 호출 가능
+    // 개선 시 가이드 본인 또는 매칭된 게스트만 허용하도록 변경 필요
+    @GetMapping("/{scheduleId}/form")
+    public ResponseEntity<GuideScheduleFormResponse> getScheduleForm(
+            @PathVariable Long guideId,
+            @PathVariable Long scheduleId
+    ) {
+        return ResponseEntity.ok(guideScheduleService.getScheduleForm(scheduleId, guideId));
+    }
+
     // 수락 후 여행 계획 양식 저장 — BOOKED 상태에만 가능 (F06-04)
     @PutMapping("/{scheduleId}/form")
     public ResponseEntity<GuideScheduleFormResponse> submitForm(

--- a/backend/module-domain/src/main/java/com/team6/domain/guide/service/GuideScheduleService.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/service/GuideScheduleService.java
@@ -184,6 +184,17 @@ public class GuideScheduleService {
         return GuideScheduleResponse.from(schedule);
     }
 
+    // 스케줄 양식 조회 — isPaid=true면 courseDetail 공개, false면 null 마스킹 (F06-04)
+    // 가이드·게스트 모두 호출 가능 (본인 확인 없음)
+    // TODO: 추후 보안 강화 필요
+    // 현재 인증된 사용자라면 누구나 호출 가능
+    // 개선 시 가이드 본인 또는 매칭된 게스트만 허용하도록 변경 필요
+    @Transactional(readOnly = true)
+    public GuideScheduleFormResponse getScheduleForm(Long scheduleId, Long guideId) {
+        GuideSchedule schedule = getVerifiedSchedule(scheduleId, guideId);
+        return GuideScheduleFormResponse.from(schedule);
+    }
+
     // 수락 후 여행 계획 양식 저장 — BOOKED 상태 스케줄에만 가능 (F06-04)
     @Transactional
     public GuideScheduleFormResponse submitForm(Long scheduleId, Long guideId, SubmitGuideScheduleFormRequest request, Long userId) {


### PR DESCRIPTION
# 🔗 이슈 번호
- Closes # 187

## 📝 작업 내용
- 가이드 스케줄 양식 조회 API 추가
- 저장된 스케줄 양식을 가이드/게스트가 조회할 수 있도록 `GET /guides/{guideId}/schedules/{scheduleId}/form` 엔드포인트를 추가했습니다.

## ⚙️ 상세 설명 (선택)
### 변경 파일
- `GuideScheduleController.java`
- `GuideScheduleService.java'

### 변경 내용
기존에는 `PUT /{scheduleId}/form` 으로 양식 저장만 가능했고,  
저장된 양식을 다시 조회하는 API는 없었습니다.

이번 PR에서는 수락 후 작성된 양식 정보(만남 장소, 안내 메시지, 코스 상세)를 조회할 수 있도록  
`GET /guides/{guideId}/schedules/{scheduleId}/form` 엔드포인트를 추가했습니다.

### 동작 방식
- `isPaid = false`
  - `courseDetail` 은 `null` 로 마스킹
  - 기존 `GuideScheduleFormResponse.from()` 로직 재사용
- `isPaid = true`
  - `courseDetail` 전체 공개
- 현재는 가이드/게스트 모두 호출 가능
  - 별도 본인 확인 로직은 아직 없음

### TODO
현재는 인증된 사용자라면 누구나 호출 가능한 상태입니다.  
추후에는 **가이드 본인 또는 해당 매칭의 게스트만 조회 가능하도록** 보안 검증 로직을 추가해야 합니다.

이번 PR에서는 범위가 커질 수 있어 제외했고, 주석으로 명시했습니다.

## 📅 마감 기한
- 2026-04-15

## ✅ 체크리스트
- [ ] 빌드가 정상적으로 되는가?
- [ ] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [ ] .gitignore에 설정 파일이 잘 포함되었는가? (application-local.yml 등)