### PR TITLE
[Feat/be#214] AI_PARSER_TUNE 로그 집계 스크립트·운영 가이드

### DIFF
--- a/tools/ai-parser-tuning/README.md
+++ b/tools/ai-parser-tuning/README.md
@@ -1,0 +1,38 @@
+# AI 파서 튜닝 로그 집계 (`[AI_PARSER_TUNE]`)
+
+`PromptRecommendationService`가 **프롬프트 원문 없이** 남기는 튜닝용 로그(`[AI_PARSER_TUNE]`)를 주기적으로 모아, 동의어·제외 키워드 YAML 보강 후보를 빠르게 찾기 위한 도구입니다.
+
+## 무엇이 집계되나
+
+- `policyVer`, `parseConfidence` 빈도
+- `ambiguityCodes`, `parserHints` 빈도
+- `signals.exclusionIntents`에 잡힌 키워드 빈도 (제외 의도 신호; 실제 `excluded` 태그로 이어지지 않은 케이스도 로그에 포함될 수 있음)
+
+## 사용법
+
+```bash
+# 샘플 자기 점검
+python3 tools/ai-parser-tuning/aggregate_parser_tune_logs.py --self-test
+
+# 최근 로그 파일에서 CSV 생성 (기본 출력: ./out/parser-tune/)
+python3 tools/ai-parser-tuning/aggregate_parser_tune_logs.py /path/to/api-server.log
+
+# 여러 파일 + 출력 디렉터리 지정
+python3 tools/ai-parser-tuning/aggregate_parser_tune_logs.py --out-dir ./reports/week12 a.log b.log
+
+# 파이프
+grep '[AI_PARSER_TUNE]' /path/to/combined.log | python3 tools/ai-parser-tuning/aggregate_parser_tune_logs.py --out-dir ./out/parser-tune
+```
+
+## 주간 운영 루프 (권장)
+
+1. **수집**: 스테이징/프로덕션에서 지난 7일 로그를보내거나, 로그 플랫폼에서 `[AI_PARSER_TUNE]`만 필터링해 파일로 저장합니다.
+2. **집계**: 위 스크립트로 `out/parser-tune/*.csv`를 생성합니다.
+3. **검토**: `exclusion_intent_keywords.csv` 상위 항목과 `parser_hints.csv` / `ambiguity_codes.csv`를 보고, `backend/...` 의 `localguest.ai.parser` YAML(팀이 쓰는 키)에 반영할 **후보 목록**을 정리합니다.
+4. **반영**: YAML 변경은 PR로 올리고, `PromptParserTest` / 필요 시 `AiRecommendationRegressionTest`를 돌려 회귀를 확인합니다.
+5. **롤백**: YAML만 되돌리면 됩니다.
+
+## 주의
+
+- 로그에 **사용자 프롬프트 전문**이 포함되지 않도록 유지합니다 (`promptHash`만 사용).
+- 스크립트는 **단순 문자열 파싱**이라, 로그 포맷이 바뀌면 함께 수정해야 합니다.

--- a/tools/ai-parser-tuning/aggregate_parser_tune_logs.py
+++ b/tools/ai-parser-tuning/aggregate_parser_tune_logs.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""
+Aggregate [AI_PARSER_TUNE] lines from application logs (stdin or files).
+
+No third-party dependencies. Intended for weekly ops tuning (synonyms / exclusion keywords).
+
+Log format is emitted by PromptRecommendationService (module-ai), e.g.:
+  [AI_PARSER_TUNE] policyVer=... promptHash=... parseConfidence=... ambiguityCodes=[...] parserHints=[...] signals={exclusionIntents=[...], budgetHint=..., durationHint=...} extracted={...}
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Iterable, TextIO
+
+
+MARKER = "[AI_PARSER_TUNE]"
+
+RE_POLICY = re.compile(r"policyVer=([^\s]+)")
+RE_CONF = re.compile(r"parseConfidence=([^\s]+)")
+
+
+def _parse_bracket_list_fragment(text: str, key: str) -> str | None:
+    """Return inner of key=[...]  (first match)."""
+    idx = text.find(key + "=[")
+    if idx < 0:
+        return None
+    start = idx + len(key) + 1  # points at '['
+    depth = 0
+    for i in range(start, len(text)):
+        c = text[i]
+        if c == "[":
+            depth += 1
+        elif c == "]":
+            depth -= 1
+            if depth == 0:
+                return text[start + 1 : i]
+    return None
+
+
+def _split_csvish(inner: str) -> list[str]:
+    inner = inner.strip()
+    if not inner:
+        return []
+    parts = []
+    for p in inner.split(","):
+        t = p.strip()
+        if t:
+            parts.append(t)
+    return parts
+
+
+def parse_tune_line(line: str) -> dict | None:
+    if MARKER not in line:
+        return None
+    pos = line.find(MARKER)
+    tail = line[pos + len(MARKER) :].strip()
+
+    m_pol = RE_POLICY.search(tail)
+    m_conf = RE_CONF.search(tail)
+    amb_inner = _parse_bracket_list_fragment(tail, "ambiguityCodes")
+    hint_inner = _parse_bracket_list_fragment(tail, "parserHints")
+
+    sig_start = tail.find("signals={")
+    excl_inner = None
+    if sig_start >= 0:
+        sig_tail = tail[sig_start:]
+        excl_inner = _parse_bracket_list_fragment(sig_tail, "exclusionIntents")
+
+    return {
+        "policyVer": m_pol.group(1) if m_pol else "",
+        "parseConfidence": m_conf.group(1) if m_conf else "",
+        "ambiguityCodes": _split_csvish(amb_inner or ""),
+        "parserHints": _split_csvish(hint_inner or ""),
+        "exclusionIntents": _split_csvish(excl_inner or ""),
+    }
+
+
+def iter_lines(files: list[Path], stdin: TextIO) -> Iterable[str]:
+    if files:
+        for path in files:
+            with path.open("r", encoding="utf-8", errors="replace") as f:
+                yield from f
+    else:
+        yield from stdin
+
+
+def write_counter_csv(path: Path, header: tuple[str, str], counter: Counter[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(header)
+        for k, v in counter.most_common():
+            w.writerow([k, v])
+
+
+def run_self_test() -> None:
+    samples = [
+        (
+            '[AI_PARSER_TUNE] policyVer=2026.04.20 promptHash=-1 parseConfidence=LOW '
+            'ambiguityCodes=[REGION_TOO_GENERIC, BUDGET_AMBIGUOUS] parserHints=[BUDGET_TOKEN_MULTISENSE] '
+            'signals={exclusionIntents=[단체, 관광버스], budgetHint=true, durationHint=false} '
+            'extracted={region=제주, style=힐링, budget=MID, durationDays=2, tags=[맛집], excluded=[], langs=[한국어], headcount=2}'
+        ),
+        (
+            '[AI_PARSER_TUNE] policyVer=2026.04.20 promptHash=42 parseConfidence=MED '
+            'ambiguityCodes=[] parserHints=[] '
+            'signals={exclusionIntents=[], budgetHint=false, durationHint=true} extracted={region=, style=, budget=, durationDays=, tags=[], excluded=[], langs=[], headcount=}'
+        ),
+    ]
+    for s in samples:
+        p = parse_tune_line(s)
+        assert p is not None, s
+        assert p["policyVer"] == "2026.04.20", p
+    first = parse_tune_line(samples[0])
+    assert first is not None
+    assert "REGION_TOO_GENERIC" in first["ambiguityCodes"]
+    assert "BUDGET_TOKEN_MULTISENSE" in first["parserHints"]
+    assert "단체" in first["exclusionIntents"]
+    print("self-test ok", file=sys.stderr)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Aggregate [AI_PARSER_TUNE] log lines.")
+    ap.add_argument(
+        "inputs",
+        nargs="*",
+        type=Path,
+        help="Log files (UTF-8). If omitted, read stdin.",
+    )
+    ap.add_argument(
+        "--out-dir",
+        type=Path,
+        default=Path("out/parser-tune"),
+        help="Directory for CSV reports (default: ./out/parser-tune)",
+    )
+    ap.add_argument("--self-test", action="store_true", help="Run embedded samples and exit.")
+    args = ap.parse_args()
+
+    if args.self_test:
+        run_self_test()
+        return 0
+
+    files: list[Path] = list(args.inputs)
+    c_policy = Counter()
+    c_conf = Counter()
+    c_amb = Counter()
+    c_hint = Counter()
+    c_excl = Counter()
+    lines_seen = 0
+    events = 0
+
+    for line in iter_lines(files, sys.stdin):
+        lines_seen += 1
+        rec = parse_tune_line(line)
+        if not rec:
+            continue
+        events += 1
+        if rec["policyVer"]:
+            c_policy[rec["policyVer"]] += 1
+        if rec["parseConfidence"]:
+            c_conf[rec["parseConfidence"]] += 1
+        for x in rec["ambiguityCodes"]:
+            c_amb[x] += 1
+        for x in rec["parserHints"]:
+            c_hint[x] += 1
+        for x in rec["exclusionIntents"]:
+            c_excl[x] += 1
+
+    out = args.out_dir
+    write_counter_csv(out / "policy_version.csv", ("policy_version", "count"), c_policy)
+    write_counter_csv(out / "parse_confidence.csv", ("parse_confidence", "count"), c_conf)
+    write_counter_csv(out / "ambiguity_codes.csv", ("ambiguity_code", "count"), c_amb)
+    write_counter_csv(out / "parser_hints.csv", ("parser_hint", "count"), c_hint)
+    write_counter_csv(out / "exclusion_intent_keywords.csv", ("keyword", "count"), c_excl)
+
+    summary = out / "summary.txt"
+    summary.parent.mkdir(parents=True, exist_ok=True)
+    with summary.open("w", encoding="utf-8") as f:
+        f.write(f"lines_read={lines_seen}\n")
+        f.write(f"ai_parser_tune_events={events}\n")
+
+    print(f"Wrote reports under {out.resolve()}", file=sys.stderr)
+    print(f"lines_read={lines_seen} events={events}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- `tools/ai-parser-tuning/aggregate_parser_tune_logs.py`: `[AI_PARSER_TUNE]` 라인을 파싱해 `policyVer`, `parseConfidence`, `ambiguityCodes`, `parserHints`, `exclusionIntents` 빈도를 CSV로 출력
- `tools/ai-parser-tuning/README.md`: 주간 운영 루프(수집→집계→YAML PR→회귀 테스트) 가이드

## Test plan
- `python3 tools/ai-parser-tuning/aggregate_parser_tune_logs.py --self-test`
- 샘플 한 줄 파이프 집계 확인
- `./gradlew :module-ai:compileJava`

Closes #214

Made with [Cursor](https://cursor.com)