### PR TITLE
Feat/be#168:실시간 채팅방 목록 업데이트

### DIFF
--- a/backend/module-chat/src/main/java/com/team6/module/chat/config/RedisConfig.java
+++ b/backend/module-chat/src/main/java/com/team6/module/chat/config/RedisConfig.java
@@ -1,0 +1,36 @@
+package com.team6.module.chat.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(connectionFactory);
+
+        // 1. Key 직렬화: String으로 저장
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+
+        // 2. Value 직렬화: JSON으로 저장
+        // ObjectMapper 설정을 통해 LocalDatetime 등 자바 8 시간 타입도 처리 가능하게 함
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
+        redisTemplate.setValueSerializer(serializer);
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(serializer);
+
+        return redisTemplate;
+    }
+}

--- a/backend/module-chat/src/main/java/com/team6/module/chat/config/RedisNotificationConfig.java
+++ b/backend/module-chat/src/main/java/com/team6/module/chat/config/RedisNotificationConfig.java
@@ -1,0 +1,27 @@
+package com.team6.module.chat.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
+
+@Configuration
+public class RedisNotificationConfig {
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(
+            RedisConnectionFactory factory, MessageListenerAdapter adapter) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(factory);
+        container.addMessageListener(adapter, new ChannelTopic("chat-notifications"));
+        return container;
+    }
+
+    @Bean
+    public MessageListenerAdapter listenerAdapter(RedisSubscriber subscriber) {
+        return new MessageListenerAdapter(subscriber, "onMessage");
+    }
+}
+

--- a/backend/module-chat/src/main/java/com/team6/module/chat/config/RedisSubscriber.java
+++ b/backend/module-chat/src/main/java/com/team6/module/chat/config/RedisSubscriber.java
@@ -1,0 +1,31 @@
+package com.team6.module.chat.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team6.module.chat.dto.notification.ChatNotificationResponse;
+import com.team6.module.chat.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisSubscriber implements MessageListener {
+    private final ObjectMapper objectMapper;
+    private final NotificationService notificationService;
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        log.info("[Redis] Message received from channel: {}", new String(message.getChannel()));
+        try {
+            ChatNotificationResponse res = objectMapper.readValue(message.getBody(), ChatNotificationResponse.class);
+            notificationService.processNotification(res);
+        } catch (IOException e) {
+            log.error("Redis 메시지 파싱 에러", e);
+        }
+    }
+}

--- a/backend/module-chat/src/main/java/com/team6/module/chat/controller/NotificationController.java
+++ b/backend/module-chat/src/main/java/com/team6/module/chat/controller/NotificationController.java
@@ -1,0 +1,38 @@
+package com.team6.module.chat.controller;
+
+import com.team6.domain.auth.provider.JwtTokenProvider;
+import com.team6.module.chat.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Slf4j
+@RestController
+@RequestMapping("/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    /**
+     * SSE 구독 엔드포인트
+     * @param token 프론트엔드 EventSource에서 보낸 쿼리 파라미터 토큰
+     */
+    @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribe(@RequestParam("token") String token) {
+
+        jwtTokenProvider.validToken(token);
+
+        String userEmail = jwtTokenProvider.getEmail(token);
+
+        log.info("[SSE Subscribe] User Email: {}", userEmail);
+
+        return notificationService.subscribe(userEmail);
+    }
+}

--- a/backend/module-chat/src/main/java/com/team6/module/chat/dto/notification/ChatNotificationResponse.java
+++ b/backend/module-chat/src/main/java/com/team6/module/chat/dto/notification/ChatNotificationResponse.java
@@ -1,0 +1,17 @@
+package com.team6.module.chat.dto.notification;
+
+import lombok.Builder;
+
+@Builder
+public record ChatNotificationResponse(
+        String type,          // CONNECT, NEW_ROOM, NEW_MESSAGE
+        String roomId,        // 이벤트 발생 방 ID
+        String senderEmail,   // 메시지 발신자 (본인 제외용)
+        String receiverEmail, // 특정 수신자 (초대 시 사용)
+        Object data           // 추가 데이터 (ChatRoomResponse 등)
+) {
+    // 공통 정적 팩토리 메서드
+    public static ChatNotificationResponse of(String type, String roomId, String senderEmail, String receiverEmail, Object data) {
+        return new ChatNotificationResponse(type, roomId, senderEmail, receiverEmail, data);
+    }
+}

--- a/backend/module-chat/src/main/java/com/team6/module/chat/repository/mysql/ChatRoomRepository.java
+++ b/backend/module-chat/src/main/java/com/team6/module/chat/repository/mysql/ChatRoomRepository.java
@@ -23,6 +23,9 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
             "WHERE p.userId IN :userIds " +
             "GROUP BY p.userId")
     List<Object[]> countRoomsGroupedByParticipantUserId(@Param("userIds") List<Long> userIds);
+
+    @Query("select distinct cr from ChatRoom cr join fetch cr.participants where cr.roomId = :roomId")
+    Optional<ChatRoom> findByRoomIdWithParticipants(@Param("roomId") String roomId);
 }
 
 

--- a/backend/module-chat/src/main/java/com/team6/module/chat/service/ChatMessageService.java
+++ b/backend/module-chat/src/main/java/com/team6/module/chat/service/ChatMessageService.java
@@ -3,6 +3,7 @@ package com.team6.module.chat.service;
 import com.mongodb.client.result.UpdateResult;
 import com.team6.module.chat.dto.chatMessage.ChatMessageRequest;
 import com.team6.module.chat.dto.chatMessage.ChatMessageResponse;
+import com.team6.module.chat.dto.notification.ChatNotificationResponse;
 import com.team6.module.chat.entity.mongodb.ChatMessage;
 import com.team6.module.chat.entity.mongodb.MessageType;
 import com.team6.module.chat.entity.mysql.ChatParticipant;
@@ -37,6 +38,7 @@ public class ChatMessageService {
     private final RedisTemplate<String, String> redisTemplate;
     private final MongoTemplate mongoTemplate;
     private final ObjectProvider<SimpMessagingTemplate> messagingTemplateProvider;
+    private final NotificationService notificationService;
 
     /**
      * 메시지 전송 및 저장
@@ -69,6 +71,10 @@ public class ChatMessageService {
         if (messagingTemplate != null) {
             messagingTemplate.convertAndSend("/sub/chat/room/" + request.roomId(), ChatMessageResponse.from(chatMessage));
         }
+
+        notificationService.broadcast(ChatNotificationResponse.of(
+                "NEW_MESSAGE", request.roomId(), request.senderEmail(), null, null
+        ));
     }
 
     /**

--- a/backend/module-chat/src/main/java/com/team6/module/chat/service/ChatRoomService.java
+++ b/backend/module-chat/src/main/java/com/team6/module/chat/service/ChatRoomService.java
@@ -3,6 +3,7 @@ package com.team6.module.chat.service;
 import com.team6.module.chat.dto.chatRoom.ChatRoomCreateRequest;
 import com.team6.module.chat.dto.chatRoom.ChatRoomResponse;
 import com.team6.module.chat.dto.chatRoom.ChatRoomsResponse;
+import com.team6.module.chat.dto.notification.ChatNotificationResponse;
 import com.team6.module.chat.entity.mysql.ChatParticipant;
 import com.team6.module.chat.entity.mysql.ChatRoom;
 import com.team6.module.chat.repository.mongodb.ChatMessageRepository;
@@ -21,6 +22,7 @@ public class ChatRoomService {
 
     private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageRepository chatMessageRepository;
+    private final NotificationService notificationService;
 
     //채팅방 생성
     @Transactional
@@ -43,8 +45,15 @@ public class ChatRoomService {
 
         // 4. 저장 (CascadeType.ALL 설정 덕분에 참여자도 함께 저장됨)
         ChatRoom savedRoom = chatRoomRepository.save(chatRoom);
+        ChatRoomResponse response = ChatRoomResponse.from(savedRoom);
 
-        return ChatRoomResponse.from(savedRoom);
+        request.participantEmails().forEach(email -> {
+            notificationService.broadcast(ChatNotificationResponse.of(
+                    "NEW_ROOM", savedRoom.getRoomId(), ownerEmail, email, response
+            ));
+        });
+
+        return response;
     }
 
     //참여 중인 채팅방 목록 조회

--- a/backend/module-chat/src/main/java/com/team6/module/chat/service/NotificationService.java
+++ b/backend/module-chat/src/main/java/com/team6/module/chat/service/NotificationService.java
@@ -1,0 +1,73 @@
+package com.team6.module.chat.service;
+
+import com.team6.module.chat.dto.notification.ChatNotificationResponse;
+import com.team6.module.chat.repository.mysql.ChatRoomRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ChatRoomRepository chatRoomRepository;
+    private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    // [1] SSE 구독 시작
+    public SseEmitter subscribe(String userEmail) {
+        SseEmitter emitter = new SseEmitter(60 * 1000L * 60); // 1시간
+        emitters.put(userEmail, emitter);
+
+        emitter.onCompletion(() -> emitters.remove(userEmail));
+        emitter.onTimeout(() -> emitters.remove(userEmail));
+
+        // 연결 직후 더미 데이터 전송 (503 에러 방지)
+        sendToLocalEmitter(userEmail, ChatNotificationResponse.of("CONNECT", null, null, userEmail, null));
+        return emitter;
+    }
+
+    // [2] Redis 채널로 알림 발행 (서버 간 통신 시작점)
+    public void broadcast(ChatNotificationResponse response) {
+
+        redisTemplate.convertAndSend("chat-notifications", response);
+    }
+
+    // [3] Redis 메시지 수신 후 내 서버에 연결된 유저에게 전송 (최적화 로직)
+    public void processNotification(ChatNotificationResponse res) {
+        if ("NEW_MESSAGE".equals(res.type())) {
+            // findByRoomId 대신 'WithParticipants'가 붙은 메서드 호출!
+            chatRoomRepository.findByRoomIdWithParticipants(res.roomId()).ifPresent(room -> {
+                room.getParticipants().forEach(participant -> {
+                    String email = participant.getUserEmail();
+                    if (!email.equals(res.senderEmail()) && emitters.containsKey(email)) {
+                        sendToLocalEmitter(email, res);
+                    }
+                });
+            });
+        } else {
+            // 초대(NEW_ROOM) 등 특정 수신자가 명시된 경우
+            if (res.receiverEmail() != null && emitters.containsKey(res.receiverEmail())) {
+                sendToLocalEmitter(res.receiverEmail(), res);
+            }
+        }
+    }
+
+    // [4] 실제 SSE 전송
+    private void sendToLocalEmitter(String userEmail, Object data) {
+        SseEmitter emitter = emitters.get(userEmail);
+        if (emitter != null) {
+            try {
+                emitter.send(SseEmitter.event().name("chat-event").data(data));
+            } catch (IOException e) {
+                emitters.remove(userEmail);
+            }
+        }
+    }
+}

--- a/backend/module-domain/src/main/java/com/team6/domain/auth/config/SecurityConfig.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/auth/config/SecurityConfig.java
@@ -28,7 +28,11 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 안씀
                 .authorizeHttpRequests(auth -> auth
+
+                        //SSE, WebSocket  접근 허용
+                        .requestMatchers("/notifications/subscribe").permitAll()
                         .requestMatchers("/ws-stomp/**").permitAll()
+
                         // 1. 누구나 접근 가능한 경로 (화이트리스트)
                         .requestMatchers("/auth/**", "/members/join").permitAll()
                         .requestMatchers("/guides/**").permitAll()


### PR DESCRIPTION
# 🔗 이슈 번호
- Closes #168 

---

## 💡 주요 변경 사항
분산 환경을 고려한 실시간 알림 아키텍처 구축
SSE(Server-Sent Events) 도입: 채팅방 외부(리스트 페이지)에서도 실시간으로 방 초대 및 메시지 알림을 수신할 수 있도록 구현했습니다.

Redis Pub/Sub 연동: 블루-그린 배포 및 다중 서버 환경에서 특정 서버에 접속 중인 유저에게 알림이 유실되지 않도록 Redis 전령사(Message Broker)를 통해 서버 간 이벤트를 공유합니다.

## ⚠️ 주의 사항 / 질문
리뷰어가 중점적으로 봐주었으면 하는 부분이나 고민되는 지점을 적어주세요.

---

## ✅ 체크리스트
- [ ] 빌드가 정상적으로 되는가?
- [ ] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [ ] .gitignore에 설정 파일이 잘 포함되었는가? (application-local.yml 등)