### PR TITLE
Feat/be#191 결제 완료 투어일 충돌 가이드 AI 후보 제외

### DIFF
--- a/backend/module-ai-integration/src/main/java/com/team6/integration/ai/DbBackedGuideCandidateProvider.java
+++ b/backend/module-ai-integration/src/main/java/com/team6/integration/ai/DbBackedGuideCandidateProvider.java
@@ -3,9 +3,11 @@ package com.team6.integration.ai;
 import com.team6.domain.guide.entity.GuideCareer;
 import com.team6.domain.guide.entity.GuideFeed;
 import com.team6.domain.guide.entity.GuideProfile;
+import com.team6.domain.guide.entity.enums.GuideScheduleStatus;
 import com.team6.domain.guide.repository.GuideCareerRepository;
 import com.team6.domain.guide.repository.GuideFeedRepository;
 import com.team6.domain.guide.repository.GuideProfileRepository;
+import com.team6.domain.guide.repository.GuideScheduleRepository;
 import com.team6.domain.matching.entity.enums.MatchRequestStatus;
 import com.team6.domain.matching.entity.enums.RefundStatus;
 import com.team6.domain.matching.repository.MatchRequestRepository;
@@ -25,6 +27,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -46,10 +49,13 @@ import java.util.stream.Collectors;
  * 정책버전 키 캐시({@link LocalGuestAiProperties#getCandidatePool()})를 적용한다.
  * <p>
  * <b>캐시 키</b>: {@link AiRecommendationTuning#POLICY_VERSION}을 접두로 하고,
- * {@code maxFetchSize}·{@code maxPoolSize}·{@code coldStartReserveRatio}·{@code excludedGuideIds}·지역 문자열을
- * 이어 붙인다. 스코어/다양성 YAML 내용 전체는 키에 넣지 않으므로, 랭킹 의미가 바뀌면
+ * {@code maxFetchSize}·{@code maxPoolSize}·{@code coldStartReserveRatio}·{@code excludedGuideIds}·지역 문자열·
+ * 선택적 {@code desiredTourDate}(투어 희망일)를 이어 붙인다. 스코어/다양성 YAML 내용 전체는 키에 넣지 않으므로, 랭킹 의미가 바뀌면
  * {@code POLICY_VERSION}을 올려 캐시를 자연스럽게 무효화하고, API {@code policyVersion}·메트릭 태그와 맞춘다.
  * 후보 풀 차원만 바꿀 때는 위 후보 풀 필드가 키에 들어가므로 별도 버전 상향 없이도 다른 엔트리가 된다.
+ * <p>
+ * <b>결제 완료 일정 제외</b>: {@code desiredTourDate}가 지정되면, 해당 로컬 날짜에
+ * {@link GuideScheduleStatus#BOOKED}이면서 {@code isPaid=true}인 스케줄이 있는 가이드는 후보에서 제외한다.
  */
 @Slf4j
 @Component
@@ -73,6 +79,7 @@ public class DbBackedGuideCandidateProvider implements GuideCandidateProvider {
     private final MatchRequestRepository matchRequestRepository;
     private final RefundRepository refundRepository;
     private final ChatRoomRepository chatRoomRepository;
+    private final GuideScheduleRepository guideScheduleRepository;
     private final PromptParser promptParser;
     private final LocalGuestAiProperties aiProperties;
 
@@ -82,10 +89,12 @@ public class DbBackedGuideCandidateProvider implements GuideCandidateProvider {
     public List<GuideRecommendRequest.GuideCandidateDto> getCandidates(
             String prompt,
             Integer topN,
-            List<GuideRecommendRequest.GuideCandidateDto> candidates
+            List<GuideRecommendRequest.GuideCandidateDto> candidates,
+            LocalDate desiredTourDate
     ) {
+        Set<Long> bookedPaidGuideIds = resolveBookedPaidGuideIds(desiredTourDate);
         if (candidates != null && !candidates.isEmpty()) {
-            return candidates;
+            return excludeBookedPaidGuides(candidates, bookedPaidGuideIds, desiredTourDate);
         }
         String safePrompt = prompt == null ? "" : prompt;
         int resolvedTopN = (topN == null || topN <= 0) ? AiRecommendationTuning.DEFAULT_TOP_N : topN;
@@ -94,7 +103,7 @@ public class DbBackedGuideCandidateProvider implements GuideCandidateProvider {
 
         LocalGuestAiProperties.CandidatePoolSettings pool = aiProperties.getCandidatePool();
         int ttlSec = pool.getPoolCacheTtlSeconds();
-        String cacheKey = buildPoolCacheKey(region, pool);
+        String cacheKey = buildPoolCacheKey(region, pool, desiredTourDate);
         if (ttlSec > 0) {
             PoolCacheEntry hit = poolCache.get(cacheKey);
             if (hit != null && !hit.isExpired()) {
@@ -105,6 +114,7 @@ public class DbBackedGuideCandidateProvider implements GuideCandidateProvider {
 
         List<GuideProfile> profiles = loadProfilesTiered(region, pool);
         profiles = filterExcludedProfiles(profiles, pool);
+        profiles = excludeBookedPaidProfiles(profiles, bookedPaidGuideIds, desiredTourDate);
 
         List<GuideRecommendRequest.GuideCandidateDto> mapped = mapProfilesToCandidates(profiles);
         List<GuideRecommendRequest.GuideCandidateDto> withSignals = mergeBehaviorSignals(mapped, profiles);
@@ -120,17 +130,76 @@ public class DbBackedGuideCandidateProvider implements GuideCandidateProvider {
         return sampled;
     }
 
+    private Set<Long> resolveBookedPaidGuideIds(LocalDate desiredTourDate) {
+        if (desiredTourDate == null) {
+            return Set.of();
+        }
+        List<Long> ids = guideScheduleRepository.findGuideProfileIdsBookedAndPaidOnDate(
+                desiredTourDate,
+                GuideScheduleStatus.BOOKED
+        );
+        if (ids == null || ids.isEmpty()) {
+            return Set.of();
+        }
+        return ids.stream().filter(Objects::nonNull).collect(Collectors.toCollection(HashSet::new));
+    }
+
+    private static List<GuideProfile> excludeBookedPaidProfiles(
+            List<GuideProfile> profiles,
+            Set<Long> bookedPaidGuideIds,
+            LocalDate desiredTourDate
+    ) {
+        if (profiles == null || profiles.isEmpty() || bookedPaidGuideIds.isEmpty()) {
+            return profiles;
+        }
+        int before = profiles.size();
+        List<GuideProfile> out = profiles.stream()
+                .filter(p -> p.getId() == null || !bookedPaidGuideIds.contains(p.getId()))
+                .collect(Collectors.toCollection(ArrayList::new));
+        if (out.size() < before) {
+            log.info("[AI_POOL] bookedPaidExclusion profiles date={} removed={}", desiredTourDate, before - out.size());
+        }
+        return out;
+    }
+
+    private static List<GuideRecommendRequest.GuideCandidateDto> excludeBookedPaidGuides(
+            List<GuideRecommendRequest.GuideCandidateDto> candidates,
+            Set<Long> bookedPaidGuideIds,
+            LocalDate desiredTourDate
+    ) {
+        if (candidates == null) {
+            return List.of();
+        }
+        if (bookedPaidGuideIds.isEmpty()) {
+            return candidates;
+        }
+        int before = candidates.size();
+        List<GuideRecommendRequest.GuideCandidateDto> out = candidates.stream()
+                .filter(c -> c.getGuideId() == null || !bookedPaidGuideIds.contains(c.getGuideId()))
+                .collect(Collectors.toCollection(ArrayList::new));
+        if (out.size() < before) {
+            log.info("[AI_POOL] bookedPaidExclusion clientCandidates date={} removed={}", desiredTourDate, before - out.size());
+        }
+        return out;
+    }
+
     /**
      * 스코어·다양성 스냅샷 필드는 포함하지 않는다(후보 집합 차원만 반영).
      */
-    private static String buildPoolCacheKey(String region, LocalGuestAiProperties.CandidatePoolSettings pool) {
+    private static String buildPoolCacheKey(
+            String region,
+            LocalGuestAiProperties.CandidatePoolSettings pool,
+            LocalDate desiredTourDate
+    ) {
         String regionKey = region == null || region.isBlank() ? "_" : region.trim().toLowerCase(Locale.ROOT);
+        String dateKey = desiredTourDate == null ? "_" : desiredTourDate.toString();
         return AiRecommendationTuning.POLICY_VERSION
                 + "|" + pool.getMaxFetchSize()
                 + "|" + pool.getMaxPoolSize()
                 + "|" + pool.getColdStartReserveRatio()
                 + "|" + pool.getExcludedGuideIds()
-                + "|" + regionKey;
+                + "|" + regionKey
+                + "|" + dateKey;
     }
 
     private List<GuideProfile> loadProfilesTiered(String region, LocalGuestAiProperties.CandidatePoolSettings pool) {

--- a/backend/module-ai-integration/src/test/java/com/team6/integration/ai/DbBackedGuideCandidateProviderTest.java
+++ b/backend/module-ai-integration/src/test/java/com/team6/integration/ai/DbBackedGuideCandidateProviderTest.java
@@ -3,9 +3,11 @@ package com.team6.integration.ai;
 import com.team6.domain.guide.entity.GuideCareer;
 import com.team6.domain.guide.entity.GuideFeed;
 import com.team6.domain.guide.entity.GuideProfile;
+import com.team6.domain.guide.entity.enums.GuideScheduleStatus;
 import com.team6.domain.guide.repository.GuideCareerRepository;
 import com.team6.domain.guide.repository.GuideFeedRepository;
 import com.team6.domain.guide.repository.GuideProfileRepository;
+import com.team6.domain.guide.repository.GuideScheduleRepository;
 import com.team6.domain.matching.entity.enums.MatchRequestStatus;
 import com.team6.domain.matching.entity.enums.RefundStatus;
 import com.team6.domain.matching.repository.MatchRequestRepository;
@@ -56,6 +58,9 @@ class DbBackedGuideCandidateProviderTest {
     @Mock
     private ChatRoomRepository chatRoomRepository;
 
+    @Mock
+    private GuideScheduleRepository guideScheduleRepository;
+
     private DbBackedGuideCandidateProvider provider;
 
     @BeforeEach
@@ -69,6 +74,7 @@ class DbBackedGuideCandidateProviderTest {
                 matchRequestRepository,
                 refundRepository,
                 chatRoomRepository,
+                guideScheduleRepository,
                 new PromptParser(aiProps),
                 aiProps
         );
@@ -88,7 +94,7 @@ class DbBackedGuideCandidateProviderTest {
                         .build()
         );
         List<GuideRecommendRequest.GuideCandidateDto> out =
-                provider.getCandidates("제주 2박", 3, client);
+                provider.getCandidates("제주 2박", 3, client, null);
         assertThat(out).isSameAs(client);
         verify(guideProfileRepository, never()).findByIsApprovedTrueAndIsActiveTrue(any(Pageable.class));
         verify(guideFeedRepository, never()).findByGuideProfile_IdInAndIsDeletedFalse(any());
@@ -97,6 +103,38 @@ class DbBackedGuideCandidateProviderTest {
         verify(matchRequestRepository, never()).countAllGroupedByGuideId(any());
         verify(matchRequestRepository, never()).countByGuideIdAndStatusInGrouped(any(), any());
         verify(chatRoomRepository, never()).countRoomsGroupedByParticipantUserId(any());
+        verify(guideScheduleRepository, never()).findGuideProfileIdsBookedAndPaidOnDate(any(), any());
+    }
+
+    @Test
+    void excludesClientCandidateWhenBookedPaidOnDesiredDate() {
+        LocalDate tourDate = LocalDate.of(2026, 4, 28);
+        when(guideScheduleRepository.findGuideProfileIdsBookedAndPaidOnDate(tourDate, GuideScheduleStatus.BOOKED))
+                .thenReturn(List.of(9L));
+        List<GuideRecommendRequest.GuideCandidateDto> client = List.of(
+                GuideRecommendRequest.GuideCandidateDto.builder()
+                        .guideId(9L)
+                        .guideName("바쁜가이드")
+                        .region("제주")
+                        .guideStyle("로컬")
+                        .priceLevel("중간")
+                        .specialtyTags(List.of("맛집"))
+                        .languages(List.of("한국어"))
+                        .build(),
+                GuideRecommendRequest.GuideCandidateDto.builder()
+                        .guideId(10L)
+                        .guideName("여유가이드")
+                        .region("제주")
+                        .guideStyle("로컬")
+                        .priceLevel("중간")
+                        .specialtyTags(List.of("맛집"))
+                        .languages(List.of("한국어"))
+                        .build()
+        );
+        List<GuideRecommendRequest.GuideCandidateDto> out =
+                provider.getCandidates("제주 맛집", 3, client, tourDate);
+        assertThat(out).hasSize(1);
+        assertThat(out.get(0).getGuideId()).isEqualTo(10L);
     }
 
     @Test
@@ -156,7 +194,7 @@ class DbBackedGuideCandidateProviderTest {
                 .thenReturn(List.<Object[]>of(new Object[]{10L, 3L}));
 
         List<GuideRecommendRequest.GuideCandidateDto> out =
-                provider.getCandidates("제주에서 힐링하고 싶어요", 3, List.of());
+                provider.getCandidates("제주에서 힐링하고 싶어요", 3, List.of(), null);
 
         assertThat(out).hasSize(1);
         assertThat(out.get(0).getGuideId()).isEqualTo(1L);
@@ -169,6 +207,39 @@ class DbBackedGuideCandidateProviderTest {
         assertThat(out.get(0).getMatchRequestCount()).isEqualTo(4);
         assertThat(out.get(0).getProgressedMatchCount()).isEqualTo(2);
         assertThat(out.get(0).getChatStartCount()).isEqualTo(3);
+    }
+
+    @Test
+    void excludesBookedPaidGuideFromDbPoolWhenDesiredDateSet() {
+        LocalDate tourDate = LocalDate.of(2026, 4, 28);
+        when(guideScheduleRepository.findGuideProfileIdsBookedAndPaidOnDate(tourDate, GuideScheduleStatus.BOOKED))
+                .thenReturn(List.of(1L));
+
+        GuideProfile p = GuideProfile.builder()
+                .id(1L)
+                .memberId(10L)
+                .nickname("가이드A")
+                .region("제주")
+                .bio("감성 사진과 카페 중심 여행을 안내합니다.")
+                .language("한국어, English")
+                .pricePerHour(new BigDecimal("40000"))
+                .isApproved(true)
+                .isActive(true)
+                .build();
+        when(guideProfileRepository.findByIsApprovedTrueAndIsActiveTrueAndRegionEqualsIgnoreCase(
+                eq("제주"),
+                any(Pageable.class)
+        )).thenReturn(new PageImpl<>(List.of()));
+        when(guideProfileRepository.findByIsApprovedTrueAndIsActiveTrueAndRegionContainingIgnoreCase(
+                eq("제주"),
+                any(Pageable.class)
+        )).thenReturn(new PageImpl<>(List.of(p)));
+
+        List<GuideRecommendRequest.GuideCandidateDto> out =
+                provider.getCandidates("제주에서 힐링하고 싶어요", 3, List.of(), tourDate);
+
+        assertThat(out).isEmpty();
+        verify(guideScheduleRepository).findGuideProfileIdsBookedAndPaidOnDate(tourDate, GuideScheduleStatus.BOOKED);
     }
 
     @Test
@@ -210,7 +281,7 @@ class DbBackedGuideCandidateProviderTest {
                 .thenReturn(List.of());
 
         List<GuideRecommendRequest.GuideCandidateDto> out =
-                provider.getCandidates("제주 가고 싶어요", 3, null);
+                provider.getCandidates("제주 가고 싶어요", 3, null, null);
 
         assertThat(out).hasSize(1);
         assertThat(out.get(0).getGuideId()).isEqualTo(2L);
@@ -245,7 +316,7 @@ class DbBackedGuideCandidateProviderTest {
                 .thenReturn(List.of());
 
         List<GuideRecommendRequest.GuideCandidateDto> out =
-                provider.getCandidates("그냥 여행 가고 싶어요", 3, List.of());
+                provider.getCandidates("그냥 여행 가고 싶어요", 3, List.of(), null);
 
         assertThat(out).hasSize(1);
         assertThat(out.get(0).getGuideId()).isEqualTo(3L);

--- a/backend/module-ai/src/main/java/com/team6/module/ai/controller/AiController.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/controller/AiController.java
@@ -36,6 +36,7 @@ public class AiController {
     @Operation(
             summary = "프롬프트 기반 가이드 추천",
             description = "자연어 프롬프트와 가이드 후보 목록을 받아 상위 N명을 추천합니다. "
+                    + "선택 필드 desiredTourDate(yyyy-MM-dd)가 있으면 해당 날짜에 결제 완료(BOOKED+isPaid) 스케줄이 있는 가이드는 후보에서 제외합니다. "
                     + "응답의 policyVersion으로 룰 정책 버전을 구분할 수 있습니다."
     )
     @ApiResponse(
@@ -70,7 +71,8 @@ public class AiController {
                 guideCandidateProvider.getCandidates(
                         request.getPrompt(),
                         request.getTopN(),
-                        request.getGuideCandidates()
+                        request.getGuideCandidates(),
+                        request.getDesiredTourDate()
                 );
 
         GuideRecommendResponse body = promptRecommendationService.recommendByPrompt(

--- a/backend/module-ai/src/main/java/com/team6/module/ai/dto/request/PromptRecommendApiRequest.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/dto/request/PromptRecommendApiRequest.java
@@ -3,11 +3,14 @@ package com.team6.module.ai.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Schema(name = "PromptRecommendApiRequest", description = "프롬프트 기반 추천 API 요청")
 @Getter
+@Setter
 @NoArgsConstructor
 public class PromptRecommendApiRequest {
     @Schema(description = "자연어 여행 요청(지역·스타일·활동 등 파싱)", requiredMode = Schema.RequiredMode.REQUIRED, example = "제주 2박3일 바다 카페")
@@ -16,4 +19,11 @@ public class PromptRecommendApiRequest {
     private Integer topN;
     @Schema(description = "가이드 후보(비우면 서버가 DB 등에서 후보를 채움)")
     private List<GuideRecommendRequest.GuideCandidateDto> guideCandidates;
+
+    @Schema(
+            description = "희망 투어일(로컬 날짜, ISO-8601 yyyy-MM-dd). "
+                    + "지정 시 해당 날짜에 결제 완료(BOOKED + isPaid) 스케줄이 있는 가이드는 추천 후보에서 제외",
+            example = "2026-04-28"
+    )
+    private LocalDate desiredTourDate;
 }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationTuning.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationTuning.java
@@ -19,7 +19,7 @@ public final class AiRecommendationTuning {
     /**
      * 룰/스코어/Reason/응답 계약이 바뀔 때마다 올린다. 로그·API에서 동일 프롬프트 비교 시 정책 변경 여부를 구분하는 데 쓴다.
      */
-    public static final String POLICY_VERSION = "2026.04.19";
+    public static final String POLICY_VERSION = "2026.04.20";
 
     public static final int DEFAULT_TOP_N = 3;
 

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/GuideCandidateProvider.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/GuideCandidateProvider.java
@@ -2,6 +2,7 @@ package com.team6.module.ai.support;
 
 import com.team6.module.ai.dto.request.GuideRecommendRequest;
 
+import java.time.LocalDate;
 import java.util.List;
 
 /**
@@ -9,11 +10,15 @@ import java.util.List;
  * <p>
  * 클라이언트가 {@code candidates}를 비우면, 구현체는 {@code prompt}(및 선택적 {@code topN})를 이용해
  * 서버 측에서 후보를 채울 수 있다(예: 상위 애플리케이션 모듈의 DB 조회 구현).
+ * <p>
+ * {@code desiredTourDate}가 있으면 해당 로컬 날짜 기준으로 도메인 정책(예: 결제 완료 스케줄)에 따라
+ * 후보를 제외할 수 있다(구현체가 DB를 쓰는 경우).
  */
 public interface GuideCandidateProvider {
     List<GuideRecommendRequest.GuideCandidateDto> getCandidates(
             String prompt,
             Integer topN,
-            List<GuideRecommendRequest.GuideCandidateDto> candidates
+            List<GuideRecommendRequest.GuideCandidateDto> candidates,
+            LocalDate desiredTourDate
     );
 }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/RequestGuideCandidateProvider.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/RequestGuideCandidateProvider.java
@@ -3,6 +3,7 @@ package com.team6.module.ai.support;
 import com.team6.module.ai.dto.request.GuideRecommendRequest;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Component
@@ -12,8 +13,10 @@ public class RequestGuideCandidateProvider implements com.team6.module.ai.suppor
     public List<GuideRecommendRequest.GuideCandidateDto> getCandidates(
             String prompt,
             Integer topN,
-            List<GuideRecommendRequest.GuideCandidateDto> candidates
+            List<GuideRecommendRequest.GuideCandidateDto> candidates,
+            LocalDate desiredTourDate
     ) {
+        // DB 없음: 결제 완료 일정 제외는 integration 구현(DbBacked)에서 처리한다.
         return candidates == null ? List.of() : candidates;
     }
 }

--- a/backend/module-domain/src/main/java/com/team6/domain/guide/repository/GuideScheduleRepository.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/repository/GuideScheduleRepository.java
@@ -32,4 +32,16 @@ public interface GuideScheduleRepository extends JpaRepository<GuideSchedule, Lo
                                       @Param("date") LocalDate date,
                                       @Param("startTime") LocalTime startTime,
                                       @Param("endTime") LocalTime endTime);
+
+    /**
+     * 해당 날짜에 결제까지 완료된(BOOKED + isPaid) 스케줄이 있는 가이드 프로필 ID.
+     * AI 추천 등에서 동일 날짜 후보를 제외할 때 사용한다.
+     */
+    @Query("SELECT DISTINCT s.guideProfile.id FROM GuideSchedule s "
+            + "WHERE s.availableDate = :date AND s.status = :status AND s.isPaid = true "
+            + "AND s.guideProfile.id IS NOT NULL")
+    List<Long> findGuideProfileIdsBookedAndPaidOnDate(
+            @Param("date") LocalDate date,
+            @Param("status") GuideScheduleStatus status
+    );
 }


### PR DESCRIPTION
## Summary
- `/ai/recommend` 요청에 선택 필드 `desiredTourDate`(ISO `yyyy-MM-dd`)를 추가했다.
- 해당 로컬 날짜에 `guide_schedules`에서 **BOOKED + isPaid=true** 인 스케줄이 있는 가이드 프로필은 AI 추천 후보(DB 로드·클라이언트 전달 목록 모두)에서 제외한다.
- 후보 풀 캐시 키에 `desiredTourDate`를 포함해 날짜별 캐시가 섞이지 않게 했다.
- `AiRecommendationTuning.POLICY_VERSION`을 `2026.04.20`으로 상향했다.

## Notes
- 제외 기준은 엔티티 주석과 맞춰 **결제 완료**를 `BOOKED`이면서 `isPaid=true`로 해석했다.
- 로컬 DB에 스케줄이 반영되는 배포(가이드 스케줄 API/동기화)가 있어야 필터가 동작한다.

## Test
- `./gradlew :module-domain:compileJava :module-ai:compileJava :module-ai-integration:compileJava :api-server:compileJava`
- `./gradlew :module-ai:test :module-ai-integration:test`

Closes #191

Made with [Cursor](https://cursor.com)