### PR TITLE
Fix/be#223: 매칭 API 이메일 단일 조회 오류 및 게스트 매칭 요청 UX 보완

### DIFF
--- a/backend/module-domain/src/main/java/com/team6/domain/matching/controller/MatchRequestController.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/controller/MatchRequestController.java
@@ -10,10 +10,7 @@ import com.team6.domain.matching.dto.request.MatchRequestProposeRequest;
 import com.team6.domain.matching.dto.response.MatchRequestActionResponse;
 import com.team6.domain.matching.dto.response.MatchRequestCreateResponse;
 import com.team6.domain.matching.service.MatchRequestService;
-import com.team6.domain.member.entity.Member;
-import com.team6.domain.member.entity.Role;
-import com.team6.domain.member.repository.MemberRepository;
-import com.team6.module.common.global.util.SecurityUtil;
+import com.team6.domain.matching.support.MatchingAuthenticationSupport;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -27,14 +24,14 @@ import java.util.List;
 public class MatchRequestController {
 
     private final MatchRequestService matchRequestService;
-    private final MemberRepository memberRepository;
     private final GuideProfileRepository guideProfileRepository;
+    private final MatchingAuthenticationSupport matchingAuthenticationSupport;
 
     @PostMapping
     public ResponseEntity<MatchRequestCreateResponse> createMatchRequest(
             @RequestBody @Valid MatchRequestCreateRequest request
     ) {
-        Long guestId = getCurrentMemberId(Role.GUEST);
+        Long guestId = matchingAuthenticationSupport.getCurrentGuestMemberId();
         if (!guideProfileRepository.existsById(request.getGuideId())) {
             throw new MatchingException(MatchingErrorCode.INVALID_REQUEST);
         }
@@ -50,14 +47,14 @@ public class MatchRequestController {
      */
     @GetMapping("/guest/list")
     public ResponseEntity<List<MatchRequestCreateResponse>> getGuestRequests() {
-        Long guestId = getCurrentMemberId(Role.GUEST);
+        Long guestId = matchingAuthenticationSupport.getCurrentGuestMemberId();
         return ResponseEntity.ok(matchRequestService.getGuestRequests(guestId));
     }
 
     /** 가이드 본인 매칭 요청 목록 — 경로는 {@code /guide/list} (게스트 {@code /guest/list} 와 대칭). */
     @GetMapping("/guide/list")
     public ResponseEntity<List<MatchRequestCreateResponse>> getGuideRequests() {
-        Long guideId = getCurrentGuideProfileId();
+        Long guideId = matchingAuthenticationSupport.getCurrentGuideProfileId();
         return ResponseEntity.ok(matchRequestService.getGuideRequests(guideId));
     }
 
@@ -65,7 +62,7 @@ public class MatchRequestController {
     public ResponseEntity<MatchRequestActionResponse> rejectMatchRequest(
             @PathVariable Long requestId
     ) {
-        Long guideId = getCurrentGuideProfileId();
+        Long guideId = matchingAuthenticationSupport.getCurrentGuideProfileId();
         MatchRequestActionResponse updated = matchRequestService.rejectMatchRequest(guideId, requestId);
         return ResponseEntity.ok(updated);
     }
@@ -75,7 +72,7 @@ public class MatchRequestController {
             @PathVariable Long requestId,
             @RequestBody @Valid MatchRequestProposeRequest request
     ) {
-        Long guideId = getCurrentGuideProfileId();
+        Long guideId = matchingAuthenticationSupport.getCurrentGuideProfileId();
         MatchRequestActionResponse updated = matchRequestService.proposeMatchRequest(guideId, requestId, request);
         return ResponseEntity.ok(updated);
     }
@@ -84,7 +81,7 @@ public class MatchRequestController {
     public ResponseEntity<MatchRequestActionResponse> acceptMatchRequest(
             @PathVariable Long requestId
     ) {
-        Long guestId = getCurrentMemberId(Role.GUEST);
+        Long guestId = matchingAuthenticationSupport.getCurrentGuestMemberId();
         MatchRequestActionResponse updated = matchRequestService.acceptMatchRequest(guestId, requestId);
         return ResponseEntity.ok(updated);
     }
@@ -97,7 +94,7 @@ public class MatchRequestController {
             @PathVariable Long requestId,
             @RequestBody @Valid MatchRequestDeclineRequest request
     ) {
-        Long guestId = getCurrentMemberId(Role.GUEST);
+        Long guestId = matchingAuthenticationSupport.getCurrentGuestMemberId();
         MatchRequestActionResponse updated = matchRequestService.declineMatchRequest(guestId, requestId, request);
         return ResponseEntity.ok(updated);
     }
@@ -107,7 +104,7 @@ public class MatchRequestController {
             @PathVariable Long requestId,
             @RequestBody @Valid CancelRequestDto request
     ) {
-        Long guestId = getCurrentMemberId(Role.GUEST);
+        Long guestId = matchingAuthenticationSupport.getCurrentGuestMemberId();
         MatchRequestActionResponse updated =
                 matchRequestService.cancelByGuest(guestId, requestId, request.getCancelReason());
         return ResponseEntity.ok(updated);
@@ -118,30 +115,9 @@ public class MatchRequestController {
             @PathVariable Long requestId,
             @RequestBody @Valid CancelRequestDto request
     ) {
-        Long guideId = getCurrentGuideProfileId();
+        Long guideId = matchingAuthenticationSupport.getCurrentGuideProfileId();
         MatchRequestActionResponse updated =
                 matchRequestService.cancelByGuide(guideId, requestId, request.getCancelReason());
         return ResponseEntity.ok(updated);
-    }
-
-    private Long getCurrentMemberId(Role requiredRole) {
-        String email = SecurityUtil.getCurrentUserEmail();
-        return memberRepository.findByEmail(email)
-                .map(member -> validateAndGetMemberId(member, requiredRole))
-                .orElseThrow(() -> new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED));
-    }
-
-    private Long validateAndGetMemberId(Member member, Role requiredRole) {
-        if (requiredRole != null && member.getRole() != requiredRole) {
-            throw new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED);
-        }
-        return member.getId();
-    }
-
-    private Long getCurrentGuideProfileId() {
-        Long memberId = getCurrentMemberId(Role.GUIDE);
-        return guideProfileRepository.findByMemberId(memberId)
-                .map(guideProfile -> guideProfile.getId())
-                .orElseThrow(() -> new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED));
     }
 }

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/controller/PaymentController.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/controller/PaymentController.java
@@ -1,6 +1,5 @@
 package com.team6.domain.matching.controller;
 
-import com.team6.domain.guide.repository.GuideProfileRepository;
 import com.team6.domain.matching.dto.request.PaymentConfirmRequest;
 import com.team6.domain.matching.dto.request.PaymentCreateRequest;
 import com.team6.domain.matching.dto.request.RefundRequestDto;
@@ -9,10 +8,8 @@ import com.team6.domain.matching.dto.response.RefundResponseDto;
 import com.team6.domain.matching.exception.MatchingErrorCode;
 import com.team6.domain.matching.exception.MatchingException;
 import com.team6.domain.matching.service.PaymentService;
-import com.team6.domain.member.entity.Member;
+import com.team6.domain.matching.support.MatchingAuthenticationSupport;
 import com.team6.domain.member.entity.Role;
-import com.team6.domain.member.repository.MemberRepository;
-import com.team6.module.common.global.util.SecurityUtil;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -31,8 +28,7 @@ import java.util.List;
 public class PaymentController {
 
     private final PaymentService paymentService;
-    private final MemberRepository memberRepository;
-    private final GuideProfileRepository guideProfileRepository;
+    private final MatchingAuthenticationSupport matchingAuthenticationSupport;
 
     /**
      * 게스트 본인 결제 목록 (마이페이지).
@@ -40,33 +36,31 @@ public class PaymentController {
      */
     @GetMapping("/guest/list")
     public ResponseEntity<List<PaymentResponseDto>> listGuestPayments() {
-        Long guestId = getCurrentMemberId(Role.GUEST);
+        Long guestId = matchingAuthenticationSupport.getCurrentGuestMemberId();
         return ResponseEntity.ok(paymentService.listPaymentsForGuest(guestId));
     }
 
     @PostMapping
     public ResponseEntity<PaymentResponseDto> createPayment(@RequestBody @Valid PaymentCreateRequest request) {
-        Long guestId = getCurrentMemberId(Role.GUEST);
+        Long guestId = matchingAuthenticationSupport.getCurrentGuestMemberId();
         return ResponseEntity.ok(paymentService.createPayment(guestId, request));
     }
 
     @PostMapping("/confirm")
     public ResponseEntity<PaymentResponseDto> confirmPayment(@RequestBody @Valid PaymentConfirmRequest request) {
-        Long guestId = getCurrentMemberId(Role.GUEST);
+        Long guestId = matchingAuthenticationSupport.getCurrentGuestMemberId();
         return ResponseEntity.ok(paymentService.confirmPayment(guestId, request));
     }
 
     @GetMapping("/{paymentId}")
     public ResponseEntity<PaymentResponseDto> getPayment(@PathVariable Long paymentId) {
-        Member member = memberRepository.findByEmail(SecurityUtil.getCurrentUserEmail())
-                .orElseThrow(() -> new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED));
-        if (member.getRole() == Role.GUEST) {
-            return ResponseEntity.ok(paymentService.getPaymentForGuest(member.getId(), paymentId));
+        Role tokenRole = matchingAuthenticationSupport.resolveTokenRole();
+        if (tokenRole == Role.GUEST) {
+            Long guestId = matchingAuthenticationSupport.getCurrentGuestMemberId();
+            return ResponseEntity.ok(paymentService.getPaymentForGuest(guestId, paymentId));
         }
-        if (member.getRole() == Role.GUIDE) {
-            Long guideProfileId = guideProfileRepository.findByMemberId(member.getId())
-                    .map(guideProfile -> guideProfile.getId())
-                    .orElseThrow(() -> new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED));
+        if (tokenRole == Role.GUIDE) {
+            Long guideProfileId = matchingAuthenticationSupport.getCurrentGuideProfileId();
             return ResponseEntity.ok(paymentService.getPaymentForGuide(guideProfileId, paymentId));
         }
         throw new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED);
@@ -74,21 +68,7 @@ public class PaymentController {
 
     @PostMapping("/refunds")
     public ResponseEntity<RefundResponseDto> requestRefund(@RequestBody @Valid RefundRequestDto request) {
-        Long guestId = getCurrentMemberId(Role.GUEST);
+        Long guestId = matchingAuthenticationSupport.getCurrentGuestMemberId();
         return ResponseEntity.ok(paymentService.requestGuestRefund(guestId, request));
-    }
-
-    private Long getCurrentMemberId(Role requiredRole) {
-        String email = SecurityUtil.getCurrentUserEmail();
-        return memberRepository.findByEmail(email)
-                .map(member -> validateAndGetMemberId(member, requiredRole))
-                .orElseThrow(() -> new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED));
-    }
-
-    private Long validateAndGetMemberId(Member member, Role requiredRole) {
-        if (requiredRole != null && member.getRole() != requiredRole) {
-            throw new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED);
-        }
-        return member.getId();
     }
 }

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/controller/TourExtensionController.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/controller/TourExtensionController.java
@@ -1,15 +1,9 @@
 package com.team6.domain.matching.controller;
 
-import com.team6.domain.guide.repository.GuideProfileRepository;
 import com.team6.domain.matching.dto.request.TourExtensionSelectRequest;
 import com.team6.domain.matching.dto.response.TourExtensionResponseDto;
-import com.team6.domain.matching.exception.MatchingErrorCode;
-import com.team6.domain.matching.exception.MatchingException;
 import com.team6.domain.matching.service.TourExtensionService;
-import com.team6.domain.member.entity.Member;
-import com.team6.domain.member.entity.Role;
-import com.team6.domain.member.repository.MemberRepository;
-import com.team6.module.common.global.util.SecurityUtil;
+import com.team6.domain.matching.support.MatchingAuthenticationSupport;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -26,15 +20,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class TourExtensionController {
 
     private final TourExtensionService tourExtensionService;
-    private final MemberRepository memberRepository;
-    private final GuideProfileRepository guideProfileRepository;
+    private final MatchingAuthenticationSupport matchingAuthenticationSupport;
 
     @GetMapping("/{requestId}")
     public ResponseEntity<TourExtensionResponseDto> getExtension(
             @PathVariable Long requestId
     ) {
-        Member member = getCurrentMember();
-        Long actorId = resolveActorIdForExtensionRead(member);
+        Long actorId = matchingAuthenticationSupport.resolveTourExtensionActorId();
         return ResponseEntity.ok(tourExtensionService.getByRequestId(requestId, actorId));
     }
 
@@ -44,34 +36,7 @@ public class TourExtensionController {
             @PathVariable Long requestId,
             @RequestBody @Valid TourExtensionSelectRequest request
     ) {
-        Long guestId = getCurrentMemberId(Role.GUEST);
+        Long guestId = matchingAuthenticationSupport.getCurrentGuestMemberId();
         return ResponseEntity.ok(tourExtensionService.selectByGuest(guestId, requestId, request));
-    }
-
-    private Long getCurrentMemberId(Role requiredRole) {
-        return validateAndGetMemberId(getCurrentMember(), requiredRole);
-    }
-
-    private Member getCurrentMember() {
-        String email = SecurityUtil.getCurrentUserEmail();
-        return memberRepository.findByEmail(email)
-                .map(member -> member)
-                .orElseThrow(() -> new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED));
-    }
-
-    private Long validateAndGetMemberId(Member member, Role requiredRole) {
-        if (requiredRole != null && member.getRole() != requiredRole) {
-            throw new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED);
-        }
-        return member.getId();
-    }
-
-    private Long resolveActorIdForExtensionRead(Member member) {
-        if (member.getRole() == Role.GUIDE) {
-            return guideProfileRepository.findByMemberId(member.getId())
-                    .map(guideProfile -> guideProfile.getId())
-                    .orElseThrow(() -> new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED));
-        }
-        return member.getId();
     }
 }

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/support/MatchingAuthenticationSupport.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/support/MatchingAuthenticationSupport.java
@@ -1,0 +1,99 @@
+package com.team6.domain.matching.support;
+
+import com.team6.domain.guide.repository.GuideProfileRepository;
+import com.team6.domain.matching.exception.MatchingErrorCode;
+import com.team6.domain.matching.exception.MatchingException;
+import com.team6.domain.member.entity.Member;
+import com.team6.domain.member.entity.Role;
+import com.team6.domain.member.repository.MemberRepository;
+import com.team6.module.common.global.util.SecurityUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+/**
+ * 매칭 API용 인증: JWT의 ROLE 과 DB의 (email, role) 행을 함께 맞춘다.
+ * 동일 이메일로 GUEST/GUIDE 계정이 분리된 경우 {@link MemberRepository#findByEmail(String)} 만으로는 잘못된 행이 선택될 수 있다.
+ */
+@Component
+@RequiredArgsConstructor
+public class MatchingAuthenticationSupport {
+
+    private final MemberRepository memberRepository;
+    private final GuideProfileRepository guideProfileRepository;
+
+    /**
+     * SecurityContext의 권한에서 JWT에 실린 역할을 읽는다. (예: ROLE_GUEST, ROLE_GUIDE)
+     */
+    public Role resolveTokenRole() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated()) {
+            throw new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED);
+        }
+        for (GrantedAuthority authority : auth.getAuthorities()) {
+            Role r = mapAuthorityToRole(authority.getAuthority());
+            if (r != null) {
+                return r;
+            }
+        }
+        throw new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED);
+    }
+
+    private Role mapAuthorityToRole(String authority) {
+        if (authority == null) {
+            return null;
+        }
+        return switch (authority) {
+            case "ROLE_GUEST" -> Role.GUEST;
+            case "ROLE_GUIDE" -> Role.GUIDE;
+            default -> null;
+        };
+    }
+
+    public Long getCurrentGuestMemberId() {
+        String email = SecurityUtil.getCurrentUserEmail();
+        if (resolveTokenRole() != Role.GUEST) {
+            throw new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED);
+        }
+        return memberRepository.findByEmailAndRole(email, Role.GUEST)
+                .map(Member::getId)
+                .orElseThrow(() -> new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED));
+    }
+
+    public Long getCurrentGuideProfileId() {
+        String email = SecurityUtil.getCurrentUserEmail();
+        if (resolveTokenRole() != Role.GUIDE) {
+            throw new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED);
+        }
+        Long memberId = memberRepository.findByEmailAndRole(email, Role.GUIDE)
+                .map(Member::getId)
+                .orElseThrow(() -> new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED));
+        return guideProfileRepository.findByMemberId(memberId)
+                .map(guideProfile -> guideProfile.getId())
+                .orElseThrow(() -> new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED));
+    }
+
+    /**
+     * TourExtension 조회: 게스트는 member id, 가이드는 guide_profiles id 를 반환한다.
+     */
+    public Long resolveTourExtensionActorId() {
+        String email = SecurityUtil.getCurrentUserEmail();
+        Role role = resolveTokenRole();
+        if (role == Role.GUEST) {
+            return memberRepository.findByEmailAndRole(email, Role.GUEST)
+                    .map(Member::getId)
+                    .orElseThrow(() -> new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED));
+        }
+        if (role == Role.GUIDE) {
+            Long memberId = memberRepository.findByEmailAndRole(email, Role.GUIDE)
+                    .map(Member::getId)
+                    .orElseThrow(() -> new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED));
+            return guideProfileRepository.findByMemberId(memberId)
+                    .map(guideProfile -> guideProfile.getId())
+                    .orElseThrow(() -> new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED));
+        }
+        throw new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED);
+    }
+}

--- a/frontend/src/pages/AiQuickSearchPage.jsx
+++ b/frontend/src/pages/AiQuickSearchPage.jsx
@@ -55,7 +55,7 @@ function tagsForGuide(rec, keywords) {
   return ['#로컬투어', '#맞춤동행', '#현지인']
 }
 
-function normalizeFallbackGuide(g) {
+function normalizeFallbackGuide(g, reasonText) {
   return {
     guideId: g?.guideId,
     guideName: g?.nickname ?? '가이드',
@@ -64,9 +64,58 @@ function normalizeFallbackGuide(g) {
     region: g?.region ?? '',
     averageRating: g?.averageRating ?? 0,
     reviewCount: g?.reviewCount ?? 0,
-    reason: 'AI 결과가 비어 있어 활동 중인 가이드 목록에서 추천했어요.',
+    reason:
+      reasonText ??
+      'AI 결과가 비어 있어 활동 중인 가이드 목록에서 추천했어요. (지역 키워드가 어긋나면 목록에서 가까운 가이드를 골라요.)',
     matched: { tags: [] },
   }
+}
+
+/**
+ * AI가 recommendations 를 비울 때 서버 keywords.region 과 다른 표기(경북 vs 구미 등)로 필터가 비는 것을 완화한다.
+ */
+function pickFallbackGuides(promptText, keywords, allGuides) {
+  if (!Array.isArray(allGuides) || allGuides.length === 0) return []
+  const p = String(promptText ?? '').trim()
+  const regionKw = String(keywords?.region ?? '').trim()
+
+  if (regionKw) {
+    const byKw = allGuides.filter((g) => String(g?.region ?? '').includes(regionKw))
+    if (byKw.length > 0) {
+      return byKw.map((g) =>
+        normalizeFallbackGuide(g, 'AI 추천 목록이 비어, 요청 지역에 가까운 활동 가이드를 골랐어요.'),
+      )
+    }
+  }
+
+  const tokens = p.match(/[\uAC00-\uD7A3]{2,}/g) ?? []
+  for (const tok of tokens) {
+    const hit = allGuides.filter((g) => String(g?.region ?? '').includes(tok))
+    if (hit.length > 0) {
+      return hit.map((g) =>
+        normalizeFallbackGuide(
+          g,
+          `프롬프트에 나온 「${tok}」와 가이드 활동 지역을 맞춰 추렸어요. (AI 추천은 비어 있었어요)`,
+        ),
+      )
+    }
+  }
+
+  for (const g of allGuides) {
+    const r = String(g?.region ?? '').trim()
+    if (r.length >= 2 && p.includes(r)) {
+      return [
+        normalizeFallbackGuide(
+          g,
+          '입력하신 문장과 가이드 지역이 겹쳐 후보로 보여 드려요. (AI 추천은 비어 있었어요)',
+        ),
+      ]
+    }
+  }
+
+  return allGuides
+    .slice(0, 3)
+    .map((g) => normalizeFallbackGuide(g, 'AI 추천이 비어, 활성 가이드 중에서 보여 드려요.'))
 }
 
 export function AiQuickSearchPage() {
@@ -218,14 +267,8 @@ export function AiQuickSearchPage() {
           const guideText = await guideRes.text()
           if (guideRes.ok) {
             const all = guideText ? JSON.parse(guideText) : []
-            const regionKeyword = String(data?.keywords?.region ?? '').trim()
-            const regionFiltered =
-              regionKeyword && Array.isArray(all)
-                ? all.filter((g) => String(g?.region ?? '').includes(regionKeyword))
-                : Array.isArray(all)
-                  ? all
-                  : []
-            setFallbackGuides(regionFiltered.slice(0, 2).map(normalizeFallbackGuide))
+            const picked = pickFallbackGuides(q, data?.keywords, Array.isArray(all) ? all : [])
+            setFallbackGuides(picked.slice(0, 2))
           }
         } catch {
           setFallbackGuides([])

--- a/frontend/src/pages/GuideDetailPage.jsx
+++ b/frontend/src/pages/GuideDetailPage.jsx
@@ -1,13 +1,35 @@
 import { useEffect, useState } from 'react'
-import { Link, useParams } from 'react-router-dom'
+import { Link, useParams, useLocation, useNavigate } from 'react-router-dom'
 
 import { apiRequest } from '../api/client'
+import { useAuth } from '../context/useAuth.js'
+
+/**
+ * @param {unknown} raw
+ * @returns {string}
+ */
+function formatScheduleDate(raw) {
+  if (raw == null) return ''
+  const s = String(raw)
+  return s.length >= 10 ? s.slice(0, 10) : s
+}
 
 export function GuideDetailPage() {
   const { guideId } = useParams()
+  const location = useLocation()
+  const navigate = useNavigate()
+  const { isAuthenticated, isGuide } = useAuth()
+
   const [detail, setDetail] = useState(null)
+  const [schedules, setSchedules] = useState([])
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(true)
+
+  const [selectedScheduleId, setSelectedScheduleId] = useState(null)
+  const [destination, setDestination] = useState('')
+  const [concept, setConcept] = useState('')
+  const [submitErr, setSubmitErr] = useState('')
+  const [submitting, setSubmitting] = useState(false)
 
   useEffect(() => {
     let cancelled = false
@@ -21,7 +43,28 @@ export function GuideDetailPage() {
           throw new Error(text || '조회 실패')
         }
         const data = text ? JSON.parse(text) : null
-        if (!cancelled) setDetail(data)
+        if (!cancelled) {
+          setDetail(data)
+          const p = data?.profile
+          if (p?.region) setDestination(String(p.region).trim())
+        }
+
+        const schRes = await apiRequest(`/guides/${guideId}/schedules`, { method: 'GET', skipAuth: true })
+        const schText = await schRes.text()
+        if (schRes.ok) {
+          const list = schText ? JSON.parse(schText) : []
+          const avail = Array.isArray(list)
+            ? list.filter((s) => String(s?.status ?? '') === 'AVAILABLE')
+            : []
+          if (!cancelled) {
+            setSchedules(avail)
+            if (avail.length > 0 && avail[0]?.scheduleId != null) {
+              setSelectedScheduleId(Number(avail[0].scheduleId))
+            }
+          }
+        } else if (!cancelled) {
+          setSchedules([])
+        }
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : '오류')
       } finally {
@@ -32,6 +75,79 @@ export function GuideDetailPage() {
       cancelled = true
     }
   }, [guideId])
+
+  useEffect(() => {
+    if (!loading && detail?.profile && location.hash === '#match-request') {
+      requestAnimationFrame(() => {
+        document.getElementById('match-request')?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+      })
+    }
+  }, [loading, detail, location.hash])
+
+  const onSubmitMatch = async (e) => {
+    e.preventDefault()
+    setSubmitErr('')
+    if (!isAuthenticated) {
+      setSubmitErr('로그인이 필요합니다.')
+      return
+    }
+    if (isGuide) {
+      setSubmitErr('여행자(GUEST) 계정으로 로그인한 뒤 요청해 주세요.')
+      return
+    }
+    if (selectedScheduleId == null || Number.isNaN(Number(selectedScheduleId))) {
+      setSubmitErr('예약 가능한 일정을 선택해 주세요. (가이드가 일정을 등록해야 합니다.)')
+      return
+    }
+    const dest = destination.trim()
+    if (!dest) {
+      setSubmitErr('여행 목적지(지역)를 입력해 주세요.')
+      return
+    }
+
+    const sch = schedules.find((s) => Number(s.scheduleId) === Number(selectedScheduleId))
+    const desiredDate = sch?.availableDate != null ? formatScheduleDate(sch.availableDate) : undefined
+
+    setSubmitting(true)
+    try {
+      const res = await apiRequest('/matching/requests', {
+        method: 'POST',
+        json: {
+          guideId: Number(guideId),
+          scheduleId: Number(selectedScheduleId),
+          destination: dest,
+          concept: concept.trim() || undefined,
+          desiredDate: desiredDate || undefined,
+        },
+      })
+      const t = await res.text()
+      if (res.status === 401 || res.status === 403) {
+        setSubmitErr('권한이 없거나 로그인이 만료되었습니다. 다시 로그인해 주세요.')
+        return
+      }
+      if (!res.ok) {
+        let msg = t || '요청에 실패했습니다.'
+        try {
+          const j = JSON.parse(t)
+          if (j?.message) msg = j.message
+        } catch {
+          /* ignore */
+        }
+        setSubmitErr(msg)
+        return
+      }
+      const data = t ? JSON.parse(t) : {}
+      const rid = data?.requestId
+      navigate(`/guides/${guideId}/match`, {
+        replace: false,
+        state: { requestId: rid != null ? Number(rid) : undefined },
+      })
+    } catch {
+      setSubmitErr('네트워크 오류가 발생했습니다.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
 
   if (loading) return <p>불러오는 중…</p>
   if (error) return <p style={{ color: '#b71c1c' }}>{error}</p>
@@ -52,6 +168,100 @@ export function GuideDetailPage() {
       <p style={{ fontSize: '0.85rem', color: '#777' }}>
         승인: {String(p.isApproved)} · 활성: {String(p.isActive)}
       </p>
+
+      <section
+        id="match-request"
+        style={{
+          marginTop: '2rem',
+          padding: '1.25rem',
+          border: '1px solid #e5e7eb',
+          borderRadius: 12,
+          background: '#fafafa',
+        }}
+      >
+        <h2 style={{ marginTop: 0, fontSize: '1.15rem' }}>매칭 요청하기</h2>
+        <p style={{ color: '#4b5563', fontSize: '0.95rem', lineHeight: 1.5 }}>
+          예약 가능한 일정을 고르고 목적지를 적으면 가이드에게 매칭 요청이 전달됩니다. (가이드가 일정을 아직 등록하지 않았다면
+          요청할 수 없어요.)
+        </p>
+
+        {!isAuthenticated && (
+          <p>
+            <Link
+              to="/auth/login"
+              state={{
+                returnTo: `/guides/${guideId}#match-request`,
+                hint: '로그인 후 이 가이드에게 매칭 요청을 보낼 수 있어요.',
+              }}
+            >
+              로그인하고 요청하기
+            </Link>
+          </p>
+        )}
+
+        {isAuthenticated && isGuide && (
+          <p style={{ color: '#b45309' }}>가이드 계정으로는 게스트 매칭 요청을 보낼 수 없습니다. 여행자로 로그인해 주세요.</p>
+        )}
+
+        {isAuthenticated && !isGuide && (
+          <form onSubmit={(e) => void onSubmitMatch(e)} style={{ display: 'grid', gap: '0.85rem', maxWidth: 480 }}>
+            <label style={{ display: 'grid', gap: 6 }}>
+              <span>예약 가능 일정</span>
+              {schedules.length === 0 ? (
+                <span style={{ color: '#6b7280' }}>등록된 예약 가능 일정이 없습니다. 가이드에게 일정 등록을 요청해 주세요.</span>
+              ) : (
+                <select
+                  value={selectedScheduleId ?? ''}
+                  onChange={(ev) => setSelectedScheduleId(ev.target.value ? Number(ev.target.value) : null)}
+                  required
+                >
+                  {schedules.map((s) => (
+                    <option key={s.scheduleId} value={s.scheduleId}>
+                      {formatScheduleDate(s.availableDate)} {s.startTime ?? ''} ~ {s.endTime ?? ''}
+                    </option>
+                  ))}
+                </select>
+              )}
+            </label>
+            <label style={{ display: 'grid', gap: 6 }}>
+              <span>여행 목적지 · 지역</span>
+              <input
+                type="text"
+                value={destination}
+                onChange={(ev) => setDestination(ev.target.value)}
+                placeholder="예: 구미, 경북 구미시"
+                required
+              />
+            </label>
+            <label style={{ display: 'grid', gap: 6 }}>
+              <span>하고 싶은 일 (선택)</span>
+              <textarea
+                rows={3}
+                value={concept}
+                onChange={(ev) => setConcept(ev.target.value)}
+                placeholder="예: 동네 맛집과 산책 코스를 함께하고 싶어요."
+              />
+            </label>
+            {submitErr && <p style={{ color: '#b91c1c', margin: 0 }}>{submitErr}</p>}
+            <div>
+              <button
+                type="submit"
+                disabled={submitting || schedules.length === 0}
+                style={{
+                  padding: '0.6rem 1.2rem',
+                  borderRadius: 8,
+                  border: 'none',
+                  background: '#111',
+                  color: '#fff',
+                  cursor: schedules.length === 0 ? 'not-allowed' : 'pointer',
+                }}
+              >
+                {submitting ? '전송 중…' : '매칭 요청 보내기'}
+              </button>
+            </div>
+          </form>
+        )}
+      </section>
     </div>
   )
 }

--- a/frontend/src/pages/GuideMatchOptionsPage.jsx
+++ b/frontend/src/pages/GuideMatchOptionsPage.jsx
@@ -25,6 +25,19 @@ function findLatestProposal(list, guideId) {
   return rows[0] ?? null
 }
 
+/** 제안문이 없어도, 이 가이드에 대한 최신 매칭 요청 id (결제·후기 UI 연결용) */
+function findLatestRequestForGuide(list, guideId) {
+  const gid = Number(guideId)
+  if (!Array.isArray(list)) return null
+  const rows = list.filter((r) => Number(r.guideId) === gid)
+  rows.sort((a, b) => {
+    const ta = a.createdAt ? new Date(a.createdAt).getTime() : 0
+    const tb = b.createdAt ? new Date(b.createdAt).getTime() : 0
+    return tb - ta
+  })
+  return rows[0] ?? null
+}
+
 function formatKrw(n) {
   return `₩ ${Number(n).toLocaleString('ko-KR')}`
 }
@@ -65,8 +78,12 @@ export function GuideMatchOptionsPage() {
         if (listRes.ok) {
           const lt = await listRes.text()
           const list = lt ? JSON.parse(lt) : []
-          const m = findLatestProposal(list, guideId)
-          rid = m?.requestId != null ? Number(m.requestId) : null
+          const proposed = findLatestProposal(list, guideId)
+          rid = proposed?.requestId != null ? Number(proposed.requestId) : null
+          if (rid == null) {
+            const anyReq = findLatestRequestForGuide(list, guideId)
+            rid = anyReq?.requestId != null ? Number(anyReq.requestId) : null
+          }
         }
       }
       setRequestId(rid != null && !Number.isNaN(rid) ? rid : null)

--- a/frontend/src/pages/GuideProposalPage.jsx
+++ b/frontend/src/pages/GuideProposalPage.jsx
@@ -259,7 +259,7 @@ export function GuideProposalPage() {
           </Link>
         )}
         {(matchState === 'no_match' || matchState === 'list_error') && (
-          <Link to={`/guides/${guideId}`} className="gp-btn gp-btn--primary">
+          <Link to={`/guides/${guideId}#match-request`} className="gp-btn gp-btn--primary">
             가이드 프로필에서 요청하기
           </Link>
         )}


### PR DESCRIPTION
## 🔗 이슈 번호
Closes #223 

## 💡 주요 변경 사항
- 동일 이메일 GUEST/GUIDE 분리 계정에서 **잘못된 Member 행**이 선택되던 가능성 제거.
- 매칭 결제 단건 조회 시 **토큰 역할(GUEST vs GUIDE)**에 맞는 조회 경로 사용.
- AI 추천이 비어도 **프롬프트·지역 문자열**로 활성 가이드 폴백을 더 잘 잡도록 개선.
- 프로필에서 **예약 가능 일정 + POST `/matching/requests`**로 실제 요청 가능.

## ⚠️ 주의 사항 / 질문
- JWT에 `ROLE_GUEST` / `ROLE_GUIDE`가 없는 인증 경로(OAuth만 등)에서는 매칭 API가 `MATCH_REQUEST_UNAUTHORIZED`로 떨어질 수 있음. 로컬은 **이메일+비번 로그인(JWT에 role 클레임)** 기준으로 확인함.
- 매칭 요청은 백엔드상 **AVAILABLE 스케줄**이 있어야 함. 가이드가 일정 미등록 시 버튼 비활성.

## ✅ 체크리스트
- [x] 빌드가 정상적으로 되는가? (`module-domain:compileJava` 등)
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [x] .gitignore에 설정 파일이 잘 포함되었는가? (application-local.yml 등)