### PR TITLE
Feat/be#202: 프롬프트 날짜/기간 자동 파싱

### DIFF
--- a/backend/module-ai/src/main/java/com/team6/module/ai/controller/AiController.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/controller/AiController.java
@@ -8,6 +8,7 @@ import com.team6.module.ai.dto.response.GuideRecommendResponse;
 import com.team6.module.ai.http.RecommendationHttpHeaders;
 import com.team6.module.ai.service.PromptRecommendationService;
 import com.team6.module.ai.support.GuideCandidateBundle;
+import com.team6.module.ai.parser.PromptParser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -34,6 +35,7 @@ public class AiController {
 
     private final PromptRecommendationService promptRecommendationService;
     private final GuideCandidateProvider guideCandidateProvider;
+    private final PromptParser promptParser;
 
     @Operation(
             summary = "프롬프트 기반 가이드 추천",
@@ -71,8 +73,8 @@ public class AiController {
                     content = @Content(schema = @Schema(implementation = PromptRecommendApiRequest.class))
             )
             @RequestBody PromptRecommendApiRequest request) {
-        LocalDate from = resolveDesiredFrom(request);
-        LocalDate to = resolveDesiredTo(request, from);
+        LocalDate from = resolveDesiredFromWithPromptFallback(request);
+        LocalDate to = resolveDesiredToWithPromptFallback(request, from);
 
         GuideCandidateBundle bundle =
                 guideCandidateProvider.getCandidates(
@@ -117,7 +119,10 @@ public class AiController {
         if (request.getDesiredTourDateFrom() != null) {
             return request.getDesiredTourDateFrom();
         }
-        return request.getDesiredTourDate();
+        if (request.getDesiredTourDate() != null) {
+            return request.getDesiredTourDate();
+        }
+        return null;
     }
 
     private static LocalDate resolveDesiredTo(PromptRecommendApiRequest request, LocalDate from) {
@@ -125,6 +130,24 @@ public class AiController {
             return request.getDesiredTourDateTo();
         }
         return from;
+    }
+
+    private LocalDate resolveDesiredFromWithPromptFallback(PromptRecommendApiRequest request) {
+        LocalDate from = resolveDesiredFrom(request);
+        if (from != null) {
+            return from;
+        }
+        PromptParser.DesiredDateRange r = promptParser.extractDesiredTourDateRange(request.getPrompt());
+        return r == null ? null : r.from();
+    }
+
+    private LocalDate resolveDesiredToWithPromptFallback(PromptRecommendApiRequest request, LocalDate from) {
+        LocalDate to = resolveDesiredTo(request, from);
+        if (to != null) {
+            return to;
+        }
+        PromptParser.DesiredDateRange r = promptParser.extractDesiredTourDateRange(request.getPrompt());
+        return r == null ? null : r.to();
     }
 
     private GuideRecommendResponse.SpecialSuggestion buildSpecialSuggestionIfNeeded(

--- a/backend/module-ai/src/main/java/com/team6/module/ai/parser/PromptParser.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/parser/PromptParser.java
@@ -5,6 +5,9 @@ import com.team6.module.ai.dto.request.GuideRecommendRequest;
 import com.team6.module.ai.support.RecommendationNoticeCodes;
 import org.springframework.stereotype.Component;
 
+import java.time.DateTimeException;
+import java.time.LocalDate;
+import java.time.Year;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -67,6 +70,14 @@ public class PromptParser {
     private static final Pattern DURATION_WEEKS = Pattern.compile("(\\d+)\\s*주");
     private static final Pattern DATE_RANGE_MONTH_DAY = Pattern.compile("(\\d{1,2})\\s*/\\s*(\\d{1,2})\\s*(?:~|\\-|부터)\\s*(\\d{1,2})\\s*/\\s*(\\d{1,2})");
     private static final Pattern DATE_RANGE_DAY_ONLY = Pattern.compile("(\\d{1,2})\\s*일\\s*(?:~|\\-|부터)\\s*(\\d{1,2})\\s*일");
+    private static final Pattern DATE_SINGLE_MONTH_DAY_SLASH = Pattern.compile("(\\d{1,2})\\s*/\\s*(\\d{1,2})");
+    private static final Pattern DATE_SINGLE_MONTH_DAY_KO = Pattern.compile("(\\d{1,2})\\s*월\\s*(\\d{1,2})\\s*일");
+    private static final Pattern DATE_RANGE_MONTH_DAY_KO = Pattern.compile(
+            "(\\d{1,2})\\s*월\\s*(\\d{1,2})\\s*일\\s*(?:~|\\-|부터)\\s*(\\d{1,2})\\s*월\\s*(\\d{1,2})\\s*일"
+    );
+    private static final Pattern DATE_RANGE_SAME_MONTH_KO = Pattern.compile(
+            "(\\d{1,2})\\s*월\\s*(\\d{1,2})\\s*일\\s*(?:~|\\-|부터)\\s*(\\d{1,2})\\s*일"
+    );
     private static final int NEGATION_AFTER_WINDOW = 12;
 
     /**
@@ -80,6 +91,9 @@ public class PromptParser {
             boolean hasBudgetHint,
             boolean hasDurationHint
     ) {
+    }
+
+    public record DesiredDateRange(LocalDate from, LocalDate to) {
     }
 
     public GuideRecommendRequest parse(
@@ -162,6 +176,88 @@ public class PromptParser {
                 || DATE_RANGE_DAY_ONLY.matcher(normalized).find();
 
         return new ParseSignals(exclusionIntents, hasBudgetHint, hasDurationHint);
+    }
+
+    /**
+     * 프롬프트에서 희망 투어 날짜/기간을 추출한다.
+     * <p>
+     * 지원: {@code 4/28}, {@code 4월 28일}, {@code 4/28~4/30}, {@code 4월 28일부터 4월 30일},
+     * {@code 4월 28일~30일}. 연도 미기재 시 서버 로컬 기준 현재 연도를 사용한다.
+     */
+    public DesiredDateRange extractDesiredTourDateRange(String prompt) {
+        String normalized = normalize(prompt);
+        int year = Year.now().getValue();
+
+        DesiredDateRange kOrange = extractKoreanMonthDayRange(normalized, year);
+        if (kOrange != null) {
+            return kOrange;
+        }
+        DesiredDateRange slashRange = extractSlashMonthDayRange(normalized, year);
+        if (slashRange != null) {
+            return slashRange;
+        }
+        DesiredDateRange single = extractSingleMonthDay(normalized, year);
+        return single;
+    }
+
+    private DesiredDateRange extractKoreanMonthDayRange(String prompt, int year) {
+        Matcher m = DATE_RANGE_MONTH_DAY_KO.matcher(prompt);
+        if (m.find()) {
+            LocalDate from = safeDate(year, m.group(1), m.group(2));
+            LocalDate to = safeDate(year, m.group(3), m.group(4));
+            return normalizeRange(from, to);
+        }
+        Matcher sameMonth = DATE_RANGE_SAME_MONTH_KO.matcher(prompt);
+        if (sameMonth.find()) {
+            LocalDate from = safeDate(year, sameMonth.group(1), sameMonth.group(2));
+            LocalDate to = safeDate(year, sameMonth.group(1), sameMonth.group(3));
+            return normalizeRange(from, to);
+        }
+        return null;
+    }
+
+    private DesiredDateRange extractSlashMonthDayRange(String prompt, int year) {
+        Matcher range = DATE_RANGE_MONTH_DAY.matcher(prompt);
+        if (range.find()) {
+            LocalDate from = safeDate(year, range.group(1), range.group(2));
+            LocalDate to = safeDate(year, range.group(3), range.group(4));
+            return normalizeRange(from, to);
+        }
+        return null;
+    }
+
+    private DesiredDateRange extractSingleMonthDay(String prompt, int year) {
+        Matcher ko = DATE_SINGLE_MONTH_DAY_KO.matcher(prompt);
+        if (ko.find()) {
+            LocalDate d = safeDate(year, ko.group(1), ko.group(2));
+            return d == null ? null : new DesiredDateRange(d, d);
+        }
+        Matcher slash = DATE_SINGLE_MONTH_DAY_SLASH.matcher(prompt);
+        if (slash.find()) {
+            LocalDate d = safeDate(year, slash.group(1), slash.group(2));
+            return d == null ? null : new DesiredDateRange(d, d);
+        }
+        return null;
+    }
+
+    private static LocalDate safeDate(int year, String mm, String dd) {
+        try {
+            int m = Integer.parseInt(mm);
+            int d = Integer.parseInt(dd);
+            return LocalDate.of(year, m, d);
+        } catch (NumberFormatException | DateTimeException e) {
+            return null;
+        }
+    }
+
+    private static DesiredDateRange normalizeRange(LocalDate from, LocalDate to) {
+        if (from == null || to == null) {
+            return null;
+        }
+        if (from.isAfter(to)) {
+            return new DesiredDateRange(to, from);
+        }
+        return new DesiredDateRange(from, to);
     }
 
     private String normalize(String prompt) {

--- a/backend/module-ai/src/test/java/com/team6/module/ai/parser/PromptParserTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/parser/PromptParserTest.java
@@ -4,6 +4,7 @@ import com.team6.module.ai.config.LocalGuestAiProperties;
 import com.team6.module.ai.dto.request.GuideRecommendRequest;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,6 +35,27 @@ class PromptParserTest {
         assertThat(request.getRegion()).isEqualTo("제주");
         assertThat(request.getBudgetLevel()).isEqualTo("중간");
         assertThat(request.getActivityTags()).contains("카페");
+    }
+
+    @Test
+    void extractDesiredTourDateRange_should_parse_single_and_ranges() {
+        int y = LocalDate.now().getYear();
+
+        PromptParser.DesiredDateRange single = promptParser.extractDesiredTourDateRange("4월 28일에 제주 맛집 투어");
+        assertThat(single.from()).isEqualTo(LocalDate.of(y, 4, 28));
+        assertThat(single.to()).isEqualTo(LocalDate.of(y, 4, 28));
+
+        PromptParser.DesiredDateRange r1 = promptParser.extractDesiredTourDateRange("4/28~4/30 제주 맛집 투어");
+        assertThat(r1.from()).isEqualTo(LocalDate.of(y, 4, 28));
+        assertThat(r1.to()).isEqualTo(LocalDate.of(y, 4, 30));
+
+        PromptParser.DesiredDateRange r2 = promptParser.extractDesiredTourDateRange("4월 28일부터 4월 30일 제주");
+        assertThat(r2.from()).isEqualTo(LocalDate.of(y, 4, 28));
+        assertThat(r2.to()).isEqualTo(LocalDate.of(y, 4, 30));
+
+        PromptParser.DesiredDateRange r3 = promptParser.extractDesiredTourDateRange("4월 28일~30일 제주");
+        assertThat(r3.from()).isEqualTo(LocalDate.of(y, 4, 28));
+        assertThat(r3.to()).isEqualTo(LocalDate.of(y, 4, 30));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- 요청 바디에 `desiredTourDate` / `desiredTourDateFrom~To`가 비어있을 때, 프롬프트에서 날짜/기간을 자동 파싱해 일정 필터에 반영합니다.

## Details
- 지원 예시
  - 단일: `4/28`, `4월 28일`
  - 기간: `4/28~4/30`, `4월 28일부터 4월 30일`, `4월 28일~30일`
- 연도 미기재 시: 서버 로컬 기준 현재 연도 사용

## Test
- `./gradlew :module-ai:test`
- `./gradlew :api-server:compileJava`

Closes #202

Made with [Cursor](https://cursor.com)