### PR TITLE
Feat/be#204: 특별 제시 안내에 기간 내 가능 날짜 포함

### DIFF
--- a/backend/module-ai-integration/src/main/java/com/team6/integration/ai/DbGuideAvailabilityProvider.java
+++ b/backend/module-ai-integration/src/main/java/com/team6/integration/ai/DbGuideAvailabilityProvider.java
@@ -1,0 +1,64 @@
+package com.team6.integration.ai;
+
+import com.team6.domain.guide.entity.enums.GuideScheduleStatus;
+import com.team6.domain.guide.repository.GuideScheduleRepository;
+import com.team6.module.ai.support.GuideAvailabilityProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Component
+@Primary
+@RequiredArgsConstructor
+public class DbGuideAvailabilityProvider implements GuideAvailabilityProvider {
+
+    private final GuideScheduleRepository guideScheduleRepository;
+
+    @Override
+    public List<LocalDate> availableDates(Long guideId, LocalDate from, LocalDate to) {
+        if (guideId == null || from == null) {
+            return List.of();
+        }
+        LocalDate end = (to == null) ? from : to;
+        LocalDate start = from.isAfter(end) ? end : from;
+        LocalDate finish = from.isAfter(end) ? from : end;
+
+        List<LocalDate> booked = guideScheduleRepository.findBookedPaidDatesByGuideIdBetween(
+                guideId,
+                start,
+                finish,
+                GuideScheduleStatus.BOOKED
+        );
+        Set<LocalDate> bookedSet = new HashSet<>();
+        if (booked != null) {
+            for (LocalDate d : booked) {
+                if (d != null) bookedSet.add(d);
+            }
+        }
+
+        int span = (int) (finish.toEpochDay() - start.toEpochDay());
+        if (span < 0) {
+            return List.of();
+        }
+        // 과도한 기간은 보호 (UX도 불명확). 0~30일까지만 안내한다.
+        if (span > 30) {
+            finish = start.plusDays(30);
+        }
+
+        java.util.ArrayList<LocalDate> out = new java.util.ArrayList<>();
+        LocalDate cur = start;
+        while (!cur.isAfter(finish)) {
+            if (!bookedSet.contains(cur)) {
+                out.add(cur);
+            }
+            cur = cur.plusDays(1);
+        }
+        return out;
+    }
+}
+

--- a/backend/module-ai/src/main/java/com/team6/module/ai/controller/AiController.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/controller/AiController.java
@@ -4,11 +4,13 @@ import com.team6.module.ai.dto.openapi.OpenApiStandardErrorBody;
 import com.team6.module.ai.dto.request.PromptRecommendApiRequest;
 import com.team6.module.ai.support.GuideCandidateProvider;
 import com.team6.module.ai.dto.request.GuideRecommendRequest;
+import com.team6.module.ai.dto.response.GuideRecommendItem;
 import com.team6.module.ai.dto.response.GuideRecommendResponse;
 import com.team6.module.ai.http.RecommendationHttpHeaders;
 import com.team6.module.ai.service.PromptRecommendationService;
 import com.team6.module.ai.support.GuideCandidateBundle;
 import com.team6.module.ai.parser.PromptParser;
+import com.team6.module.ai.support.GuideAvailabilityProvider;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -24,6 +26,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -36,6 +39,7 @@ public class AiController {
     private final PromptRecommendationService promptRecommendationService;
     private final GuideCandidateProvider guideCandidateProvider;
     private final PromptParser promptParser;
+    private final GuideAvailabilityProvider guideAvailabilityProvider;
 
     @Operation(
             summary = "프롬프트 기반 가이드 추천",
@@ -92,7 +96,7 @@ public class AiController {
         );
 
         GuideRecommendResponse.SpecialSuggestion specialSuggestion =
-                buildSpecialSuggestionIfNeeded(request, main, bundle);
+                buildSpecialSuggestionIfNeeded(request, main, bundle, from, to);
 
         GuideRecommendResponse body = (specialSuggestion == null)
                 ? main
@@ -153,18 +157,20 @@ public class AiController {
     private GuideRecommendResponse.SpecialSuggestion buildSpecialSuggestionIfNeeded(
             PromptRecommendApiRequest request,
             GuideRecommendResponse main,
-            GuideCandidateBundle bundle
+            GuideCandidateBundle bundle,
+            LocalDate from,
+            LocalDate to
     ) {
         if (bundle == null || bundle.unfilteredCandidates() == null || bundle.unfilteredCandidates().isEmpty()) {
             return null;
         }
         if (main == null || main.getRecommendations() == null || main.getRecommendations().isEmpty()) {
             // 메인 추천이 비어도, “일정 필터만 없었다면 Top1”이 있으면 특별 제시한다.
-            return computeTop1SpecialSuggestion(request, bundle);
+            return computeTop1SpecialSuggestion(request, bundle, from, to);
         }
 
         Long mainTop1 = main.getRecommendations().get(0).getGuideId();
-        GuideRecommendResponse.SpecialSuggestion special = computeTop1SpecialSuggestion(request, bundle);
+        GuideRecommendResponse.SpecialSuggestion special = computeTop1SpecialSuggestion(request, bundle, from, to);
         if (special == null || special.getGuide() == null || special.getGuide().getGuideId() == null) {
             return null;
         }
@@ -175,7 +181,9 @@ public class AiController {
 
     private GuideRecommendResponse.SpecialSuggestion computeTop1SpecialSuggestion(
             PromptRecommendApiRequest request,
-            GuideCandidateBundle bundle
+            GuideCandidateBundle bundle,
+            LocalDate from,
+            LocalDate to
     ) {
         GuideRecommendResponse top1 = promptRecommendationService.recommendByPrompt(
                 request.getPrompt(),
@@ -185,9 +193,29 @@ public class AiController {
         if (top1.getRecommendations() == null || top1.getRecommendations().isEmpty()) {
             return null;
         }
+        GuideRecommendItem guide = top1.getRecommendations().get(0);
+        String notice = buildAvailabilityNotice(guide.getGuideId(), from, to);
         return GuideRecommendResponse.SpecialSuggestion.builder()
-                .guide(top1.getRecommendations().get(0))
-                .notice("조건에 잘 부합하지만 선택한 날짜에는 예약이 있어요")
+                .guide(guide)
+                .notice(notice)
                 .build();
+    }
+
+    private String buildAvailabilityNotice(Long guideId, LocalDate from, LocalDate to) {
+        String base = "조건에 잘 부합하지만 선택한 날짜에는 예약이 있어요";
+        if (guideId == null || from == null) {
+            return base;
+        }
+        List<LocalDate> available = guideAvailabilityProvider.availableDates(guideId, from, to);
+        if (available == null || available.isEmpty()) {
+            return base;
+        }
+        // 안내는 과도하지 않게 7개까지만
+        List<LocalDate> clipped = new ArrayList<>();
+        for (int i = 0; i < available.size() && i < 7; i++) {
+            clipped.add(available.get(i));
+        }
+        String suffix = " (기간 내 가능: " + String.join(", ", clipped.stream().map(LocalDate::toString).toList()) + ")";
+        return base + suffix;
     }
 }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/GuideAvailabilityProvider.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/GuideAvailabilityProvider.java
@@ -1,0 +1,19 @@
+package com.team6.module.ai.support;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 가이드의 날짜 가용 정보를 제공한다.
+ * <p>
+ * module-ai는 도메인(JPA)에 의존하지 않으므로, 실제 구현은 integration/상위 모듈에서 제공할 수 있다.
+ */
+public interface GuideAvailabilityProvider {
+
+    /**
+     * 요청 기간 내에서 가이드가 예약 가능한 날짜 목록(로컬 날짜)을 반환한다.
+     * 구현이 없거나 계산 불가 시 빈 리스트를 반환할 수 있다.
+     */
+    List<LocalDate> availableDates(Long guideId, LocalDate from, LocalDate to);
+}
+

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/NoopGuideAvailabilityProvider.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/NoopGuideAvailabilityProvider.java
@@ -1,0 +1,15 @@
+package com.team6.module.ai.support;
+
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Component
+public class NoopGuideAvailabilityProvider implements GuideAvailabilityProvider {
+    @Override
+    public List<LocalDate> availableDates(Long guideId, LocalDate from, LocalDate to) {
+        return List.of();
+    }
+}
+

--- a/backend/module-domain/src/main/java/com/team6/domain/guide/repository/GuideScheduleRepository.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/repository/GuideScheduleRepository.java
@@ -45,4 +45,19 @@ public interface GuideScheduleRepository extends JpaRepository<GuideSchedule, Lo
             @Param("to") LocalDate to,
             @Param("status") GuideScheduleStatus status
     );
+
+    /**
+     * 특정 가이드에 대해, 기간 중 결제까지 완료된(BOOKED + isPaid) 스케줄의 날짜 목록.
+     * 특별 제시 안내에서 기간 내 가능한 날짜를 계산할 때 사용한다.
+     */
+    @Query("SELECT DISTINCT s.availableDate FROM GuideSchedule s "
+            + "WHERE s.guideProfile.id = :guideId "
+            + "AND s.availableDate BETWEEN :from AND :to "
+            + "AND s.status = :status AND s.isPaid = true")
+    List<LocalDate> findBookedPaidDatesByGuideIdBetween(
+            @Param("guideId") Long guideId,
+            @Param("from") LocalDate from,
+            @Param("to") LocalDate to,
+            @Param("status") GuideScheduleStatus status
+    );
 }


### PR DESCRIPTION
## Summary
- 특별 제시(specialSuggestion) 안내 문구에 요청 기간 내 **가능한 날짜만** 포함합니다.
- 기간 밖 대체 날짜 제안은 하지 않습니다.

## Details
- 계산 기준: 해당 가이드의 `guide_schedules`에서 **BOOKED + isPaid=true** 인 날짜를 기간(from~to)에서 제외
- 기간이 없으면 기존 문구 유지
- 안내는 과도하지 않게 최대 7개 날짜까지만 표시

## Test
- `./gradlew :module-ai:test :module-ai-integration:test`
- `./gradlew :api-server:compileJava`

Closes #204

Made with [Cursor](https://cursor.com)