### PR TITLE
Feat/be#206 후보 제외 사유 메트릭 추가

### DIFF
--- a/backend/module-ai-integration/build.gradle
+++ b/backend/module-ai-integration/build.gradle
@@ -10,6 +10,8 @@ dependencies {
 
     // module-domain의 implementation 의존성은 전이되지 않으므로, 스프링 컴포넌트 컴파일용으로 명시
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    // module-ai의 micrometer 의존은 implementation이라 전이되지 않음(테스트에서 AiRecommendationMetrics 생성에 필요)
+    testImplementation 'io.micrometer:micrometer-core'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/backend/module-ai-integration/src/main/java/com/team6/integration/ai/DbBackedGuideCandidateProvider.java
+++ b/backend/module-ai-integration/src/main/java/com/team6/integration/ai/DbBackedGuideCandidateProvider.java
@@ -16,6 +16,7 @@ import com.team6.module.chat.repository.mysql.ChatRoomRepository;
 import com.team6.module.ai.config.LocalGuestAiProperties;
 import com.team6.module.ai.dto.request.GuideRecommendRequest;
 import com.team6.module.ai.parser.PromptParser;
+import com.team6.module.ai.support.AiRecommendationMetrics;
 import com.team6.module.ai.support.AiRecommendationTuning;
 import com.team6.module.ai.support.GuideCandidateBundle;
 import com.team6.module.ai.support.GuideCandidateProvider;
@@ -83,6 +84,7 @@ public class DbBackedGuideCandidateProvider implements GuideCandidateProvider {
     private final GuideScheduleRepository guideScheduleRepository;
     private final PromptParser promptParser;
     private final LocalGuestAiProperties aiProperties;
+    private final AiRecommendationMetrics metrics;
 
     private final ConcurrentHashMap<String, PoolCacheEntry> poolCache = new ConcurrentHashMap<>();
 
@@ -99,6 +101,11 @@ public class DbBackedGuideCandidateProvider implements GuideCandidateProvider {
             Set<Long> bookedPaidGuideIds = resolveBookedPaidGuideIds(desiredTourDateFrom, desiredTourDateTo);
             List<GuideRecommendRequest.GuideCandidateDto> filtered =
                     excludeBookedPaidGuides(unfiltered, bookedPaidGuideIds, desiredTourDateFrom, desiredTourDateTo);
+            metrics.recordCandidateExclusion(
+                    "schedule_conflict",
+                    unfiltered.size() - filtered.size(),
+                    AiRecommendationTuning.POLICY_VERSION
+            );
             return new GuideCandidateBundle(filtered, unfiltered);
         }
         String safePrompt = prompt == null ? "" : prompt;
@@ -122,7 +129,13 @@ public class DbBackedGuideCandidateProvider implements GuideCandidateProvider {
         }
 
         List<GuideProfile> profiles = loadProfilesTiered(region, pool);
+        int beforeExcluded = profiles.size();
         profiles = filterExcludedProfiles(profiles, pool);
+        metrics.recordCandidateExclusion(
+                "config_excluded",
+                beforeExcluded - profiles.size(),
+                AiRecommendationTuning.POLICY_VERSION
+        );
 
         List<GuideRecommendRequest.GuideCandidateDto> mapped = mapProfilesToCandidates(profiles);
         List<GuideRecommendRequest.GuideCandidateDto> withSignals = mergeBehaviorSignals(mapped, profiles);
@@ -130,6 +143,11 @@ public class DbBackedGuideCandidateProvider implements GuideCandidateProvider {
         Set<Long> bookedPaidGuideIds = resolveBookedPaidGuideIds(desiredTourDateFrom, desiredTourDateTo);
         List<GuideRecommendRequest.GuideCandidateDto> sampledFiltered =
                 excludeBookedPaidGuides(sampledUnfiltered, bookedPaidGuideIds, desiredTourDateFrom, desiredTourDateTo);
+        metrics.recordCandidateExclusion(
+                "schedule_conflict",
+                sampledUnfiltered.size() - sampledFiltered.size(),
+                AiRecommendationTuning.POLICY_VERSION
+        );
 
         if (ttlSec > 0) {
             long ttlNanos = ttlSec * 1_000_000_000L;

--- a/backend/module-ai-integration/src/test/java/com/team6/integration/ai/DbBackedGuideCandidateProviderTest.java
+++ b/backend/module-ai-integration/src/test/java/com/team6/integration/ai/DbBackedGuideCandidateProviderTest.java
@@ -16,7 +16,9 @@ import com.team6.module.chat.repository.mysql.ChatRoomRepository;
 import com.team6.module.ai.config.LocalGuestAiProperties;
 import com.team6.module.ai.dto.request.GuideRecommendRequest;
 import com.team6.module.ai.parser.PromptParser;
+import com.team6.module.ai.support.AiRecommendationMetrics;
 import com.team6.module.ai.support.GuideCandidateBundle;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -68,6 +70,7 @@ class DbBackedGuideCandidateProviderTest {
     void setUp() {
         LocalGuestAiProperties aiProps = new LocalGuestAiProperties();
         aiProps.getCandidatePool().setPoolCacheTtlSeconds(0);
+        AiRecommendationMetrics metrics = new AiRecommendationMetrics(new SimpleMeterRegistry());
         provider = new DbBackedGuideCandidateProvider(
                 guideProfileRepository,
                 guideFeedRepository,
@@ -77,7 +80,8 @@ class DbBackedGuideCandidateProviderTest {
                 chatRoomRepository,
                 guideScheduleRepository,
                 new PromptParser(aiProps),
-                aiProps
+                aiProps,
+                metrics
         );
     }
 

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationMetrics.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationMetrics.java
@@ -58,6 +58,23 @@ public class AiRecommendationMetrics {
     }
 
     /**
+     * 후보 풀/후보 필터링 단계에서 제외 사유를 집계한다.
+     * 예: 결제 완료 일정 충돌, 운영 제외 ID, 희소 풀 등.
+     *
+     * @param reason schedule_conflict / config_excluded / sparse_pool 등(소문자 권장)
+     * @param removedCount 제외된 후보 수(0이면 기록하지 않음)
+     */
+    public void recordCandidateExclusion(String reason, int removedCount, String policyVersion) {
+        if (removedCount <= 0) {
+            return;
+        }
+        String pv = policyVersion == null ? "unknown" : policyVersion;
+        String r = reason == null || reason.isBlank() ? "unknown" : reason;
+        registry.counter(PREFIX + ".candidate_exclusion",
+                Tags.of("policy_version", pv, "reason", r)).increment(removedCount);
+    }
+
+    /**
      * @param relaxStage 조건 완화 단계 이름(예: {@code DROP_ACTIVITY_TAGS_ONLY}). 체인 실패 시 {@code STRATEGIC_EXHAUSTED}.
      */
     public void recordFallback(String relaxStage) {


### PR DESCRIPTION
## Summary
- 후보 풀 단계에서 후보가 제외된 사유를 Micrometer counter로 수집하도록 `localguest.ai.recommend.candidate_exclusion` 추가
- 예약 충돌(BOOKED+PAID) 제외, 운영 제외 ID(excludedGuideIds) 제외를 reason 태그로 구분

## Metrics
- `localguest.ai.recommend.candidate_exclusion{policy_version=..., reason=schedule_conflict|config_excluded}`

## Test plan
- `./gradlew :module-ai:test :module-ai-integration:test`
- `./gradlew :api-server:compileJava`

Closes #206

Made with [Cursor](https://cursor.com)