### PR TITLE
Feat/be#220 /ai/recommend MockMvc 엔드포인트 회귀

### DIFF
--- a/backend/module-ai/src/test/java/com/team6/module/ai/ModuleAiWebMvcTestApplication.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/ModuleAiWebMvcTestApplication.java
@@ -1,0 +1,23 @@
+package com.team6.module.ai;
+
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+import com.team6.module.ai.controller.AiController;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * MockMvc 통합 테스트용 최소 부트 설정.
+ * 전체 패키지 스캔은 하지 않고 {@link AiController}만 등록한다.
+ */
+@SpringBootConfiguration
+@Import(AiController.class)
+@EnableAutoConfiguration(exclude = {
+        DataSourceAutoConfiguration.class,
+        HibernateJpaAutoConfiguration.class,
+        SecurityAutoConfiguration.class
+})
+public class ModuleAiWebMvcTestApplication {
+}

--- a/backend/module-ai/src/test/java/com/team6/module/ai/controller/AiRecommendEndpointMockMvcTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/controller/AiRecommendEndpointMockMvcTest.java
@@ -1,0 +1,149 @@
+package com.team6.module.ai.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team6.module.ai.dto.request.GuideRecommendRequest;
+import com.team6.module.ai.dto.request.PromptRecommendApiRequest;
+import com.team6.module.ai.dto.response.GuideRecommendItem;
+import com.team6.module.ai.dto.response.GuideRecommendResponse;
+import com.team6.module.ai.http.RecommendationHttpHeaders;
+import com.team6.module.ai.parser.PromptParser;
+import com.team6.module.ai.service.PromptRecommendationService;
+import com.team6.module.ai.support.GuideAvailabilityProvider;
+import com.team6.module.ai.support.GuideCandidateBundle;
+import com.team6.module.ai.support.GuideCandidateProvider;
+import com.team6.module.ai.ModuleAiWebMvcTestApplication;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * {@code POST /ai/recommend} HTTP·JSON·헤더 계약 회귀(Provider/단위 목과 보완).
+ */
+@SpringBootTest(classes = ModuleAiWebMvcTestApplication.class)
+@AutoConfigureMockMvc(addFilters = false)
+class AiRecommendEndpointMockMvcTest {
+
+    private static final String PV = "2026.reg.mockmvc";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private PromptRecommendationService promptRecommendationService;
+    @MockitoBean
+    private GuideCandidateProvider guideCandidateProvider;
+    @MockitoBean
+    private PromptParser promptParser;
+    @MockitoBean
+    private GuideAvailabilityProvider guideAvailabilityProvider;
+
+    @Test
+    void postRecommend_returnsJson_andPolicyHeader() throws Exception {
+        when(promptParser.extractDesiredTourDateRange(any())).thenReturn(null);
+
+        GuideRecommendRequest.GuideCandidateDto dto = GuideRecommendRequest.GuideCandidateDto.builder()
+                .guideId(7L)
+                .guideName("테스트")
+                .region("제주")
+                .guideStyle("힐링")
+                .priceLevel("중간")
+                .specialtyTags(List.of("카페"))
+                .languages(List.of("한국어"))
+                .build();
+        GuideCandidateBundle bundle = new GuideCandidateBundle(List.of(dto), List.of(dto));
+        when(guideCandidateProvider.getCandidates(eq("제주"), eq(2), isNull(), isNull(), isNull()))
+                .thenReturn(bundle);
+
+        GuideRecommendItem item = GuideRecommendItem.builder()
+                .guideId(7L)
+                .guideName("테스트")
+                .score(10)
+                .reason("r")
+                .reasonCodes(List.of("REGION"))
+                .build();
+        GuideRecommendResponse main = GuideRecommendResponse.builder()
+                .policyVersion(PV)
+                .totalCount(1)
+                .recommendations(List.of(item))
+                .build();
+        when(promptRecommendationService.recommendByPrompt(eq("제주"), eq(2), anyList())).thenReturn(main);
+        when(promptRecommendationService.recommendByPrompt(eq("제주"), eq(1), anyList())).thenReturn(main);
+
+        PromptRecommendApiRequest body = new PromptRecommendApiRequest();
+        body.setPrompt("제주");
+        body.setTopN(2);
+
+        mockMvc.perform(post("/ai/recommend")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isOk())
+                .andExpect(header().string(RecommendationHttpHeaders.X_RECOMMENDATION_POLICY, PV))
+                .andExpect(jsonPath("$.policyVersion").value(PV))
+                .andExpect(jsonPath("$.totalCount").value(1))
+                .andExpect(jsonPath("$.recommendations[0].guideId").value(7))
+                .andExpect(jsonPath("$.specialSuggestion").doesNotExist());
+    }
+
+    @Test
+    void postRecommend_serializesSpecialSuggestion_whenOrchestrationProducesIt() throws Exception {
+        when(promptParser.extractDesiredTourDateRange(any())).thenReturn(null);
+
+        LocalDate d = LocalDate.of(2026, 4, 28);
+        GuideRecommendRequest.GuideCandidateDto a = GuideRecommendRequest.GuideCandidateDto.builder()
+                .guideId(1L).guideName("A").region("제주").guideStyle("힐링").priceLevel("중간")
+                .specialtyTags(List.of("카페")).languages(List.of("한국어")).build();
+        GuideRecommendRequest.GuideCandidateDto b = GuideRecommendRequest.GuideCandidateDto.builder()
+                .guideId(2L).guideName("B").region("제주").guideStyle("힐링").priceLevel("중간")
+                .specialtyTags(List.of("카페")).languages(List.of("한국어")).build();
+        GuideCandidateBundle bundle = new GuideCandidateBundle(List.of(b), List.of(a, b));
+        when(guideCandidateProvider.getCandidates(eq("제주 힐링"), anyInt(), isNull(), eq(d), eq(d)))
+                .thenReturn(bundle);
+
+        GuideRecommendItem topMain = GuideRecommendItem.builder()
+                .guideId(2L).guideName("B").score(20).reason("r").reasonCodes(List.of("REGION")).build();
+        GuideRecommendItem topUnfiltered = GuideRecommendItem.builder()
+                .guideId(1L).guideName("A").score(30).reason("r").reasonCodes(List.of("REGION")).build();
+        GuideRecommendResponse main = GuideRecommendResponse.builder()
+                .policyVersion(PV).totalCount(1).recommendations(List.of(topMain)).build();
+        GuideRecommendResponse unfilteredTop1 = GuideRecommendResponse.builder()
+                .policyVersion(PV).totalCount(1).recommendations(List.of(topUnfiltered)).build();
+
+        when(promptRecommendationService.recommendByPrompt(eq("제주 힐링"), eq(3), anyList())).thenReturn(main);
+        when(promptRecommendationService.recommendByPrompt(eq("제주 힐링"), eq(1), anyList())).thenReturn(unfilteredTop1);
+        when(guideAvailabilityProvider.availableDates(1L, d, d)).thenReturn(List.of());
+
+        PromptRecommendApiRequest req = new PromptRecommendApiRequest();
+        req.setPrompt("제주 힐링");
+        req.setTopN(3);
+        req.setDesiredTourDateFrom(d);
+        req.setDesiredTourDateTo(d);
+
+        mockMvc.perform(post("/ai/recommend")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.specialSuggestion.guide.guideId").value(1))
+                .andExpect(jsonPath("$.specialSuggestion.notice").value("조건에 잘 부합하지만 선택한 날짜에는 예약이 있어요"));
+    }
+}


### PR DESCRIPTION
## Summary
- `ModuleAiWebMvcTestApplication`: 테스트 전용 최소 `@SpringBootConfiguration` — `AiController`만 `@Import`, JPA·Security 자동설정 제외
- `AiRecommendEndpointMockMvcTest`: `POST /ai/recommend` — 200, JSON `policyVersion`·`recommendations`, `X-Recommendation-Policy` 헤더, 특별 제시 시 `specialSuggestion` 직렬화

## Test plan
- `./gradlew :module-ai:test`
- `./gradlew :api-server:compileJava`

Closes #220

Made with [Cursor](https://cursor.com)