### PR TITLE
Feat/be#200 특별 제시(일정 충돌 Top1, 기간 지원)

### DIFF
--- a/backend/module-ai-integration/src/main/java/com/team6/integration/ai/DbBackedGuideCandidateProvider.java
+++ b/backend/module-ai-integration/src/main/java/com/team6/integration/ai/DbBackedGuideCandidateProvider.java
@@ -17,6 +17,7 @@ import com.team6.module.ai.config.LocalGuestAiProperties;
 import com.team6.module.ai.dto.request.GuideRecommendRequest;
 import com.team6.module.ai.parser.PromptParser;
 import com.team6.module.ai.support.AiRecommendationTuning;
+import com.team6.module.ai.support.GuideCandidateBundle;
 import com.team6.module.ai.support.GuideCandidateProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -49,12 +50,12 @@ import java.util.stream.Collectors;
  * 정책버전 키 캐시({@link LocalGuestAiProperties#getCandidatePool()})를 적용한다.
  * <p>
  * <b>캐시 키</b>: {@link AiRecommendationTuning#POLICY_VERSION}을 접두로 하고,
- * {@code maxFetchSize}·{@code maxPoolSize}·{@code coldStartReserveRatio}·{@code excludedGuideIds}·지역 문자열·
- * 선택적 {@code desiredTourDate}(투어 희망일)를 이어 붙인다. 스코어/다양성 YAML 내용 전체는 키에 넣지 않으므로, 랭킹 의미가 바뀌면
+ * {@code maxFetchSize}·{@code maxPoolSize}·{@code coldStartReserveRatio}·{@code excludedGuideIds}·지역 문자열을
+ * 이어 붙인다. 스코어/다양성 YAML 내용 전체는 키에 넣지 않으므로, 랭킹 의미가 바뀌면
  * {@code POLICY_VERSION}을 올려 캐시를 자연스럽게 무효화하고, API {@code policyVersion}·메트릭 태그와 맞춘다.
  * 후보 풀 차원만 바꿀 때는 위 후보 풀 필드가 키에 들어가므로 별도 버전 상향 없이도 다른 엔트리가 된다.
  * <p>
- * <b>결제 완료 일정 제외</b>: {@code desiredTourDate}가 지정되면, 해당 로컬 날짜에
+ * <b>결제 완료 일정 제외</b>: 희망 기간({@code desiredTourDateFrom~desiredTourDateTo})가 지정되면, 기간 중 하루라도
  * {@link GuideScheduleStatus#BOOKED}이면서 {@code isPaid=true}인 스케줄이 있는 가이드는 후보에서 제외한다.
  */
 @Slf4j
@@ -86,15 +87,19 @@ public class DbBackedGuideCandidateProvider implements GuideCandidateProvider {
     private final ConcurrentHashMap<String, PoolCacheEntry> poolCache = new ConcurrentHashMap<>();
 
     @Override
-    public List<GuideRecommendRequest.GuideCandidateDto> getCandidates(
+    public GuideCandidateBundle getCandidates(
             String prompt,
             Integer topN,
             List<GuideRecommendRequest.GuideCandidateDto> candidates,
-            LocalDate desiredTourDate
+            LocalDate desiredTourDateFrom,
+            LocalDate desiredTourDateTo
     ) {
-        Set<Long> bookedPaidGuideIds = resolveBookedPaidGuideIds(desiredTourDate);
         if (candidates != null && !candidates.isEmpty()) {
-            return excludeBookedPaidGuides(candidates, bookedPaidGuideIds, desiredTourDate);
+            List<GuideRecommendRequest.GuideCandidateDto> unfiltered = candidates;
+            Set<Long> bookedPaidGuideIds = resolveBookedPaidGuideIds(desiredTourDateFrom, desiredTourDateTo);
+            List<GuideRecommendRequest.GuideCandidateDto> filtered =
+                    excludeBookedPaidGuides(unfiltered, bookedPaidGuideIds, desiredTourDateFrom, desiredTourDateTo);
+            return new GuideCandidateBundle(filtered, unfiltered);
         }
         String safePrompt = prompt == null ? "" : prompt;
         int resolvedTopN = (topN == null || topN <= 0) ? AiRecommendationTuning.DEFAULT_TOP_N : topN;
@@ -103,39 +108,48 @@ public class DbBackedGuideCandidateProvider implements GuideCandidateProvider {
 
         LocalGuestAiProperties.CandidatePoolSettings pool = aiProperties.getCandidatePool();
         int ttlSec = pool.getPoolCacheTtlSeconds();
-        String cacheKey = buildPoolCacheKey(region, pool, desiredTourDate);
+        String cacheKey = buildPoolCacheKey(region, pool);
         if (ttlSec > 0) {
             PoolCacheEntry hit = poolCache.get(cacheKey);
             if (hit != null && !hit.isExpired()) {
                 log.debug("[AI_POOL] cache hit key={}", cacheKey);
-                return List.copyOf(hit.candidates());
+                List<GuideRecommendRequest.GuideCandidateDto> unfiltered = List.copyOf(hit.candidates());
+                Set<Long> bookedPaidGuideIds = resolveBookedPaidGuideIds(desiredTourDateFrom, desiredTourDateTo);
+                List<GuideRecommendRequest.GuideCandidateDto> filtered =
+                        excludeBookedPaidGuides(unfiltered, bookedPaidGuideIds, desiredTourDateFrom, desiredTourDateTo);
+                return new GuideCandidateBundle(filtered, unfiltered);
             }
         }
 
         List<GuideProfile> profiles = loadProfilesTiered(region, pool);
         profiles = filterExcludedProfiles(profiles, pool);
-        profiles = excludeBookedPaidProfiles(profiles, bookedPaidGuideIds, desiredTourDate);
 
         List<GuideRecommendRequest.GuideCandidateDto> mapped = mapProfilesToCandidates(profiles);
         List<GuideRecommendRequest.GuideCandidateDto> withSignals = mergeBehaviorSignals(mapped, profiles);
-        List<GuideRecommendRequest.GuideCandidateDto> sampled = applyPoolSampling(withSignals, pool);
+        List<GuideRecommendRequest.GuideCandidateDto> sampledUnfiltered = applyPoolSampling(withSignals, pool);
+        Set<Long> bookedPaidGuideIds = resolveBookedPaidGuideIds(desiredTourDateFrom, desiredTourDateTo);
+        List<GuideRecommendRequest.GuideCandidateDto> sampledFiltered =
+                excludeBookedPaidGuides(sampledUnfiltered, bookedPaidGuideIds, desiredTourDateFrom, desiredTourDateTo);
 
         if (ttlSec > 0) {
             long ttlNanos = ttlSec * 1_000_000_000L;
             long expiresAt = System.nanoTime() + ttlNanos;
-            poolCache.put(cacheKey, new PoolCacheEntry(sampled, expiresAt));
-            log.debug("[AI_POOL] cache put key={} size={}", cacheKey, sampled.size());
+            poolCache.put(cacheKey, new PoolCacheEntry(sampledUnfiltered, expiresAt));
+            log.debug("[AI_POOL] cache put key={} size={}", cacheKey, sampledUnfiltered.size());
         }
 
-        return sampled;
+        return new GuideCandidateBundle(sampledFiltered, sampledUnfiltered);
     }
 
-    private Set<Long> resolveBookedPaidGuideIds(LocalDate desiredTourDate) {
-        if (desiredTourDate == null) {
+    private Set<Long> resolveBookedPaidGuideIds(LocalDate desiredFrom, LocalDate desiredTo) {
+        if (desiredFrom == null) {
             return Set.of();
         }
-        List<Long> ids = guideScheduleRepository.findGuideProfileIdsBookedAndPaidOnDate(
-                desiredTourDate,
+        LocalDate to = desiredTo == null ? desiredFrom : desiredTo;
+        LocalDate from = desiredFrom.isAfter(to) ? to : desiredFrom;
+        List<Long> ids = guideScheduleRepository.findGuideProfileIdsBookedAndPaidBetween(
+                from,
+                to,
                 GuideScheduleStatus.BOOKED
         );
         if (ids == null || ids.isEmpty()) {
@@ -144,28 +158,11 @@ public class DbBackedGuideCandidateProvider implements GuideCandidateProvider {
         return ids.stream().filter(Objects::nonNull).collect(Collectors.toCollection(HashSet::new));
     }
 
-    private static List<GuideProfile> excludeBookedPaidProfiles(
-            List<GuideProfile> profiles,
-            Set<Long> bookedPaidGuideIds,
-            LocalDate desiredTourDate
-    ) {
-        if (profiles == null || profiles.isEmpty() || bookedPaidGuideIds.isEmpty()) {
-            return profiles;
-        }
-        int before = profiles.size();
-        List<GuideProfile> out = profiles.stream()
-                .filter(p -> p.getId() == null || !bookedPaidGuideIds.contains(p.getId()))
-                .collect(Collectors.toCollection(ArrayList::new));
-        if (out.size() < before) {
-            log.info("[AI_POOL] bookedPaidExclusion profiles date={} removed={}", desiredTourDate, before - out.size());
-        }
-        return out;
-    }
-
     private static List<GuideRecommendRequest.GuideCandidateDto> excludeBookedPaidGuides(
             List<GuideRecommendRequest.GuideCandidateDto> candidates,
             Set<Long> bookedPaidGuideIds,
-            LocalDate desiredTourDate
+            LocalDate desiredFrom,
+            LocalDate desiredTo
     ) {
         if (candidates == null) {
             return List.of();
@@ -178,7 +175,8 @@ public class DbBackedGuideCandidateProvider implements GuideCandidateProvider {
                 .filter(c -> c.getGuideId() == null || !bookedPaidGuideIds.contains(c.getGuideId()))
                 .collect(Collectors.toCollection(ArrayList::new));
         if (out.size() < before) {
-            log.info("[AI_POOL] bookedPaidExclusion clientCandidates date={} removed={}", desiredTourDate, before - out.size());
+            log.info("[AI_POOL] bookedPaidExclusion candidates from={} to={} removed={}",
+                    desiredFrom, desiredTo, before - out.size());
         }
         return out;
     }
@@ -188,18 +186,15 @@ public class DbBackedGuideCandidateProvider implements GuideCandidateProvider {
      */
     private static String buildPoolCacheKey(
             String region,
-            LocalGuestAiProperties.CandidatePoolSettings pool,
-            LocalDate desiredTourDate
+            LocalGuestAiProperties.CandidatePoolSettings pool
     ) {
         String regionKey = region == null || region.isBlank() ? "_" : region.trim().toLowerCase(Locale.ROOT);
-        String dateKey = desiredTourDate == null ? "_" : desiredTourDate.toString();
         return AiRecommendationTuning.POLICY_VERSION
                 + "|" + pool.getMaxFetchSize()
                 + "|" + pool.getMaxPoolSize()
                 + "|" + pool.getColdStartReserveRatio()
                 + "|" + pool.getExcludedGuideIds()
-                + "|" + regionKey
-                + "|" + dateKey;
+                + "|" + regionKey;
     }
 
     private List<GuideProfile> loadProfilesTiered(String region, LocalGuestAiProperties.CandidatePoolSettings pool) {

--- a/backend/module-ai-integration/src/test/java/com/team6/integration/ai/DbBackedGuideCandidateProviderTest.java
+++ b/backend/module-ai-integration/src/test/java/com/team6/integration/ai/DbBackedGuideCandidateProviderTest.java
@@ -16,6 +16,7 @@ import com.team6.module.chat.repository.mysql.ChatRoomRepository;
 import com.team6.module.ai.config.LocalGuestAiProperties;
 import com.team6.module.ai.dto.request.GuideRecommendRequest;
 import com.team6.module.ai.parser.PromptParser;
+import com.team6.module.ai.support.GuideCandidateBundle;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -93,9 +94,10 @@ class DbBackedGuideCandidateProviderTest {
                         .languages(List.of("한국어"))
                         .build()
         );
-        List<GuideRecommendRequest.GuideCandidateDto> out =
-                provider.getCandidates("제주 2박", 3, client, null);
-        assertThat(out).isSameAs(client);
+        GuideCandidateBundle out =
+                provider.getCandidates("제주 2박", 3, client, null, null);
+        assertThat(out.candidates()).isSameAs(client);
+        assertThat(out.unfilteredCandidates()).isSameAs(client);
         verify(guideProfileRepository, never()).findByIsApprovedTrueAndIsActiveTrue(any(Pageable.class));
         verify(guideFeedRepository, never()).findByGuideProfile_IdInAndIsDeletedFalse(any());
         verify(guideCareerRepository, never()).findByGuideProfile_IdIn(any());
@@ -103,13 +105,13 @@ class DbBackedGuideCandidateProviderTest {
         verify(matchRequestRepository, never()).countAllGroupedByGuideId(any());
         verify(matchRequestRepository, never()).countByGuideIdAndStatusInGrouped(any(), any());
         verify(chatRoomRepository, never()).countRoomsGroupedByParticipantUserId(any());
-        verify(guideScheduleRepository, never()).findGuideProfileIdsBookedAndPaidOnDate(any(), any());
+        verify(guideScheduleRepository, never()).findGuideProfileIdsBookedAndPaidBetween(any(), any(), any());
     }
 
     @Test
     void excludesClientCandidateWhenBookedPaidOnDesiredDate() {
         LocalDate tourDate = LocalDate.of(2026, 4, 28);
-        when(guideScheduleRepository.findGuideProfileIdsBookedAndPaidOnDate(tourDate, GuideScheduleStatus.BOOKED))
+        when(guideScheduleRepository.findGuideProfileIdsBookedAndPaidBetween(tourDate, tourDate, GuideScheduleStatus.BOOKED))
                 .thenReturn(List.of(9L));
         List<GuideRecommendRequest.GuideCandidateDto> client = List.of(
                 GuideRecommendRequest.GuideCandidateDto.builder()
@@ -131,10 +133,11 @@ class DbBackedGuideCandidateProviderTest {
                         .languages(List.of("한국어"))
                         .build()
         );
-        List<GuideRecommendRequest.GuideCandidateDto> out =
-                provider.getCandidates("제주 맛집", 3, client, tourDate);
-        assertThat(out).hasSize(1);
-        assertThat(out.get(0).getGuideId()).isEqualTo(10L);
+        GuideCandidateBundle out =
+                provider.getCandidates("제주 맛집", 3, client, tourDate, tourDate);
+        assertThat(out.unfilteredCandidates()).hasSize(2);
+        assertThat(out.candidates()).hasSize(1);
+        assertThat(out.candidates().get(0).getGuideId()).isEqualTo(10L);
     }
 
     @Test
@@ -193,26 +196,27 @@ class DbBackedGuideCandidateProviderTest {
         when(chatRoomRepository.countRoomsGroupedByParticipantUserId(List.of(10L)))
                 .thenReturn(List.<Object[]>of(new Object[]{10L, 3L}));
 
-        List<GuideRecommendRequest.GuideCandidateDto> out =
-                provider.getCandidates("제주에서 힐링하고 싶어요", 3, List.of(), null);
+        GuideCandidateBundle out =
+                provider.getCandidates("제주에서 힐링하고 싶어요", 3, List.of(), null, null);
 
-        assertThat(out).hasSize(1);
-        assertThat(out.get(0).getGuideId()).isEqualTo(1L);
-        assertThat(out.get(0).getRegion()).isEqualTo("제주");
-        assertThat(out.get(0).getLanguages()).containsExactly("한국어", "English");
-        assertThat(out.get(0).getPriceLevel()).isEqualTo("낮음");
-        assertThat(out.get(0).getGuideStyle()).isEqualTo("감성");
-        assertThat(out.get(0).getSpecialtyTags()).contains("카페", "바다", "사진", "시장", "야경", "맛집");
-        assertThat(out.get(0).getApprovedRefundCount()).isZero();
-        assertThat(out.get(0).getMatchRequestCount()).isEqualTo(4);
-        assertThat(out.get(0).getProgressedMatchCount()).isEqualTo(2);
-        assertThat(out.get(0).getChatStartCount()).isEqualTo(3);
+        assertThat(out.candidates()).hasSize(1);
+        assertThat(out.unfilteredCandidates()).hasSize(1);
+        assertThat(out.candidates().get(0).getGuideId()).isEqualTo(1L);
+        assertThat(out.candidates().get(0).getRegion()).isEqualTo("제주");
+        assertThat(out.candidates().get(0).getLanguages()).containsExactly("한국어", "English");
+        assertThat(out.candidates().get(0).getPriceLevel()).isEqualTo("낮음");
+        assertThat(out.candidates().get(0).getGuideStyle()).isEqualTo("감성");
+        assertThat(out.candidates().get(0).getSpecialtyTags()).contains("카페", "바다", "사진", "시장", "야경", "맛집");
+        assertThat(out.candidates().get(0).getApprovedRefundCount()).isZero();
+        assertThat(out.candidates().get(0).getMatchRequestCount()).isEqualTo(4);
+        assertThat(out.candidates().get(0).getProgressedMatchCount()).isEqualTo(2);
+        assertThat(out.candidates().get(0).getChatStartCount()).isEqualTo(3);
     }
 
     @Test
     void excludesBookedPaidGuideFromDbPoolWhenDesiredDateSet() {
         LocalDate tourDate = LocalDate.of(2026, 4, 28);
-        when(guideScheduleRepository.findGuideProfileIdsBookedAndPaidOnDate(tourDate, GuideScheduleStatus.BOOKED))
+        when(guideScheduleRepository.findGuideProfileIdsBookedAndPaidBetween(tourDate, tourDate, GuideScheduleStatus.BOOKED))
                 .thenReturn(List.of(1L));
 
         GuideProfile p = GuideProfile.builder()
@@ -235,11 +239,12 @@ class DbBackedGuideCandidateProviderTest {
                 any(Pageable.class)
         )).thenReturn(new PageImpl<>(List.of(p)));
 
-        List<GuideRecommendRequest.GuideCandidateDto> out =
-                provider.getCandidates("제주에서 힐링하고 싶어요", 3, List.of(), tourDate);
+        GuideCandidateBundle out =
+                provider.getCandidates("제주에서 힐링하고 싶어요", 3, List.of(), tourDate, tourDate);
 
-        assertThat(out).isEmpty();
-        verify(guideScheduleRepository).findGuideProfileIdsBookedAndPaidOnDate(tourDate, GuideScheduleStatus.BOOKED);
+        assertThat(out.unfilteredCandidates()).isNotNull();
+        assertThat(out.candidates()).isEmpty();
+        verify(guideScheduleRepository).findGuideProfileIdsBookedAndPaidBetween(tourDate, tourDate, GuideScheduleStatus.BOOKED);
     }
 
     @Test
@@ -280,11 +285,11 @@ class DbBackedGuideCandidateProviderTest {
         when(chatRoomRepository.countRoomsGroupedByParticipantUserId(List.of(11L)))
                 .thenReturn(List.of());
 
-        List<GuideRecommendRequest.GuideCandidateDto> out =
-                provider.getCandidates("제주 가고 싶어요", 3, null, null);
+        GuideCandidateBundle out =
+                provider.getCandidates("제주 가고 싶어요", 3, null, null, null);
 
-        assertThat(out).hasSize(1);
-        assertThat(out.get(0).getGuideId()).isEqualTo(2L);
+        assertThat(out.candidates()).hasSize(1);
+        assertThat(out.candidates().get(0).getGuideId()).isEqualTo(2L);
         verify(guideProfileRepository).findByIsApprovedTrueAndIsActiveTrue(any(Pageable.class));
     }
 
@@ -315,11 +320,11 @@ class DbBackedGuideCandidateProviderTest {
         when(chatRoomRepository.countRoomsGroupedByParticipantUserId(List.of(12L)))
                 .thenReturn(List.of());
 
-        List<GuideRecommendRequest.GuideCandidateDto> out =
-                provider.getCandidates("그냥 여행 가고 싶어요", 3, List.of(), null);
+        GuideCandidateBundle out =
+                provider.getCandidates("그냥 여행 가고 싶어요", 3, List.of(), null, null);
 
-        assertThat(out).hasSize(1);
-        assertThat(out.get(0).getGuideId()).isEqualTo(3L);
+        assertThat(out.candidates()).hasSize(1);
+        assertThat(out.candidates().get(0).getGuideId()).isEqualTo(3L);
         verify(guideProfileRepository, never()).findByIsApprovedTrueAndIsActiveTrueAndRegionContainingIgnoreCase(
                 any(),
                 any(Pageable.class)

--- a/backend/module-ai/src/main/java/com/team6/module/ai/controller/AiController.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/controller/AiController.java
@@ -7,6 +7,7 @@ import com.team6.module.ai.dto.request.GuideRecommendRequest;
 import com.team6.module.ai.dto.response.GuideRecommendResponse;
 import com.team6.module.ai.http.RecommendationHttpHeaders;
 import com.team6.module.ai.service.PromptRecommendationService;
+import com.team6.module.ai.support.GuideCandidateBundle;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Objects;
 
@@ -36,7 +38,9 @@ public class AiController {
     @Operation(
             summary = "프롬프트 기반 가이드 추천",
             description = "자연어 프롬프트와 가이드 후보 목록을 받아 상위 N명을 추천합니다. "
-                    + "선택 필드 desiredTourDate(yyyy-MM-dd)가 있으면 해당 날짜에 결제 완료(BOOKED+isPaid) 스케줄이 있는 가이드는 후보에서 제외합니다. "
+                    + "선택 필드 desiredTourDate 또는 desiredTourDateFrom~desiredTourDateTo(yyyy-MM-dd)가 있으면 "
+                    + "기간 중 하루라도 결제 완료(BOOKED+isPaid) 스케줄이 있는 가이드는 메인 추천 후보에서 제외합니다. "
+                    + "단, 일정 필터만 없었다면 Top1이었을 가이드는 specialSuggestion으로 별도 제시할 수 있습니다. "
                     + "응답의 policyVersion으로 룰 정책 버전을 구분할 수 있습니다."
     )
     @ApiResponse(
@@ -67,22 +71,100 @@ public class AiController {
                     content = @Content(schema = @Schema(implementation = PromptRecommendApiRequest.class))
             )
             @RequestBody PromptRecommendApiRequest request) {
-        List<GuideRecommendRequest.GuideCandidateDto> candidates =
+        LocalDate from = resolveDesiredFrom(request);
+        LocalDate to = resolveDesiredTo(request, from);
+
+        GuideCandidateBundle bundle =
                 guideCandidateProvider.getCandidates(
                         request.getPrompt(),
                         request.getTopN(),
                         request.getGuideCandidates(),
-                        request.getDesiredTourDate()
+                        from,
+                        to
                 );
 
-        GuideRecommendResponse body = promptRecommendationService.recommendByPrompt(
+        GuideRecommendResponse main = promptRecommendationService.recommendByPrompt(
                 request.getPrompt(),
                 request.getTopN(),
-                candidates
+                bundle.candidates()
         );
+
+        GuideRecommendResponse.SpecialSuggestion specialSuggestion =
+                buildSpecialSuggestionIfNeeded(request, main, bundle);
+
+        GuideRecommendResponse body = (specialSuggestion == null)
+                ? main
+                : GuideRecommendResponse.builder()
+                .conceptSummary(main.getConceptSummary())
+                .keywords(main.getKeywords())
+                .matchRequestDraft(main.getMatchRequestDraft())
+                .notice(main.getNotice())
+                .noticeCodes(main.getNoticeCodes())
+                .policyVersion(main.getPolicyVersion())
+                .promptParseConfidence(main.getPromptParseConfidence())
+                .totalCount(main.getTotalCount())
+                .recommendations(main.getRecommendations())
+                .specialSuggestion(specialSuggestion)
+                .build();
+
         String policy = Objects.requireNonNullElse(body.getPolicyVersion(), "");
         return ResponseEntity.ok()
                 .header(RecommendationHttpHeaders.X_RECOMMENDATION_POLICY, policy)
                 .body(body);
+    }
+
+    private static LocalDate resolveDesiredFrom(PromptRecommendApiRequest request) {
+        if (request.getDesiredTourDateFrom() != null) {
+            return request.getDesiredTourDateFrom();
+        }
+        return request.getDesiredTourDate();
+    }
+
+    private static LocalDate resolveDesiredTo(PromptRecommendApiRequest request, LocalDate from) {
+        if (request.getDesiredTourDateTo() != null) {
+            return request.getDesiredTourDateTo();
+        }
+        return from;
+    }
+
+    private GuideRecommendResponse.SpecialSuggestion buildSpecialSuggestionIfNeeded(
+            PromptRecommendApiRequest request,
+            GuideRecommendResponse main,
+            GuideCandidateBundle bundle
+    ) {
+        if (bundle == null || bundle.unfilteredCandidates() == null || bundle.unfilteredCandidates().isEmpty()) {
+            return null;
+        }
+        if (main == null || main.getRecommendations() == null || main.getRecommendations().isEmpty()) {
+            // 메인 추천이 비어도, “일정 필터만 없었다면 Top1”이 있으면 특별 제시한다.
+            return computeTop1SpecialSuggestion(request, bundle);
+        }
+
+        Long mainTop1 = main.getRecommendations().get(0).getGuideId();
+        GuideRecommendResponse.SpecialSuggestion special = computeTop1SpecialSuggestion(request, bundle);
+        if (special == null || special.getGuide() == null || special.getGuide().getGuideId() == null) {
+            return null;
+        }
+        Long unfilteredTop1 = special.getGuide().getGuideId();
+        // 정책: “Top1이 일정 때문에 빠졌을 때만” 특별 제시
+        return Objects.equals(mainTop1, unfilteredTop1) ? null : special;
+    }
+
+    private GuideRecommendResponse.SpecialSuggestion computeTop1SpecialSuggestion(
+            PromptRecommendApiRequest request,
+            GuideCandidateBundle bundle
+    ) {
+        GuideRecommendResponse top1 = promptRecommendationService.recommendByPrompt(
+                request.getPrompt(),
+                1,
+                bundle.unfilteredCandidates()
+        );
+        if (top1.getRecommendations() == null || top1.getRecommendations().isEmpty()) {
+            return null;
+        }
+        return GuideRecommendResponse.SpecialSuggestion.builder()
+                .guide(top1.getRecommendations().get(0))
+                .notice("조건에 잘 부합하지만 선택한 날짜에는 예약이 있어요")
+                .build();
     }
 }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/dto/request/PromptRecommendApiRequest.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/dto/request/PromptRecommendApiRequest.java
@@ -26,4 +26,18 @@ public class PromptRecommendApiRequest {
             example = "2026-04-28"
     )
     private LocalDate desiredTourDate;
+
+    @Schema(
+            description = "희망 투어 기간 시작일(로컬 날짜, ISO-8601 yyyy-MM-dd). "
+                    + "기간이 지정되면 기간 중 하루라도 결제 완료(BOOKED + isPaid) 스케줄이 있는 가이드는 추천 후보에서 제외",
+            example = "2026-04-28"
+    )
+    private LocalDate desiredTourDateFrom;
+
+    @Schema(
+            description = "희망 투어 기간 종료일(로컬 날짜, ISO-8601 yyyy-MM-dd). "
+                    + "미입력 시 desiredTourDateFrom(또는 desiredTourDate)와 동일 날짜로 처리",
+            example = "2026-04-30"
+    )
+    private LocalDate desiredTourDateTo;
 }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/dto/response/GuideRecommendResponse.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/dto/response/GuideRecommendResponse.java
@@ -38,6 +38,19 @@ public class GuideRecommendResponse {
     @Schema(description = "정렬된 추천 목록")
     private List<GuideRecommendItem> recommendations;
 
+    @Schema(description = "일정 충돌로 메인 추천에서 제외됐지만, 조건 매칭이 좋아 참고로 보여주는 1개 제시(선택)")
+    private SpecialSuggestion specialSuggestion;
+
+    @Schema(name = "GuideRecommendResponseSpecialSuggestion", description = "특별 제시(메인 추천과 분리된 참고용 제시)")
+    @Getter
+    @Builder
+    public static class SpecialSuggestion {
+        @Schema(description = "참고로 보여주는 가이드 1명")
+        private GuideRecommendItem guide;
+        @Schema(description = "특별 제시 안내 문구")
+        private String notice;
+    }
+
     @Schema(name = "GuideRecommendResponseKeywords", description = "프롬프트에서 추출한 키워드")
     @Getter
     @Builder

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/GuideCandidateBundle.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/GuideCandidateBundle.java
@@ -1,0 +1,17 @@
+package com.team6.module.ai.support;
+
+import com.team6.module.ai.dto.request.GuideRecommendRequest;
+
+import java.util.List;
+
+/**
+ * AI 추천에 사용할 후보 묶음.
+ * <p>
+ * - {@code candidates}: 일정/도메인 정책 등을 반영해 "메인 추천"에 사용할 후보\n+ * - {@code unfilteredCandidates}: 동일 풀에서 일정 필터만 제거했을 때의 후보(특별 제시 Top1 계산용)
+ */
+public record GuideCandidateBundle(
+        List<GuideRecommendRequest.GuideCandidateDto> candidates,
+        List<GuideRecommendRequest.GuideCandidateDto> unfilteredCandidates
+) {
+}
+

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/GuideCandidateProvider.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/GuideCandidateProvider.java
@@ -15,10 +15,11 @@ import java.util.List;
  * 후보를 제외할 수 있다(구현체가 DB를 쓰는 경우).
  */
 public interface GuideCandidateProvider {
-    List<GuideRecommendRequest.GuideCandidateDto> getCandidates(
+    GuideCandidateBundle getCandidates(
             String prompt,
             Integer topN,
             List<GuideRecommendRequest.GuideCandidateDto> candidates,
-            LocalDate desiredTourDate
+            LocalDate desiredTourDateFrom,
+            LocalDate desiredTourDateTo
     );
 }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/RequestGuideCandidateProvider.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/RequestGuideCandidateProvider.java
@@ -10,13 +10,15 @@ import java.util.List;
 public class RequestGuideCandidateProvider implements com.team6.module.ai.support.GuideCandidateProvider {
 
     @Override
-    public List<GuideRecommendRequest.GuideCandidateDto> getCandidates(
+    public GuideCandidateBundle getCandidates(
             String prompt,
             Integer topN,
             List<GuideRecommendRequest.GuideCandidateDto> candidates,
-            LocalDate desiredTourDate
+            LocalDate desiredTourDateFrom,
+            LocalDate desiredTourDateTo
     ) {
         // DB 없음: 결제 완료 일정 제외는 integration 구현(DbBacked)에서 처리한다.
-        return candidates == null ? List.of() : candidates;
+        List<GuideRecommendRequest.GuideCandidateDto> out = candidates == null ? List.of() : candidates;
+        return new GuideCandidateBundle(out, out);
     }
 }

--- a/backend/module-domain/src/main/java/com/team6/domain/guide/repository/GuideScheduleRepository.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/repository/GuideScheduleRepository.java
@@ -34,14 +34,15 @@ public interface GuideScheduleRepository extends JpaRepository<GuideSchedule, Lo
                                       @Param("endTime") LocalTime endTime);
 
     /**
-     * 해당 날짜에 결제까지 완료된(BOOKED + isPaid) 스케줄이 있는 가이드 프로필 ID.
-     * AI 추천 등에서 동일 날짜 후보를 제외할 때 사용한다.
+     * 기간 중 결제까지 완료된(BOOKED + isPaid) 스케줄이 있는 가이드 프로필 ID.
+     * AI 추천 등에서 기간 내 하루라도 예약 불가한 가이드를 제외할 때 사용한다.
      */
     @Query("SELECT DISTINCT s.guideProfile.id FROM GuideSchedule s "
-            + "WHERE s.availableDate = :date AND s.status = :status AND s.isPaid = true "
+            + "WHERE s.availableDate BETWEEN :from AND :to AND s.status = :status AND s.isPaid = true "
             + "AND s.guideProfile.id IS NOT NULL")
-    List<Long> findGuideProfileIdsBookedAndPaidOnDate(
-            @Param("date") LocalDate date,
+    List<Long> findGuideProfileIdsBookedAndPaidBetween(
+            @Param("from") LocalDate from,
+            @Param("to") LocalDate to,
             @Param("status") GuideScheduleStatus status
     );
 }


### PR DESCRIPTION
## Summary
- 희망 투어일/기간 기준으로 **결제 완료(BOOKED+isPaid) 일정 충돌 가이드**를 메인 추천 후보에서 제외합니다.
- 단, 일정 필터만 없었다면 Top1이었을 가이드 1명을 `specialSuggestion`으로 별도 제시합니다.

## API 변경
- Request: `desiredTourDateFrom`, `desiredTourDateTo` 추가(ISO `yyyy-MM-dd`)
  - 기존 `desiredTourDate`는 호환 유지(from=to)
- Response: `specialSuggestion`(별도 필드) 추가
  - notice: "조건에 잘 부합하지만 선택한 날짜에는 예약이 있어요"

## 정책
- 특별 제시 조건: **Top1이 일정 때문에 빠진 경우에만**
- 스코어 기준: 일정 필터만 제거하고 스코어링/다양성은 동일(Top1 계산은 topN=1로 재평가)
- 기간 충돌 규칙: **기간 중 하루라도 BOOKED+PAID면 제외**

## Test
- `./gradlew :module-ai:test :module-ai-integration:test`
- `./gradlew :api-server:compileJava`

Closes #200

Made with [Cursor](https://cursor.com)