### PR TITLE
Feat/be#195: FE CICD 구축

### DIFF
--- a/.github/workflows/frontend_cicd.yml
+++ b/.github/workflows/frontend_cicd.yml
@@ -47,7 +47,7 @@ jobs:
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
-            export DOCKER_IMAGE_TAG=${{ github.sha }}
+            export FRONTEND_IMAGE_TAG=${{ github.sha }}
             export DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}
             export FRONTEND_IMAGE_NAME=${{ secrets.FRONTEND_IMAGE_NAME }}
             

--- a/.github/workflows/frontend_cicd.yml
+++ b/.github/workflows/frontend_cicd.yml
@@ -1,0 +1,56 @@
+name: Frontend Blue-Green CI/CD
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'frontend/**' # 프론트엔드 변경 시에만 작동
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: './frontend/package-lock.json'
+
+      # ⭐ 순서 변경: 빌드(Docker build) 전에 파일을 먼저 생성해야 합니다.
+      - name: Create .env.production from Secrets
+        working-directory: ./frontend
+        run: |
+          echo "${{ secrets.FE_ENV_PROD }}" > .env.production
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./frontend
+          file: ./frontend/Dockerfile
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.FRONTEND_IMAGE_NAME }}:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.FRONTEND_IMAGE_NAME }}:${{ github.sha }}
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to EC2 via SSH
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            export DOCKER_IMAGE_TAG=${{ github.sha }}
+            export DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}
+            export FRONTEND_IMAGE_NAME=${{ secrets.FRONTEND_IMAGE_NAME }}
+            
+            # 프론트엔드 전용 배포 스크립트 실행
+            cd /home/ubuntu/frontend-deploy
+            ./deploy-fe.sh

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -17,10 +17,6 @@
           </set>
         </option>
       </GradleProjectSettings>
-      <GradleProjectSettings>
-        <option name="externalProjectPath" value="$PROJECT_DIR$/backend/api-server" />
-        <option name="gradleJvm" value="jbr-21" />
-      </GradleProjectSettings>
     </option>
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,7 +4,7 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$/backend" />
   </component>
-  <component name="ProjectRootManager" version="2" project-jdk-name="21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="corretto-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -3,12 +3,7 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/LocalGuest.iml" filepath="$PROJECT_DIR$/.idea/LocalGuest.iml" />
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/api-server/backend.api-server.main.iml" filepath="$PROJECT_DIR$/.idea/modules/api-server/backend.api-server.main.iml" />
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/module-ai-integration/backend.module-ai-integration.main.iml" filepath="$PROJECT_DIR$/.idea/modules/module-ai-integration/backend.module-ai-integration.main.iml" />
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/module-ai/backend.module-ai.main.iml" filepath="$PROJECT_DIR$/.idea/modules/module-ai/backend.module-ai.main.iml" />
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/module-chat/backend.module-chat.main.iml" filepath="$PROJECT_DIR$/.idea/modules/module-chat/backend.module-chat.main.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/module-common/backend.module-common.main.iml" filepath="$PROJECT_DIR$/.idea/modules/module-common/backend.module-common.main.iml" />
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/module-domain/backend.module-domain.main.iml" filepath="$PROJECT_DIR$/.idea/modules/module-domain/backend.module-domain.main.iml" />
     </modules>
   </component>
 </project>

--- a/.idea/modules/api-server/backend.api-server.main.iml
+++ b/.idea/modules/api-server/backend.api-server.main.iml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module version="4">
-  <component name="AdditionalModuleElements">
-    <content url="file://$MODULE_DIR$/../../../backend/api-server/build/generated/sources/annotationProcessor/java/main">
-      <sourceFolder url="file://$MODULE_DIR$/../../../backend/api-server/build/generated/sources/annotationProcessor/java/main" isTestSource="false" generated="true" />
-    </content>
-  </component>
-</module>

--- a/.idea/modules/module-ai-integration/backend.module-ai-integration.main.iml
+++ b/.idea/modules/module-ai-integration/backend.module-ai-integration.main.iml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module version="4">
-  <component name="AdditionalModuleElements">
-    <content url="file://$MODULE_DIR$/../../../backend/module-ai-integration/build/generated/sources/annotationProcessor/java/main">
-      <sourceFolder url="file://$MODULE_DIR$/../../../backend/module-ai-integration/build/generated/sources/annotationProcessor/java/main" isTestSource="false" generated="true" />
-    </content>
-  </component>
-</module>

--- a/.idea/modules/module-ai/backend.module-ai.main.iml
+++ b/.idea/modules/module-ai/backend.module-ai.main.iml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module version="4">
-  <component name="AdditionalModuleElements">
-    <content url="file://$MODULE_DIR$/../../../backend/module-ai/build/generated/sources/annotationProcessor/java/main">
-      <sourceFolder url="file://$MODULE_DIR$/../../../backend/module-ai/build/generated/sources/annotationProcessor/java/main" isTestSource="false" generated="true" />
-    </content>
-  </component>
-</module>

--- a/.idea/modules/module-chat/backend.module-chat.main.iml
+++ b/.idea/modules/module-chat/backend.module-chat.main.iml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module version="4">
-  <component name="AdditionalModuleElements">
-    <content url="file://$MODULE_DIR$/../../../backend/module-chat/build/generated/sources/annotationProcessor/java/main">
-      <sourceFolder url="file://$MODULE_DIR$/../../../backend/module-chat/build/generated/sources/annotationProcessor/java/main" isTestSource="false" generated="true" />
-    </content>
-  </component>
-</module>

--- a/.idea/modules/module-domain/backend.module-domain.main.iml
+++ b/.idea/modules/module-domain/backend.module-domain.main.iml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module version="4">
-  <component name="AdditionalModuleElements">
-    <content url="file://$MODULE_DIR$/../../../backend/module-domain/build/generated/sources/annotationProcessor/java/main">
-      <sourceFolder url="file://$MODULE_DIR$/../../../backend/module-domain/build/generated/sources/annotationProcessor/java/main" isTestSource="false" generated="true" />
-    </content>
-  </component>
-</module>

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -41,4 +41,5 @@ subprojects {
     test {
         useJUnitPlatform()
     }
+
 }

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.env.local
+.env.production

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,24 @@
+# 1단계: 빌드 (Build Stage)
+FROM node:20-alpine AS builder
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+# 모든 소스 복사 (이때 위에서 만든 .env.production도 포함됨)
+COPY . .
+
+# 여기서 빌드! (환경변수가 JS에 박히는 순간)
+# Vite 기반이라면 dist 폴더가 생성됩니다.
+RUN npm run build
+
+# 2단계: 실행 (Production Stage)
+FROM nginx:alpine
+# 빌드된 정적 파일만 Nginx로 복사
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+# Nginx 기본 설정 덮어쓰기 (필요 시)
+# COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/deployment/deploy.sh
+++ b/frontend/deployment/deploy.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# 1. 환경 설정
+TARGET_PORT_BLUE=3001
+TARGET_PORT_GREEN=3002
+
+# 필수 환경변수 체크 (변수가 비어있으면 배포 중단)
+if [ -z "$DOCKERHUB_USERNAME" ] || [ -z "$FRONTEND_IMAGE_NAME" ] || [ -z "$FRONTEND_IMAGE_TAG" ]; then
+    echo "❌ 에러: 필수 환경변수(DOCKERHUB_USERNAME, IMAGE_NAME, TAG)가 누락되었습니다."
+    exit 1
+fi
+
+# 2. 현재 실행 중인 컬러 확인
+IS_BLUE=$(docker ps --filter "name=frontend-blue" --filter "status=running" -q)
+
+if [ -z "$IS_BLUE" ]; then
+    TARGET_COLOR="blue"; TARGET_PORT=$TARGET_PORT_BLUE; OLD_COLOR="green"; INC_FILE="fe_blue.inc"
+else
+    TARGET_COLOR="green"; TARGET_PORT=$TARGET_PORT_GREEN; OLD_COLOR="blue"; INC_FILE="fe_green.inc"
+fi
+
+echo "--- 🎨 프론트엔드 $TARGET_COLOR 배포 시작 (Port: $TARGET_PORT) ---"
+
+# 3. 이미지 Pull 및 컨테이너 교체
+docker pull $DOCKERHUB_USERNAME/$FRONTEND_IMAGE_NAME:$FRONTEND_IMAGE_TAG
+
+# 기존에 죽어있을 수도 있는 타겟 컨테이너 정리
+docker stop frontend-$TARGET_COLOR 2>/dev/null || true
+docker rm frontend-$TARGET_COLOR 2>/dev/null || true
+
+# 4. 새 컨테이너 실행
+docker run -d \
+  --name frontend-$TARGET_COLOR \
+  -p $TARGET_PORT:80 \
+  --restart always \
+  $DOCKERHUB_USERNAME/$FRONTEND_IMAGE_NAME:$FRONTEND_IMAGE_TAG
+
+# 5. 헬스체크 (최대 5번 시도)
+echo "⏳ 헬스체크 시작..."
+for i in {1..5}; do
+    sleep 5
+    HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:$TARGET_PORT)
+    if [ "$HTTP_STATUS" -eq 200 ]; then
+        echo "✅ 프론트엔드 헬스체크 성공!"
+        break
+    fi
+    if [ $i -eq 5 ]; then
+        echo "❌ 헬스체크 실패! 배포를 중단하고 롤백합니다."
+        docker stop frontend-$TARGET_COLOR || true
+        exit 1
+    fi
+    echo "...대기 중 ($i/5)"
+done
+
+# 6. Nginx 설정 전환
+echo "🔄 Nginx 설정 교체 및 Reload..."
+sudo cp /home/ubuntu/frontend-deploy/nginx/$INC_FILE /etc/nginx/conf.d/frontend.inc
+
+if sudo nginx -t; then
+    sudo nginx -s reload
+    echo "✅ Nginx 리로드 완료!"
+else
+    echo "❌ Nginx 설정 오류 발생!"
+    exit 1
+fi
+
+# 7. 구 버전 정리 및 최적화
+echo "🧹 불필요한 이미지 및 캐시 정리..."
+
+# 이전 버전 컨테이너 삭제
+docker stop frontend-$OLD_COLOR 2>/dev/null || true
+docker rm frontend-$OLD_COLOR 2>/dev/null || true
+
+# 찌꺼기 이미지 및 빌드 캐시 정리
+docker image prune -f
+docker builder prune -f
+
+echo "🎊 프론트엔드 배포 및 디스크 정리 완료!"
+df -h | grep '/$'

--- a/frontend/deployment/nginx/fe_blue.inc
+++ b/frontend/deployment/nginx/fe_blue.inc
@@ -1,0 +1,3 @@
+location / {
+    proxy_pass http://127.0.0.1:3001; # 프론트 Blue 포트
+}

--- a/frontend/deployment/nginx/fe_green.inc
+++ b/frontend/deployment/nginx/fe_green.inc
@@ -1,0 +1,3 @@
+location / {
+    proxy_pass http://127.0.0.1:3002; # 프론트 Green 포트
+}


### PR DESCRIPTION
# 🔗 이슈 번호
- Closes #195 

---

## 💡 주요 변경 사항
Frontend Blue-Green CI/CD 파이프라인 구축
사용자의 서비스 중단 없이 새로운 버전을 배포할 수 있는 무중단 배포(Blue-Green) 시스템을 프론트엔드 환경에 맞게 구축했습니다.

GitHub Actions를 이용한 자동화: * frontend/** 경로의 소스 코드 변경 시 자동으로 배포 워크플로우가 실행되도록 설정했습니다.

보안 강화를 위해 GitHub Secrets에서 환경변수(.env.production)를 동적으로 생성하여 빌드 타임에 주입합니다.

Docker 기반 빌드 및 이미지화: * Multi-stage Build를 적용하여 빌드 환경(Node.js)과 실행 환경(Nginx)을 분리함으로써 최적화된 경량 이미지를 생성합니다.

환경변수가 정적 파일에 직접 박히는 리액트의 특성을 고려하여, Docker 빌드 시점에 설정을 완료하도록 설계했습니다.

Nginx 리버스 프록시 및 포트 스위칭:

EC2 내 Nginx를 컨트롤 타워로 활용하여 **Blue(3001)**와 Green(3002) 컨테이너 사이의 트래픽을 중단 없이 전환합니다.

deploy-fe.sh 스크립트를 통해 헬스체크(Health Check) 후 설정 교체 및 리로드(Reload) 과정을 자동화했습니다.

서버 자원 최적화:

배포 성공 후 이전 버전 컨테이너를 자동으로 중지 및 삭제합니다.

docker image prune 및 builder prune 명령을 추가하여 빌드 찌꺼기와 미사용 이미지를 정리, EC2 디스크 용량을 상시 확보합니다.

---

## ⚠️ 주의 사항 / 질문

---

## ✅ 체크리스트
- [ ] 빌드가 정상적으로 되는가?
- [ ] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [ ] .gitignore에 설정 파일이 잘 포함되었는가? (application-local.yml 등)