### PR TITLE
Feat/be#226 module-ai F03 플로우 가이드 및 핵심 경로 주석

### DIFF
--- a/backend/module-ai/F03_FLOW_GUIDE.md
+++ b/backend/module-ai/F03_FLOW_GUIDE.md
@@ -1,0 +1,1214 @@
+# F03 AI Flow Guide
+
+이 문서는 `module-ai` 기준으로 F03 흐름을 초보자도 따라갈 수 있게 정리한 설명서다.
+
+목표는 아래 3가지다.
+
+1. `프롬프트 입력 -> AI 추천` 흐름이 어디서 시작해서 어디서 끝나는지 이해하기
+2. 각 클래스가 왜 필요한지 이해하기
+3. AI 모듈과 다른 모듈(`module-domain`, `module-chat`)의 경계를 이해하기
+
+---
+
+## 1. F03를 한 줄로 설명하면
+
+F03는 사용자가 입력한 여행 프롬프트를 해석해서, 조건에 맞는 가이드를 추천해주는 흐름이다.
+
+아주 크게 보면 이렇게 움직인다.
+
+1. 사용자가 자연어 프롬프트를 입력한다.
+2. AI 추천 API가 요청을 받는다.
+3. 서버가 추천 대상이 될 가이드 후보군을 준비한다.
+4. 프롬프트를 지역, 스타일, 예산, 활동, 언어 같은 구조화된 조건으로 바꾼다.
+5. 각 가이드 후보에게 점수를 매긴다.
+6. 추천 이유와 함께 상위 가이드를 응답으로 내려준다.
+7. 프론트는 그 결과를 카드 형태로 보여준다.
+8. 이후 사용자는 가이드를 선택하고, 매칭 요청 생성 단계로 넘어간다.
+
+즉 AI 모듈의 핵심 역할은 `추천까지`다.
+
+---
+
+## 2. 전체 흐름
+
+최신 코드 기준으로 F03 흐름은 이렇게 이해하면 된다.
+
+1. 프론트가 `POST /ai/recommend` 호출
+2. [AiController.java](src/main/java/com/team6/module/ai/controller/AiController.java) 가 요청 수신
+3. `GuideCandidateProvider`가 후보 가이드 목록 준비
+4. [PromptRecommendationService.java](src/main/java/com/team6/module/ai/service/PromptRecommendationService.java) 가 추천 전체 흐름 조립
+5. [PromptParser.java](src/main/java/com/team6/module/ai/parser/PromptParser.java) 가 프롬프트 해석
+6. 인접 지역 확장, fallback, notice 조립
+7. [AiRecommendationServiceImpl.java](src/main/java/com/team6/module/ai/service/AiRecommendationServiceImpl.java) 가 엔진 입력 형태로 변환
+8. [MatchingEngine.java](src/main/java/com/team6/module/ai/engine/MatchingEngine.java) 이 최종 추천 카드 생성
+9. [GuideRecommendResponse.java](src/main/java/com/team6/module/ai/dto/response/GuideRecommendResponse.java) 형태로 응답 반환
+
+---
+
+## 3. 초보자용 코드 읽는 순서
+
+아래 순서로 읽는 것이 가장 이해하기 쉽다.
+
+### 3-1. 1단계: 시작점 보기
+
+[AiController.java](src/main/java/com/team6/module/ai/controller/AiController.java)
+
+여기서 먼저 확인할 것:
+
+- 어떤 URL로 요청을 받는지
+- 어떤 request DTO를 받는지
+- 어떤 서비스로 넘기는지
+- 최종적으로 어떤 response를 돌려주는지
+
+초보자 관점에서는 이 파일을 `입구`라고 생각하면 된다.
+
+### 3-2. 2단계: 추천 흐름 전체 보기
+
+[PromptRecommendationService.java](src/main/java/com/team6/module/ai/service/PromptRecommendationService.java)
+
+여기서 먼저 확인할 것:
+
+- 프롬프트를 어떻게 파싱하는지
+- 지역이 없으면 왜 종료하는지
+- 인접 지역 확장은 왜 하는지
+- fallback은 왜 하는지
+- `conceptSummary`, `keywords`, `matchRequestDraft`는 왜 만드는지
+
+이 파일은 `흐름 조정자`다.
+
+### 3-3. 3단계: 프롬프트 해석 보기
+
+[PromptParser.java](src/main/java/com/team6/module/ai/parser/PromptParser.java)
+
+여기서 먼저 확인할 것:
+
+- 지역 추출
+- 예산 추출
+- 스타일 추출
+- 활동 태그 추출
+- 언어 추출
+- 기간/날짜 추출
+- 제외 태그 / soft penalty 태그 추출
+
+이 파일은 `자연어 -> 구조화 데이터 변환기`다.
+
+### 3-4. 4단계: 후보 가이드가 어디서 오는지 보기
+
+[DbBackedGuideCandidateProvider.java](../module-ai-integration/src/main/java/com/team6/integration/ai/DbBackedGuideCandidateProvider.java)
+
+여기서 먼저 확인할 것:
+
+- 프론트에서 후보를 안 보내면 어떻게 하는지
+- DB에서 어떤 가이드를 읽어오는지
+- 일정 필터가 어떻게 걸리는지
+- `GuideCandidateBundle`이 왜 필요한지
+
+이 클래스는 `추천 엔진이 비교할 후보군을 만드는 담당자`다.
+
+### 3-5. 5단계: 엔진 입력으로 바꾸는 부분 보기
+
+[AiRecommendationServiceImpl.java](src/main/java/com/team6/module/ai/service/AiRecommendationServiceImpl.java)
+
+[AiRecommendationMapper.java](src/main/java/com/team6/module/ai/support/AiRecommendationMapper.java)
+
+여기서 먼저 확인할 것:
+
+- `GuideRecommendRequest`를 `TravelerPreference`로 어떻게 바꾸는지
+- 후보 DTO를 `GuideAiProfile`로 어떻게 바꾸는지
+
+이 단계는 `API/파서 결과 -> 엔진 전용 모델` 변환 단계다.
+
+### 3-6. 6단계: 추천 카드가 만들어지는 곳 보기
+
+[MatchingEngine.java](src/main/java/com/team6/module/ai/engine/MatchingEngine.java)
+
+여기서 먼저 확인할 것:
+
+- 각 후보에게 점수를 어떻게 매기는지
+- 추천 이유를 어떻게 만드는지
+- 왜 diversity penalty를 쓰는지
+- `GuideRecommendItem`이 어떻게 만들어지는지
+
+이 파일은 `최종 추천 엔진`이다.
+
+### 3-7. 7단계: 점수 계산 세부 보기
+
+[ScoreCalculator.java](src/main/java/com/team6/module/ai/engine/ScoreCalculator.java)
+
+정책 클래스들:
+
+- [RegionMatchPolicy.java](src/main/java/com/team6/module/ai/policy/RegionMatchPolicy.java)
+- [StyleMatchPolicy.java](src/main/java/com/team6/module/ai/policy/StyleMatchPolicy.java)
+- [BudgetMatchPolicy.java](src/main/java/com/team6/module/ai/policy/BudgetMatchPolicy.java)
+- [ActivityMatchPolicy.java](src/main/java/com/team6/module/ai/policy/ActivityMatchPolicy.java)
+- [LanguageMatchPolicy.java](src/main/java/com/team6/module/ai/policy/LanguageMatchPolicy.java)
+- [FeedbackMatchPolicy.java](src/main/java/com/team6/module/ai/policy/FeedbackMatchPolicy.java)
+
+이 단계는 `왜 이 가이드가 몇 점인지`를 이해하는 단계다.
+
+---
+
+## 4. 핵심 클래스별 역할
+
+### AiController
+
+역할:
+
+- API 요청 받기
+- 날짜 범위 확정
+- 후보 가이드 번들 조회
+- 메인 추천 실행
+- specialSuggestion 조립
+- 최종 응답 반환
+
+쉽게 말하면 `입구 + 최상위 조립`이다.
+
+### PromptRecommendationService
+
+역할:
+
+- 프롬프트 파싱
+- 지역 검증
+- 후보 확장
+- 추천 1차 실행
+- 전략적 fallback
+- notice / noticeCodes / confidence 생성
+- `conceptSummary`, `keywords`, `matchRequestDraft` 생성
+
+쉽게 말하면 `추천 흐름 조정자`다.
+
+### PromptParser
+
+역할:
+
+- 자유로운 자연어를 규칙 기반으로 해석
+- 사용자의 의도를 구조화된 필드로 추출
+
+쉽게 말하면 `번역기`다.
+
+### DbBackedGuideCandidateProvider
+
+역할:
+
+- DB에서 후보 가이드 목록 만들기
+- 일정 충돌 가이드 걸러내기
+- 비필터 후보도 따로 보관해서 specialSuggestion 지원
+
+쉽게 말하면 `비교 대상 준비 담당자`다.
+
+### AiRecommendationServiceImpl
+
+역할:
+
+- 파서 결과를 엔진이 이해하는 모델로 변환
+- `MatchingEngine` 호출
+
+쉽게 말하면 `중간 어댑터`다.
+
+### MatchingEngine
+
+역할:
+
+- 후보별 점수 계산
+- 이유 생성
+- 다양성 보정
+- 추천 카드 DTO 생성
+
+쉽게 말하면 `최종 추천 결과 생산기`다.
+
+### ScoreCalculator
+
+역할:
+
+- 각 정책 점수 합산
+
+쉽게 말하면 `채점기`다.
+
+---
+
+## 5. request와 response를 쉽게 이해하기
+
+### 입력 request
+
+주요 입력은 [PromptRecommendApiRequest.java](src/main/java/com/team6/module/ai/dto/request/PromptRecommendApiRequest.java) 다.
+
+중요 필드:
+
+- `prompt`: 사용자의 자연어 요청
+- `topN`: 몇 명 추천할지
+- `guideCandidates`: 선택적 후보 목록
+- `desiredTourDate`, `desiredTourDateFrom`, `desiredTourDateTo`: 일정 필터용 날짜
+
+실서비스에서는 보통 `prompt` 중심으로 쓰고, 후보는 서버가 채운다.
+
+### 내부 request
+
+[GuideRecommendRequest.java](src/main/java/com/team6/module/ai/dto/request/GuideRecommendRequest.java)
+
+이건 파싱 이후 추천 엔진에 넘기기 위한 내부 구조다.
+
+예:
+
+- `region`
+- `travelStyle`
+- `budgetLevel`
+- `activityTags`
+- `preferredLanguages`
+- `durationDays`
+- `excludedActivityTags`
+- `softPenaltyActivityTags`
+
+### 최종 response
+
+[GuideRecommendResponse.java](src/main/java/com/team6/module/ai/dto/response/GuideRecommendResponse.java)
+
+주요 필드:
+
+- `conceptSummary`
+- `keywords`
+- `matchRequestDraft`
+- `notice`
+- `noticeCodes`
+- `policyVersion`
+- `recommendations`
+- `specialSuggestion`
+
+### 추천 카드 1장
+
+[GuideRecommendItem.java](src/main/java/com/team6/module/ai/dto/response/GuideRecommendItem.java)
+
+주요 필드:
+
+- `guideId`
+- `guideName`
+- `representativeImageUrl`
+- `region`
+- `priceLevel`
+- `averageRating`
+- `reviewCount`
+- `publicFeedThumbnailUrls`
+- `score`
+- `reason`
+- `reasonCodes`
+- `matched`
+
+즉 프론트는 이 객체만으로도 추천 카드 UI를 꽤 많이 그릴 수 있다.
+
+---
+
+## 6. F03에서 AI 모듈이 실제로 하는 일
+
+현재 코드 기준으로 AI 모듈이 직접 하는 일은 여기까지다.
+
+1. 프롬프트 해석
+2. 후보군 준비 요청
+3. 후보 점수 계산
+4. 추천 이유 생성
+5. 추천 카드 응답 생성
+6. 매칭 요청 화면용 draft 생성
+
+반대로 AI 모듈이 직접 하지 않는 일은 이렇다.
+
+- 가이드 피드 절반 공개
+- 매칭 요청 저장
+- 가이드 제안 수락/거절 처리
+- 결제 처리
+- 채팅방 관리
+
+이건 다른 모듈이 맡는다.
+
+---
+
+## 7. AI 모듈과 다른 모듈의 경계
+
+### module-ai
+
+담당:
+
+- 프롬프트 해석
+- 추천 점수 계산
+- 추천 응답 생성
+
+### module-ai-integration
+
+담당:
+
+- 도메인 DB 데이터를 AI 후보 DTO로 연결
+- DB 기반 후보 제공
+
+### module-domain
+
+담당:
+
+- 가이드 피드 조회
+- 매칭 요청 생성
+- 가이드 제안
+- 게스트 수락/거절
+
+### module-chat
+
+담당:
+
+- 채팅방 생성/조회
+- 채팅 메시지 처리
+
+즉 이 프로젝트는 `AI가 전부 다 하는 구조`가 아니라, `추천은 AI`, `거래/상태 변경은 domain`, `대화는 chat`으로 나눠져 있다.
+
+---
+
+## 8. specialSuggestion이란?
+
+최신 코드에서는 메인 추천과 별도로 `specialSuggestion`이 있다.
+
+이건 이런 경우를 위한 기능이다.
+
+- 조건은 매우 잘 맞는 가이드가 있음
+- 그런데 사용자가 고른 날짜에는 이미 예약이 있음
+- 메인 추천에서는 빠짐
+- 대신 “일정만 아니면 추천됐을 가이드”를 별도 카드로 보여줌
+
+즉:
+
+- `recommendations` = 지금 바로 추천 가능한 가이드
+- `specialSuggestion` = 조건은 맞지만 일정 때문에 메인 추천에서 빠진 가이드
+
+---
+
+## 9. fallback은 왜 필요한가?
+
+사용자가 프롬프트를 너무 빡세게 쓰면 결과가 0개가 될 수 있다.
+
+예:
+
+- 지역도 정확함
+- 스타일도 요구
+- 활동도 많이 요구
+- 언어도 요구
+- 후보 수는 적음
+
+이럴 때 그냥 빈 결과를 반환하면 UX가 안 좋다.
+
+그래서 현재는 전략적으로 순서대로 완화한다.
+
+1. 활동 태그 완화
+2. 스타일 완화
+3. 지역 완화
+
+단, 언어는 중요도가 높다고 보고 유지한다.
+
+즉 fallback은 `추천 실패를 줄이기 위한 안전장치`다.
+
+---
+
+## 10. 현재 F03 구현 상태를 실무적으로 보면
+
+현재 기준으로 F03의 추천 핵심은 거의 구현돼 있다.
+
+구현된 것:
+
+- 프롬프트 입력
+- 추천 API
+- 파서 고도화
+- 후보 DB 조회
+- 점수 계산
+- 이유 생성
+- 카드용 응답 정보
+- 매칭 요청 draft 생성
+- specialSuggestion
+
+부분 구현 또는 외부 연계 의존:
+
+- 추천 결과 -> 실제 매칭 요청 생성은 프론트 연결 필요
+- 게스트 최종 수락 후 자동 채팅방 생성은 AI 모듈 범위 밖
+
+즉 AI 모듈 관점에서는 F03의 추천 파이프라인은 상당히 완성된 편이다.
+
+---
+
+## 11. F03를 공부할 때 추천하는 읽기 방식
+
+처음엔 코드 전체를 다 이해하려 하지 말고, 아래 방식으로 보자.
+
+### 1차 읽기
+
+- `AiController`
+- `PromptRecommendationService`
+- `MatchingEngine`
+
+목표:
+
+- 전체 큰 흐름 잡기
+
+### 2차 읽기
+
+- `PromptParser`
+- `DbBackedGuideCandidateProvider`
+- `AiRecommendationMapper`
+
+목표:
+
+- 입력이 어떻게 구조화되고 후보가 어떻게 들어오는지 이해
+
+### 3차 읽기
+
+- `ScoreCalculator`
+- 정책 클래스들
+- `ReasonGenerator`
+
+목표:
+
+- 왜 이 가이드가 추천됐는지 이해
+
+---
+
+## 12. 한 줄 최종 요약
+
+F03 AI 모듈은 `사용자 프롬프트를 해석하고, 비교할 가이드 후보를 준비한 뒤, 점수를 계산해서 추천 카드와 후속 매칭용 요약 정보를 내려주는 추천 엔진`이다.
+
+---
+
+## 13. F03-01 ~ F03-06 단계별 매핑
+
+| 단계 | 의미 | 관련 API | 주요 클래스 | 현재 상태 | 비고 |
+| --- | --- | --- | --- | --- | --- |
+| F03-01 | 사용자가 AI 추천용 여행 프롬프트 입력 | `POST /ai/recommend` | [AiController.java](src/main/java/com/team6/module/ai/controller/AiController.java), [PromptRecommendApiRequest.java](src/main/java/com/team6/module/ai/dto/request/PromptRecommendApiRequest.java) | 구현 | 프롬프트, `topN`, 날짜 필드 등을 함께 받을 수 있음 |
+| F03-02 | 프롬프트 해석 후 가이드 추천 결과 생성 | `POST /ai/recommend` 내부 처리 | [PromptRecommendationService.java](src/main/java/com/team6/module/ai/service/PromptRecommendationService.java), [PromptParser.java](src/main/java/com/team6/module/ai/parser/PromptParser.java), [DbBackedGuideCandidateProvider.java](../module-ai-integration/src/main/java/com/team6/integration/ai/DbBackedGuideCandidateProvider.java), [MatchingEngine.java](src/main/java/com/team6/module/ai/engine/MatchingEngine.java) | 구현 | 추천 카드, 이유, `conceptSummary`, `matchRequestDraft`, `specialSuggestion`까지 생성 |
+| F03-03 | 추천된 가이드 상세/피드 일부 공개 확인 | `GET /guides/{guideId}/feeds?isMatched=false` | [GuideFeedController.java](../module-domain/src/main/java/com/team6/domain/guide/controller/GuideFeedController.java), [GuideFeedService.java](../module-domain/src/main/java/com/team6/domain/guide/service/GuideFeedService.java) | 구현 | 매칭 전에는 절반 공개, 매칭 후에는 전체 공개 |
+| F03-04 | 게스트가 특정 가이드에게 매칭 요청 생성 | `POST /matching/requests` | [MatchRequestController.java](../module-domain/src/main/java/com/team6/domain/matching/controller/MatchRequestController.java), [MatchRequestService.java](../module-domain/src/main/java/com/team6/domain/matching/service/MatchRequestService.java) | 구현 | AI 응답의 `matchRequestDraft`를 프론트가 읽어 요청 폼 기본값으로 활용 가능 |
+| F03-05 | 가이드가 제시안(일정/메시지) 등록 | `PATCH /matching/requests/{requestId}/propose` | [MatchRequestController.java](../module-domain/src/main/java/com/team6/domain/matching/controller/MatchRequestController.java), [MatchRequestService.java](../module-domain/src/main/java/com/team6/domain/matching/service/MatchRequestService.java) | 구현 | `proposedSchedule`, `proposeMessage` 저장, 상태는 `ACCEPTED` 계열로 이동 |
+| F03-06 | 게스트가 가이드 제안을 최종 수락 또는 거절 | `PATCH /matching/requests/{requestId}/accept`, `PATCH /matching/requests/{requestId}/decline` | [MatchRequestController.java](../module-domain/src/main/java/com/team6/domain/matching/controller/MatchRequestController.java), [MatchRequestService.java](../module-domain/src/main/java/com/team6/domain/matching/service/MatchRequestService.java) | 부분 구현 | 수락/거절 API는 있으나, 최종 수락 직후 채팅방 자동 생성까지는 아직 직접 연결되어 있지 않음 |
+
+### 단계별로 아주 짧게 보면
+
+- `F03-01 ~ F03-02`는 주로 `module-ai`, `module-ai-integration`
+- `F03-03 ~ F03-06`은 주로 `module-domain`
+- 이후 채팅/실시간 대화는 `module-chat`
+
+즉 F03 전체는 하나의 모듈이 다 맡는 게 아니라, 추천과 매칭 진행이 분리된 구조다.
+
+---
+
+## 14. 실제 API 호출 예시
+
+아래 예시는 프론트가 F03 흐름을 따라갈 때 어떻게 호출할 수 있는지 보여주는 샘플이다.
+
+### 14-1. AI 추천 요청
+
+```http
+POST /ai/recommend
+Content-Type: application/json
+Authorization: Bearer <token>
+```
+
+```json
+{
+  "prompt": "제주에서 2박3일 동안 친구랑 가는데 바다랑 카페 위주로 조용하게 여행하고 싶어요. 술집은 말고 영어 가능한 가이드면 좋겠어요.",
+  "topN": 3,
+  "desiredTourDateFrom": "2026-04-20",
+  "desiredTourDateTo": "2026-04-22"
+}
+```
+
+응답 예시 요약:
+
+```json
+{
+  "conceptSummary": "[제주] 3일, 친구 · 활동: 바다/카페",
+  "matchRequestDraft": {
+    "destination": "제주",
+    "conceptSummary": "[제주] 3일, 친구 · 활동: 바다/카페",
+    "budgetHint": "중간",
+    "durationDays": 3,
+    "activityTags": ["바다", "카페"],
+    "preferredLanguages": ["영어"]
+  },
+  "recommendations": [
+    {
+      "guideId": 12,
+      "guideName": "제주바다가이드",
+      "representativeImageUrl": "https://...",
+      "region": "제주",
+      "priceLevel": "중간",
+      "averageRating": 4.8,
+      "reviewCount": 31,
+      "publicFeedThumbnailUrls": ["https://...", "https://..."],
+      "score": 74,
+      "reason": "희망 지역과 일치하고 바다/카페 취향이 잘 맞아요."
+    }
+  ],
+  "specialSuggestion": null
+}
+```
+
+### 14-2. 추천 가이드 피드 절반 공개 조회
+
+```http
+GET /guides/12/feeds?isMatched=false
+Authorization: Bearer <token>
+```
+
+응답 예시 요약:
+
+```json
+[
+  {
+    "id": 101,
+    "content": "제주 바다 카페 코스",
+    "imageUrl": "https://...",
+    "locked": false
+  },
+  {
+    "id": 102,
+    "content": null,
+    "imageUrl": null,
+    "locked": true
+  }
+]
+```
+
+### 14-3. 매칭 요청 생성
+
+AI 추천 응답의 `matchRequestDraft`와 사용자가 선택한 `guideId`를 조합해서 보낼 수 있다.
+
+```http
+POST /matching/requests
+Content-Type: application/json
+Authorization: Bearer <token>
+```
+
+```json
+{
+  "guideId": 12,
+  "destination": "제주",
+  "concept": "제주에서 2박3일 동안 친구랑 바다랑 카페 위주로 조용한 여행",
+  "conceptSummary": "[제주] 3일, 친구 · 활동: 바다/카페",
+  "desiredDate": "2026-04-20",
+  "desiredBudget": 200000
+}
+```
+
+### 14-4. 가이드 제시안 등록
+
+```http
+PATCH /matching/requests/55/propose
+Content-Type: application/json
+Authorization: Bearer <guide-token>
+```
+
+```json
+{
+  "proposedSchedule": "1일차 바다 산책 및 카페, 2일차 로컬 맛집, 3일차 감성 포토 스팟",
+  "proposeMessage": "조용한 동선 위주로 맞춰봤어요."
+}
+```
+
+### 14-5. 게스트 최종 수락
+
+```http
+PATCH /matching/requests/55/accept
+Authorization: Bearer <guest-token>
+```
+
+### 14-6. 게스트 최종 거절
+
+```http
+PATCH /matching/requests/55/decline
+Content-Type: application/json
+Authorization: Bearer <guest-token>
+```
+
+```json
+{
+  "reason": "일정이 맞지 않아서 이번에는 진행하지 않을게요."
+}
+```
+
+### 14-7. 가이드가 받은 요청 목록 조회
+
+```http
+GET /matching/requests/guides/me
+Authorization: Bearer <guide-token>
+```
+
+이 응답 안에서 `conceptSummary`, `desiredDate`, `desiredBudget` 등을 보고 가이드가 제안을 준비한다.
+
+---
+
+## 15. 자주 헷갈리는 DTO 관계도
+
+F03를 보다 보면 `request`, `candidate`, `profile`, `response`, `draft` 이름이 비슷해서 자주 헷갈린다.
+
+아래처럼 단계별로 나눠서 보면 이해가 쉽다.
+
+### 15-1. 가장 큰 그림
+
+```text
+프론트 요청 JSON
+  -> PromptRecommendApiRequest
+  -> PromptParser
+  -> GuideRecommendRequest
+  -> AiRecommendationMapper
+  -> TravelerPreference / GuideAiProfile
+  -> MatchingEngine
+  -> GuideRecommendItem
+  -> GuideRecommendResponse
+  -> 프론트 추천 카드 UI
+  -> matchRequestDraft 재사용
+  -> MatchRequestCreateRequest
+```
+
+즉 DTO가 한 개만 있는 게 아니라,
+
+- API 입구용 DTO
+- 추천 계산용 내부 DTO
+- 엔진용 모델
+- API 응답 DTO
+- 매칭 요청용 DTO
+
+이렇게 역할별로 나뉘어 있다.
+
+### 15-2. API 입구 DTO
+
+[PromptRecommendApiRequest.java](src/main/java/com/team6/module/ai/dto/request/PromptRecommendApiRequest.java)
+
+역할:
+
+- 프론트가 `/ai/recommend` 호출할 때 보내는 입력값을 받음
+
+주요 필드:
+
+- `prompt`
+- `topN`
+- `guideCandidates`
+- `desiredTourDate`
+- `desiredTourDateFrom`
+- `desiredTourDateTo`
+
+헷갈리기 쉬운 포인트:
+
+- 이 객체는 `프론트 요청 원본`이다.
+- 아직 추천 계산용으로 정리된 상태가 아니다.
+
+### 15-3. 추천 계산용 내부 DTO
+
+[GuideRecommendRequest.java](src/main/java/com/team6/module/ai/dto/request/GuideRecommendRequest.java)
+
+역할:
+
+- `PromptParser`가 프롬프트를 해석한 뒤 만드는 내부 추천 요청 객체
+
+주요 필드:
+
+- `region`
+- `travelStyle`
+- `budgetLevel`
+- `companionType`
+- `activityTags`
+- `preferredLanguages`
+- `headcount`
+- `durationDays`
+- `excludedActivityTags`
+- `softPenaltyActivityTags`
+- `guideCandidates`
+
+헷갈리기 쉬운 포인트:
+
+- 이름에 `Request`가 들어가지만, 프론트가 직접 보내는 API request와는 다르다.
+- 이건 `추천 엔진에 넘기기 위한 내부 구조`다.
+
+### 15-4. 후보 가이드 DTO
+
+[GuideRecommendRequest.GuideCandidateDto](src/main/java/com/team6/module/ai/dto/request/GuideRecommendRequest.java)
+
+역할:
+
+- 추천 비교 대상이 되는 가이드 1명의 요약 프로필
+
+주요 필드:
+
+- `guideId`
+- `guideName`
+- `region`
+- `guideStyle`
+- `priceLevel`
+- `specialtyTags`
+- `languages`
+- `averageRating`
+- `reviewCount`
+- `approvedRefundCount`
+- `matchRequestCount`
+- `progressedMatchCount`
+- `chatStartCount`
+
+어디서 만들어지나:
+
+- 보통 [DbBackedGuideCandidateProvider.java](../module-ai-integration/src/main/java/com/team6/integration/ai/DbBackedGuideCandidateProvider.java)
+- 내부적으로 [GuideProfileAiCandidateMapper.java](../module-ai-integration/src/main/java/com/team6/integration/ai/GuideProfileAiCandidateMapper.java) 를 거침
+
+헷갈리기 쉬운 포인트:
+
+- 이건 도메인 엔티티 `GuideProfile` 자체가 아니다.
+- 엔진에 넘기기 좋게 정제된 `후보용 DTO`다.
+
+### 15-5. 엔진용 모델
+
+[TravelerPreference.java](src/main/java/com/team6/module/ai/model/TravelerPreference.java)
+
+[GuideAiProfile.java](src/main/java/com/team6/module/ai/model/GuideAiProfile.java)
+
+역할:
+
+- `MatchingEngine`가 직접 사용하는 모델
+
+변환 담당:
+
+- [AiRecommendationMapper.java](src/main/java/com/team6/module/ai/support/AiRecommendationMapper.java)
+
+헷갈리기 쉬운 포인트:
+
+- `GuideCandidateDto`와 `GuideAiProfile`은 비슷해 보이지만 다르다.
+- `GuideCandidateDto`는 API/서비스 경계 쪽 DTO
+- `GuideAiProfile`은 엔진 내부 모델
+
+즉 관계는 이렇다.
+
+```text
+GuideCandidateDto -> GuideAiProfile
+GuideRecommendRequest -> TravelerPreference
+```
+
+### 15-6. 추천 카드 DTO
+
+[GuideRecommendItem.java](src/main/java/com/team6/module/ai/dto/response/GuideRecommendItem.java)
+
+역할:
+
+- 프론트가 카드 UI를 그릴 때 사용하는 추천 결과 1건
+
+주요 필드:
+
+- `guideId`
+- `guideName`
+- `representativeImageUrl`
+- `region`
+- `priceLevel`
+- `averageRating`
+- `reviewCount`
+- `publicFeedThumbnailUrls`
+- `score`
+- `reason`
+- `reasonCodes`
+- `reasonFacts`
+- `matched`
+
+헷갈리기 쉬운 포인트:
+
+- 이건 `후보 가이드 DTO`가 아니다.
+- 점수 계산과 이유 생성이 끝난 `최종 추천 카드`다.
+
+### 15-7. 최종 응답 DTO
+
+[GuideRecommendResponse.java](src/main/java/com/team6/module/ai/dto/response/GuideRecommendResponse.java)
+
+역할:
+
+- `/ai/recommend`의 최종 응답 전체
+
+주요 필드:
+
+- `conceptSummary`
+- `keywords`
+- `matchRequestDraft`
+- `notice`
+- `noticeCodes`
+- `promptParseConfidence`
+- `policyVersion`
+- `recommendations`
+- `specialSuggestion`
+
+즉 관계는:
+
+```text
+GuideRecommendResponse
+  └─ recommendations: List<GuideRecommendItem>
+```
+
+### 15-8. 매칭 요청 연결용 draft DTO
+
+[GuideRecommendResponse.MatchRequestDraft](src/main/java/com/team6/module/ai/dto/response/GuideRecommendResponse.java)
+
+역할:
+
+- AI 추천 응답을 매칭 요청 생성 화면으로 자연스럽게 넘기기 위한 초안 데이터
+
+주요 필드:
+
+- `destination`
+- `concept`
+- `conceptSummary`
+- `budgetHint`
+- `headcount`
+- `durationDays`
+- `travelStyle`
+- `companionType`
+- `activityTags`
+- `excludedActivityTags`
+- `preferredLanguages`
+
+헷갈리기 쉬운 포인트:
+
+- 이건 실제 매칭 요청 저장 DTO가 아니다.
+- 프론트가 읽어서 `MatchRequestCreateRequest`로 옮겨 담기 쉽게 만든 중간 재료다.
+
+즉 관계는:
+
+```text
+GuideRecommendResponse.matchRequestDraft
+  -> 프론트가 읽음
+  -> MatchRequestCreateRequest 로 매핑
+```
+
+### 15-9. 실제 매칭 요청 DTO
+
+[MatchRequestCreateRequest.java](../module-domain/src/main/java/com/team6/domain/matching/dto/request/MatchRequestCreateRequest.java)
+
+역할:
+
+- `/matching/requests` 생성 API가 실제로 받는 DTO
+
+주요 필드:
+
+- `guideId`
+- `destination`
+- `concept`
+- `conceptSummary`
+- `desiredDate`
+- `desiredBudget`
+
+헷갈리기 쉬운 포인트:
+
+- AI 응답 안의 `matchRequestDraft`와 완전히 같은 객체가 아니다.
+- 프론트가 필요한 값만 골라서 최종 요청으로 다시 조립해야 한다.
+
+---
+
+## 16. DTO 관계를 한 번에 보면
+
+```text
+[프론트 입력]
+PromptRecommendApiRequest
+
+    |
+    v
+
+[파서 결과 / 내부 추천 요청]
+GuideRecommendRequest
+  └─ GuideCandidateDto
+
+    |
+    v
+
+[엔진 전용 모델]
+TravelerPreference
+GuideAiProfile
+
+    |
+    v
+
+[추천 결과 카드]
+GuideRecommendItem
+
+    |
+    v
+
+[최종 AI 응답]
+GuideRecommendResponse
+  ├─ recommendations: List<GuideRecommendItem>
+  └─ matchRequestDraft
+
+    |
+    v
+
+[프론트가 재조립]
+MatchRequestCreateRequest
+```
+
+이 흐름만 기억해도 DTO가 왜 여러 개 있는지 훨씬 덜 헷갈린다.
+
+---
+
+## 17. 클래스 관계도
+
+이번에는 DTO가 아니라 `클래스가 서로 어떻게 연결되는지`를 본다.
+
+즉 "누가 누구를 호출하는가?"를 따라가는 섹션이다.
+
+### 17-1. 가장 큰 클래스 흐름
+
+```text
+AiController
+  -> GuideCandidateProvider
+      -> DbBackedGuideCandidateProvider
+          -> GuideProfileRepository
+          -> GuideFeedRepository
+          -> GuideCareerRepository
+          -> MatchRequestRepository
+          -> RefundRepository
+          -> ChatRoomRepository
+          -> GuideProfileAiCandidateMapper
+  -> PromptRecommendationService
+      -> PromptParser
+      -> RegionCandidateExpansion
+      -> AiRecommendationService
+          -> AiRecommendationServiceImpl
+              -> AiRecommendationMapper
+              -> MatchingEngine
+                  -> ScoreCalculator
+                      -> RegionMatchPolicy
+                      -> StyleMatchPolicy
+                      -> BudgetMatchPolicy
+                      -> ActivityMatchPolicy
+                      -> LanguageMatchPolicy
+                      -> FeedbackMatchPolicy
+                  -> ReasonGenerator
+```
+
+이 그림이 F03 추천 핵심 구조다.
+
+### 17-2. 가장 바깥쪽 입구
+
+[AiController.java](src/main/java/com/team6/module/ai/controller/AiController.java)
+
+역할:
+
+- API 요청 받기
+- 후보군 준비
+- 추천 실행
+- specialSuggestion 조립
+- 최종 응답 반환
+
+즉 클래스 관계의 시작점은 항상 `AiController`다.
+
+### 17-3. 후보군 준비 라인
+
+```text
+AiController
+  -> GuideCandidateProvider
+      -> DbBackedGuideCandidateProvider
+          -> PromptParser
+          -> 각종 Repository
+          -> GuideProfileAiCandidateMapper
+```
+
+설명:
+
+- `AiController`는 인터페이스인 `GuideCandidateProvider`만 안다.
+- 실제 기본 구현은 `DbBackedGuideCandidateProvider`
+- 여기서 DB에서 가이드 후보를 읽고 AI 후보 DTO로 만든다.
+
+즉 이 라인은 `추천 대상 만들기` 라인이다.
+
+### 17-4. 추천 흐름 조립 라인
+
+```text
+AiController
+  -> PromptRecommendationService
+      -> PromptParser
+      -> RegionCandidateExpansion
+      -> AiRecommendationService
+```
+
+설명:
+
+- `PromptRecommendationService`는 추천의 전체 순서를 관리한다.
+- 프롬프트를 파싱하고
+- 지역이 부족하면 인접 지역을 확장하고
+- 필요하면 fallback을 돌리고
+- 최종 응답을 조립한다.
+
+즉 이 라인은 `추천 흐름 관리` 라인이다.
+
+### 17-5. 엔진 호출 라인
+
+```text
+PromptRecommendationService
+  -> AiRecommendationServiceImpl
+      -> AiRecommendationMapper
+      -> MatchingEngine
+```
+
+설명:
+
+- `AiRecommendationServiceImpl`은 엔진 바로 앞 단계의 어댑터다.
+- 파서 결과를 엔진용 모델로 바꾸고
+- `MatchingEngine`을 호출한다.
+
+즉 이 라인은 `엔진에 넣기 전 변환` 라인이다.
+
+### 17-6. 점수 계산 라인
+
+```text
+MatchingEngine
+  -> ScoreCalculator
+      -> RegionMatchPolicy
+      -> StyleMatchPolicy
+      -> BudgetMatchPolicy
+      -> ActivityMatchPolicy
+      -> LanguageMatchPolicy
+      -> FeedbackMatchPolicy
+```
+
+설명:
+
+- `MatchingEngine`은 각 가이드에게 점수를 매겨야 하므로
+- `ScoreCalculator`에 계산을 맡긴다
+- `ScoreCalculator`는 정책 클래스를 각각 호출해 점수를 더한다
+
+즉 이 라인은 `채점` 라인이다.
+
+### 17-7. 추천 이유 생성 라인
+
+```text
+MatchingEngine
+  -> ReasonGenerator
+```
+
+설명:
+
+- 점수만 있으면 프론트나 사용자 입장에서 이유를 알 수 없다
+- 그래서 `ReasonGenerator`가
+  - 사람용 이유 문장
+  - 코드형 이유
+  - 구조화된 근거값
+  을 만든다
+
+즉 이 라인은 `설명 가능한 추천` 라인이다.
+
+### 17-8. 응답 생성 라인
+
+```text
+MatchingEngine
+  -> GuideRecommendItem
+PromptRecommendationService
+  -> GuideRecommendResponse
+```
+
+설명:
+
+- `MatchingEngine`은 추천 카드 1장씩(`GuideRecommendItem`) 만든다
+- `PromptRecommendationService`는 그 카드 리스트를 감싸서
+  `GuideRecommendResponse`를 만든다
+
+즉 관계는:
+
+```text
+GuideRecommendItem = 카드 1장
+GuideRecommendResponse = 카드 묶음 + 부가 정보
+```
+
+### 17-9. AI 모듈 밖으로 이어지는 라인
+
+추천 응답이 끝나면 다음 단계는 다른 모듈로 넘어간다.
+
+```text
+GuideRecommendResponse
+  -> 프론트
+      -> GuideFeedController / GuideFeedService
+      -> MatchRequestController / MatchRequestService
+      -> ChatRoomController / ChatRoomService (이후 단계)
+```
+
+설명:
+
+- 피드 절반 공개는 `guide`
+- 매칭 요청 생성/수락/거절은 `matching`
+- 채팅은 `chat`
+
+즉 AI 추천이 끝난 뒤의 흐름은 AI 모듈 밖에서 이어진다.
+
+---
+
+## 18. 클래스를 층(layer)으로 보면
+
+F03를 층으로 이해하면 훨씬 덜 헷갈린다.
+
+### 18-1. API 층
+
+- `AiController`
+
+역할:
+
+- 요청 받고 응답 반환
+
+### 18-2. 흐름 조립 층
+
+- `PromptRecommendationService`
+- `DbBackedGuideCandidateProvider`
+
+역할:
+
+- 후보군 준비
+- 추천 순서 조립
+- 응답 포장
+
+### 18-3. 파싱 층
+
+- `PromptParser`
+- `KeywordNormalizer`
+
+역할:
+
+- 프롬프트 해석
+- 표현 정규화
+
+### 18-4. 엔진 층
+
+- `AiRecommendationServiceImpl`
+- `MatchingEngine`
+- `ScoreCalculator`
+- `ReasonGenerator`
+
+역할:
+
+- 점수 계산
+- 이유 생성
+- 최종 카드 생성
+
+### 18-5. 정책 층
+
+- `RegionMatchPolicy`
+- `StyleMatchPolicy`
+- `BudgetMatchPolicy`
+- `ActivityMatchPolicy`
+- `LanguageMatchPolicy`
+- `FeedbackMatchPolicy`
+
+역할:
+
+- 각각의 기준으로 점수 계산
+
+### 18-6. 도메인 연동 층
+
+- `DbBackedGuideCandidateProvider`
+- `GuideProfileAiCandidateMapper`
+
+역할:
+
+- DB 데이터를 AI 후보 데이터로 번역
+
+---
+
+## 19. 클래스 관계를 외우는 가장 쉬운 문장
+
+아래 한 문장만 기억해도 관계가 많이 정리된다.
+
+```text
+AiController가 요청을 받고,
+PromptRecommendationService가 흐름을 조립하고,
+PromptParser가 문장을 해석하고,
+DbBackedGuideCandidateProvider가 후보를 준비하고,
+AiRecommendationServiceImpl이 엔진용 모델로 바꾸고,
+MatchingEngine이 점수와 이유를 만들어 최종 추천 카드를 만든다.
+```
+
+이 문장을 기준으로 각 파일을 다시 보면 구조가 훨씬 덜 복잡하게 느껴진다.

--- a/backend/module-ai/src/main/java/com/team6/module/ai/controller/AiController.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/controller/AiController.java
@@ -36,9 +36,21 @@ import java.util.Objects;
 @RequestMapping("/ai")
 public class AiController {
 
+    // F03 추천 파이프라인의 메인 조립자.
+    // 실제로는 PromptRecommendationService -> AiRecommendationServiceImpl -> MatchingEngine 순으로 이어지며,
+    // 프롬프트 파싱, 후보 보정, fallback 재시도, conceptSummary/matchRequestDraft 생성까지 담당한다.
     private final PromptRecommendationService promptRecommendationService;
+
+    // 추천 비교 대상이 될 가이드 후보군을 준비한다.
+    // 현재 기본 구현은 @Primary가 붙은 DbBackedGuideCandidateProvider로 연결되며,
+    // 프론트가 후보를 직접 보내지 않으면 DB에서 승인/활성 가이드, 공개 피드, 경력,
+    // 일부 운영 신호(환불/행동 데이터 등)를 합쳐 AI 후보 DTO로 채워 넣는다.
     private final GuideCandidateProvider guideCandidateProvider;
+
+    // 사용자가 날짜를 별도 필드로 주지 않은 경우, 프롬프트 문장에서 희망 투어 날짜 범위를 추출하는 fallback 용도다.
     private final PromptParser promptParser;
+
+    // 일정 필터에 걸려 메인 추천에서 빠진 가이드에 대해, 가능한 날짜를 안내하기 위한 조회용 provider다.
     private final GuideAvailabilityProvider guideAvailabilityProvider;
 
     @Operation(
@@ -55,7 +67,7 @@ public class AiController {
             headers = @Header(
                     name = RecommendationHttpHeaders.X_RECOMMENDATION_POLICY,
                     description = "룰 정책 버전(응답 body의 policyVersion과 동일). 캐시 키·디버깅에 활용 가능.",
-                    schema = @Schema(implementation = String.class, example = "2026.04.15")
+                    schema = @Schema(implementation = String.class, example = "2026.04.20")
             ),
             content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = GuideRecommendResponse.class))
     )
@@ -77,9 +89,18 @@ public class AiController {
                     content = @Content(schema = @Schema(implementation = PromptRecommendApiRequest.class))
             )
             @RequestBody PromptRecommendApiRequest request) {
+        // 1) 투어 희망 날짜를 확정한다.
+        // 우선순위는 요청 필드 > 프롬프트 문장 파싱 결과이며, 이후 후보 필터링/특별 제시에 함께 사용된다.
+        // 즉 프론트가 날짜를 명시하지 않아도 "4/20~4/22", "다음 주말" 같은 문장에서
+        // 일정 범위를 뽑아 추천 후보 필터에 활용하려는 목적이다.
         LocalDate from = resolveDesiredFromWithPromptFallback(request);
         LocalDate to = resolveDesiredToWithPromptFallback(request, from);
 
+        // 2) 추천 대상 가이드 후보를 모은다.
+        // 실제로는 GuideCandidateProvider 구현체인 DbBackedGuideCandidateProvider#getCandidates(...)가 주로 실행된다.
+        // 이 단계에서 일정 충돌이 있는 가이드는 메인 후보에서 빠질 수 있고,
+        // 동시에 "일정만 아니면 추천됐을 후보"를 위해 unfilteredCandidates도 함께 보관한다.
+        // 그래서 반환 타입도 단순 List가 아니라 GuideCandidateBundle이다.
         GuideCandidateBundle bundle =
                 guideCandidateProvider.getCandidates(
                         request.getPrompt(),
@@ -89,15 +110,26 @@ public class AiController {
                         to
                 );
 
+        // 3) 실제 메인 추천을 수행한다.
+        // 내부에서는 프롬프트 파싱 -> 후보 보정 -> 점수 계산 -> 이유 생성 -> 응답 생성 흐름으로 이어진다.
+        // 여기서 만들어지는 main은 "일정 필터를 통과한 후보들만" 대상으로 계산된 기본 추천 결과다.
         GuideRecommendResponse main = promptRecommendationService.recommendByPrompt(
                 request.getPrompt(),
                 request.getTopN(),
                 bundle.candidates()
         );
 
+        // 4) 일정 때문에 메인 추천에서 빠졌지만, 원래는 Top1이었을 가이드를 특별 제안(specialSuggestion)으로 만들지 판단한다.
+        // 사용자가 원하는 조건에는 잘 맞지만 선택 날짜에 예약이 있어 빠진 경우를
+        // "아예 숨기지 말고 별도 카드로 보여주자"는 UX 목적의 보조 흐름이다.
         GuideRecommendResponse.SpecialSuggestion specialSuggestion =
                 buildSpecialSuggestionIfNeeded(request, main, bundle, from, to);
 
+        // 5) 최종 응답을 구성한다.
+        // specialSuggestion이 없으면 메인 추천 응답을 그대로 쓰고,
+        // 있으면 메인 추천 카드 + 특별 제안 카드를 함께 내려 프론트가 별도 섹션으로 보여줄 수 있게 한다.
+        // 즉 recommendations는 "지금 바로 추천 가능한 가이드", specialSuggestion은
+        // "조건은 맞지만 일정 때문에 메인 추천에서 빠진 가이드"라고 이해하면 된다.
         GuideRecommendResponse body = (specialSuggestion == null)
                 ? main
                 : GuideRecommendResponse.builder()
@@ -113,6 +145,10 @@ public class AiController {
                 .specialSuggestion(specialSuggestion)
                 .build();
 
+        // 6) 정책 버전을 헤더와 body에 함께 실어 응답한다.
+        // 프론트는 recommendations로 추천 카드 UI를 그리고,
+        // matchRequestDraft는 이후 매칭 요청 생성 단계의 기본값으로 재사용할 수 있다.
+        // policyVersion은 추천 규칙이 바뀌었는지 확인하는 디버깅/캐시 키 용도로 같이 내려간다.
         String policy = Objects.requireNonNullElse(body.getPolicyVersion(), "");
         return ResponseEntity.ok()
                 .header(RecommendationHttpHeaders.X_RECOMMENDATION_POLICY, policy)
@@ -120,6 +156,7 @@ public class AiController {
     }
 
     private static LocalDate resolveDesiredFrom(PromptRecommendApiRequest request) {
+        // 프론트가 시작일/단일 희망일을 명시적으로 보냈다면 그 값을 우선 신뢰한다.
         if (request.getDesiredTourDateFrom() != null) {
             return request.getDesiredTourDateFrom();
         }
@@ -130,6 +167,7 @@ public class AiController {
     }
 
     private static LocalDate resolveDesiredTo(PromptRecommendApiRequest request, LocalDate from) {
+        // 종료일이 따로 없으면 단일 날짜 요청으로 간주해 from과 동일하게 본다.
         if (request.getDesiredTourDateTo() != null) {
             return request.getDesiredTourDateTo();
         }
@@ -141,6 +179,8 @@ public class AiController {
         if (from != null) {
             return from;
         }
+        // 명시 필드가 비어 있으면 프롬프트에서 날짜 범위를 뽑아본다.
+        // 이 로직 덕분에 "4/20~4/22 가능한 가이드" 같은 문장도 일정 필터에 걸 수 있다.
         PromptParser.DesiredDateRange r = promptParser.extractDesiredTourDateRange(request.getPrompt());
         return r == null ? null : r.from();
     }
@@ -150,6 +190,7 @@ public class AiController {
         if (to != null) {
             return to;
         }
+        // 시작일과 마찬가지로, 종료일도 프롬프트 해석 결과를 fallback으로 사용한다.
         PromptParser.DesiredDateRange r = promptParser.extractDesiredTourDateRange(request.getPrompt());
         return r == null ? null : r.to();
     }
@@ -164,8 +205,10 @@ public class AiController {
         if (bundle == null || bundle.unfilteredCandidates() == null || bundle.unfilteredCandidates().isEmpty()) {
             return null;
         }
+
+        // 메인 추천이 아예 비었더라도, 일정 필터만 없었다면 추천될 가이드가 있는지 한 번 더 확인한다.
+        // 즉 "추천 불가"와 "일정만 안 맞아서 빠짐"을 구분해서 보여주려는 의도다.
         if (main == null || main.getRecommendations() == null || main.getRecommendations().isEmpty()) {
-            // 메인 추천이 비어도, “일정 필터만 없었다면 Top1”이 있으면 특별 제시한다.
             return computeTop1SpecialSuggestion(request, bundle, from, to);
         }
 
@@ -175,7 +218,8 @@ public class AiController {
             return null;
         }
         Long unfilteredTop1 = special.getGuide().getGuideId();
-        // 정책: “Top1이 일정 때문에 빠졌을 때만” 특별 제시
+        // 정책: 일정 필터 때문에 메인 Top1이 달라진 경우에만 특별 제시한다.
+        // 메인 Top1과 원본 Top1이 같으면 굳이 별도 specialSuggestion을 만들 필요가 없다.
         return Objects.equals(mainTop1, unfilteredTop1) ? null : special;
     }
 
@@ -185,6 +229,8 @@ public class AiController {
             LocalDate from,
             LocalDate to
     ) {
+        // 메인 후보 필터를 적용하지 않은 원본 후보군으로 "진짜 Top1"을 다시 계산한다.
+        // 이때 topN을 1로 고정해서 "일정 필터만 없었다면 가장 먼저 추천됐을 가이드"를 찾는다.
         GuideRecommendResponse top1 = promptRecommendationService.recommendByPrompt(
                 request.getPrompt(),
                 1,
@@ -206,11 +252,14 @@ public class AiController {
         if (guideId == null || from == null) {
             return base;
         }
+
+        // 특별 제시 카드에는 "이 날짜는 불가하지만 기간 내 가능한 날짜가 언제인지"를 함께 안내한다.
+        // 사용자는 이 안내를 보고 날짜를 바꾸거나, 다른 추천을 선택할지 판단할 수 있다.
         List<LocalDate> available = guideAvailabilityProvider.availableDates(guideId, from, to);
         if (available == null || available.isEmpty()) {
             return base;
         }
-        // 안내는 과도하지 않게 7개까지만
+        // 안내는 과도하지 않게 7개까지만 노출한다.
         List<LocalDate> clipped = new ArrayList<>();
         for (int i = 0; i < available.size() && i < 7; i++) {
             clipped.add(available.get(i));

--- a/backend/module-ai/src/main/java/com/team6/module/ai/engine/MatchingEngine.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/engine/MatchingEngine.java
@@ -25,10 +25,19 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class MatchingEngine {
 
+    // 지역/스타일/예산/활동/언어/피드백 정책을 합산해 "숫자 점수"를 만드는 계산기.
     private final ScoreCalculator scoreCalculator;
+
+    // 점수만 주는 것이 아니라, 왜 추천됐는지 사람이 읽을 수 있는 이유 문구/코드를 만든다.
     private final ReasonGenerator reasonGenerator;
+
+    // 인접 지역 판정은 점수 계산뿐 아니라 다양성 보정, matched evidence 생성에도 쓰인다.
     private final AdjacentRegionProvider adjacentRegionProvider;
+
+    // Top-N이 너무 비슷한 가이드로만 채워지지 않도록 하는 다양성 재정렬 가중치 설정.
     private final DiversityRerankSnapshot diversity;
+
+    // 다양성 패널티 크기 같은 운영 지표를 남긴다.
     private final AiRecommendationMetrics recommendationMetrics;
 
 
@@ -37,16 +46,29 @@ public class MatchingEngine {
             List<GuideAiProfile> guides,
             int topN
     ) {
+        // MatchingEngine은 "후보 가이드 리스트"를 받아 실제 추천 카드 리스트로 바꾸는 마지막 엔진이다.
+        // 순서는 대략:
+        // 1) 각 가이드 점수 계산
+        // 2) 추천 이유 생성
+        // 3) 점수순 정렬
+        // 4) 다양성 패널티로 Top-N 재선정
+        // 5) GuideRecommendItem 응답 형태로 변환
         List<ScoredGuide> scored = guides.stream()
                 .map(guide -> {
+                    // 점수는 ScoreCalculator가 정책별로 합산한다.
                     int score = scoreCalculator.calculate(preference, guide);
+                    // 같은 점수라도 "왜 추천됐는지"가 보여야 프론트/운영/사용자 모두 해석 가능하다.
                     ReasonBundle bundle = reasonGenerator.generate(preference, guide, score);
                     return new ScoredGuide(guide, score, bundle);
                 })
+                // 1차 정렬은 순수 baseScore 기준이다.
                 .sorted(Comparator.comparingInt(ScoredGuide::baseScore).reversed())
                 .toList();
 
+        // baseScore가 높더라도 너무 비슷한 가이드만 연속 노출되지 않도록 Top-N을 다시 고른다.
         List<ScoredGuide> picked = pickWithDiversityPenalty(scored, topN, preference);
+
+        // 최종적으로 프론트가 바로 그릴 수 있는 추천 카드 응답으로 변환한다.
         List<GuideRecommendItem> items = picked.stream()
                 .map(sg -> GuideRecommendItem.builder()
                         .guideId(sg.guide.getGuideId())
@@ -65,6 +87,8 @@ public class MatchingEngine {
                         .build())
                 .toList();
 
+        // MatchingEngine이 만드는 응답은 "추천 카드 본체"다.
+        // conceptSummary / notice / matchRequestDraft 같은 부가 정보는 상위 서비스(PromptRecommendationService)에서 붙인다.
         return GuideRecommendResponse.builder()
                 .policyVersion(AiRecommendationTuning.POLICY_VERSION)
                 .totalCount(items.size())
@@ -80,6 +104,8 @@ public class MatchingEngine {
             int topN,
             TravelerPreference preference
     ) {
+        // 이 메서드는 단순히 앞에서 topN개 자르는 것이 아니라,
+        // 이미 뽑힌 가이드들과 "얼마나 비슷한지"를 보고 패널티를 준 뒤 다시 고른다.
         if (topN <= 0 || candidates.isEmpty()) {
             return List.of();
         }
@@ -94,9 +120,12 @@ public class MatchingEngine {
             double bestDiversityPenalty = 0.0;
 
             for (ScoredGuide c : candidates) {
+                // 같은 guideId가 중복 후보로 들어와도 한 번만 노출한다.
                 if (c.guide.getGuideId() == null || used.contains(c.guide.getGuideId())) {
                     continue;
                 }
+                // 이미 뽑힌 가이드와 비슷할수록 패널티가 커진다.
+                // 첫 번째 추천은 비교 대상이 없으므로 패널티 없이 그대로 뽑힌다.
                 double penalty = selected.isEmpty()
                         ? 0.0
                         : maxSimilarityToSelected(c.guide, selected, preference) * diversity.diversityLambda();
@@ -114,6 +143,7 @@ public class MatchingEngine {
             }
 
             if (!selected.isEmpty()) {
+                // 첫 번째 이후 추천에서 실제로 얼마나 패널티가 걸렸는지 운영 지표로 남긴다.
                 recommendationMetrics.recordDiversityPenaltyMagnitude(
                         bestDiversityPenalty,
                         AiRecommendationTuning.POLICY_VERSION
@@ -170,6 +200,8 @@ public class MatchingEngine {
      * 0~1에 가깝게 정규화한 프로필 유사도. 여행자 희망 지역이 있으면 인접권 안의 서로 다른 지역도 부분 유사로 본다.
      */
     private double similarity(TravelerPreference preference, GuideAiProfile a, GuideAiProfile b) {
+        // 유사도는 "둘이 얼마나 같은 타입의 가이드인가"를 0~1 사이로 정규화한 값이다.
+        // 여기서는 여행자 선호와의 적합도가 아니라, 가이드 프로필끼리의 중복/유사성을 본다.
         double sim = 0.0;
 
         sim += diversity.regionSimWeight() * regionSimilarityForDiversity(preference, a, b);
@@ -199,6 +231,8 @@ public class MatchingEngine {
      * 태그 Jaccard가 높을수록(유사 코스) 유효 유사도를 추가로 올려 Top-N에서 덜 고른다.
      */
     private double boostTagJaccardForNearDuplicate(double jaccard) {
+        // 태그가 거의 같은 가이드들은 실제 체감상 "거의 같은 코스"처럼 보일 수 있어서
+        // 임계값을 넘으면 유사도를 조금 더 키워 다양성 패널티가 강하게 작동하게 한다.
         if (jaccard < diversity.tagNearDuplicateThreshold()) {
             return jaccard;
         }
@@ -303,6 +337,9 @@ public class MatchingEngine {
     }
 
     private GuideRecommendItem.MatchedEvidence buildMatchedEvidence(TravelerPreference pref, GuideAiProfile guide) {
+        // 추천 결과 카드에 보여줄 구조화 근거다.
+        // 예: 지역 일치 여부, 예산 인접 여부, 겹친 태그/언어 목록 등
+        // 프론트는 이 값을 이용해 배지/툴팁/강조 표시를 할 수 있다.
         boolean region = safeEquals(pref.getRegion(), guide.getRegion());
         boolean regionAdjacent = !region && adjacentRegionProvider.isAdjacentTo(pref.getRegion(), guide.getRegion());
         boolean style = safeEquals(pref.getTravelStyle(), guide.getGuideStyle());
@@ -327,6 +364,8 @@ public class MatchingEngine {
     }
 
     private List<String> softPenaltyOverlapTags(List<String> softPenaltyTags, List<String> guideSpecialtyTags) {
+        // 사용자가 "너무 힘든 등산은 부담" 같은 soft 부정을 준 경우,
+        // 그 태그를 가이드가 강하게 전문으로 갖고 있으면 어떤 활동이 충돌했는지 노출하기 위한 보조 데이터다.
         if (softPenaltyTags == null || guideSpecialtyTags == null || softPenaltyTags.isEmpty() || guideSpecialtyTags.isEmpty()) {
             return List.of();
         }
@@ -377,6 +416,8 @@ public class MatchingEngine {
     }
 
     private List<GuideRecommendItem.ReasonFact> toResponseFacts(ReasonBundle bundle) {
+        // ReasonGenerator 내부 근거 팩트를 API 응답용 DTO로 옮긴다.
+        // reasonCodes만으로 부족할 때, 어떤 태그/언어/값이 근거였는지 프론트가 상세히 보여줄 수 있다.
         if (bundle == null || bundle.getReasonFacts() == null || bundle.getReasonFacts().isEmpty()) {
             return List.of();
         }
@@ -389,6 +430,8 @@ public class MatchingEngine {
                 .toList();
     }
 
+    // 추천 과정 중 계산 편의를 위한 임시 묶음 객체.
+    // 아직 API 응답으로 변환되기 전 단계의 "가이드 + 점수 + 추천 이유" 세트를 보관한다.
     private record ScoredGuide(GuideAiProfile guide, int baseScore, ReasonBundle bundle) {
     }
 }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
@@ -30,10 +30,20 @@ import static com.team6.module.ai.support.AiRecommendationTuning.POLICY_VERSION;
 @Slf4j
 public class PromptRecommendationService {
 
+    // 자연어 프롬프트를 구조화된 추천 요청(region/style/tags/langs...)으로 바꾸는 파서.
     private final PromptParser promptParser;
+
+    // 실제 추천 엔진 진입점.
+    // 현재 구현은 AiRecommendationServiceImpl -> MatchingEngine 흐름으로 이어진다.
     private final AiRecommendationService aiRecommendationService;
+
+    // 요청 지역 후보가 너무 적을 때 인접 지역 확장 판단에 사용한다.
     private final AdjacentRegionProvider adjacentRegionProvider;
+
+    // 호출 수, fallback 발생, 지연 시간 같은 운영 관측 지표를 기록한다.
     private final AiRecommendationMetrics metrics;
+
+    // 운영 중 조정 가능한 추천 임계값(low-signal 점수, fallback 개선폭 등) 스냅샷.
     private final ScoringPolicySnapshot scoringPolicy;
 
     public PromptRecommendationService(
@@ -71,15 +81,22 @@ public class PromptRecommendationService {
             Integer topN,
             List<GuideRecommendRequest.GuideCandidateDto> guideCandidates
     ) {
+        // PromptRecommendationService는 F03 추천의 "흐름 조정자" 역할을 한다.
+        // 여기서는 프롬프트를 파싱하고, 후보군을 보정하고, 추천을 실행하고,
+        // 부족한 결과면 fallback을 시도한 뒤 최종 응답(conceptSummary/keywords/notice)을 만든다.
         long startNs = System.nanoTime();
         metrics.recordPromptRecommendCall();
 
         try {
+            // 1) topN 기본값을 보정하고, 자연어 프롬프트를 추천용 구조로 변환한다.
             Integer resolvedTopN = (topN == null || topN <= 0)
                     ? AiRecommendationTuning.DEFAULT_TOP_N
                     : topN;
             GuideRecommendRequest parsed = promptParser.parse(prompt, resolvedTopN, guideCandidates);
 
+            // 2) 지역이 없으면 추천 품질이 크게 떨어지기 때문에 여기서 바로 short-circuit 한다.
+            // 대신 빈 응답만 보내지 않고 conceptSummary / keywords / matchRequestDraft는 같이 만들어
+            // 프론트가 "무엇을 더 입력해야 하는지" 안내할 수 있게 한다.
             if (!notBlank(parsed.getRegion())) {
                 GuideRecommendResponse empty = GuideRecommendResponse.builder()
                         .totalCount(0)
@@ -114,6 +131,8 @@ public class PromptRecommendationService {
                 return out;
             }
 
+            // 3) 정확히 같은 지역의 후보가 부족하면, 인접 지역까지 후보 풀을 넓혀본다.
+            // 이 단계는 추천 점수 계산 전 "후보군 보정"에 해당한다.
             RegionCandidateExpansion.Result expansion =
                 RegionCandidateExpansion.apply(
                         parsed.getGuideCandidates(),
@@ -121,7 +140,9 @@ public class PromptRecommendationService {
                         adjacentRegionProvider::neighbors
                 );
 
-        GuideRecommendRequest effective = GuideRecommendRequest.builder()
+        // 4) 실제 점수 계산에 넣을 최종 요청 객체를 다시 만든다.
+        // parsed는 파서 원본 결과, effective는 인접 지역 확장까지 반영된 계산용 최종본이라고 보면 된다.
+            GuideRecommendRequest effective = GuideRecommendRequest.builder()
                 .region(parsed.getRegion())
                 .travelStyle(parsed.getTravelStyle())
                 .budgetLevel(parsed.getBudgetLevel())
@@ -136,36 +157,46 @@ public class PromptRecommendationService {
                 .guideCandidates(expansion.candidates())
                 .build();
 
-        GuideRecommendResponse base = aiRecommendationService.recommend(effective);
-        FallbackOutcome fallback = resolveFallbackWithStrategicRelaxation(effective, base);
-        GuideRecommendResponse finalBase = fallback.responseAfterFallback();
+            // 5) 1차 추천을 수행한다.
+            // 이 시점의 base는 조건을 그대로 적용했을 때의 첫 추천 결과다.
+            GuideRecommendResponse base = aiRecommendationService.recommend(effective);
 
-        String parseConfidence = computePromptParseConfidence(parsed);
-        List<String> ambiguityCodes = collectAmbiguityNoticeCodes(prompt, parsed);
-        List<String> parserHints = parsed.getParserNoticeCodes() == null ? List.of() : parsed.getParserNoticeCodes();
-        logParserTuningSignals(prompt, parsed, parseConfidence, ambiguityCodes, parserHints);
+            // 6) 결과가 없거나 점수가 너무 약하면 활동 태그 -> 스타일 -> 지역 순으로
+            // 한 단계씩만 완화하는 전략적 fallback을 시도한다.
+            FallbackOutcome fallback = resolveFallbackWithStrategicRelaxation(effective, base);
+            GuideRecommendResponse finalBase = fallback.responseAfterFallback();
 
-        String notice = fallback.fallbackNotice();
-        if (expansion.expansionUsed()) {
-            notice = mergeNotice(NOTICE_ADJACENT_INCLUDED, notice);
-            metrics.recordRegionExpansion();
-        }
-        int effectivePoolSizeForNotice = poolSize(expansion.candidates());
-        if (effectivePoolSizeForNotice == 1 && finalBase.getTotalCount() > 0) {
-            notice = mergeNotice(NOTICE_SPARSE_GUIDE_POOL, notice);
-            metrics.recordSparsePoolNotice();
-        }
-        notice = enrichNoticeForParseQuality(notice, parseConfidence, ambiguityCodes);
+            // 7) 파싱 결과가 얼마나 풍부한지(HIGH/MEDIUM/LOW), 어떤 모호함이 있었는지 계산한다.
+            // 이 값들은 추천 점수 자체보다 notice/로그/운영 튜닝에 더 가깝게 쓰인다.
+            String parseConfidence = computePromptParseConfidence(parsed);
+            List<String> ambiguityCodes = collectAmbiguityNoticeCodes(prompt, parsed);
+            List<String> parserHints = parsed.getParserNoticeCodes() == null ? List.of() : parsed.getParserNoticeCodes();
+            logParserTuningSignals(prompt, parsed, parseConfidence, ambiguityCodes, parserHints);
 
-        if (fallback.attemptedRelaxChain()) {
-            String metricStage = fallback.winningRelaxStage() != RelaxStage.NONE
-                    ? fallback.winningRelaxStage().name()
-                    : "STRATEGIC_EXHAUSTED";
-            metrics.recordFallback(metricStage);
-            boolean adopted = fallback.winningRelaxStage() != RelaxStage.NONE;
-            metrics.recordStrategicFallbackOutcome(adopted, POLICY_VERSION);
-        }
+            // 8) 사용자에게 보여줄 notice 문구를 조립한다.
+            // 인접 지역 확장, 후보 수 부족, 파싱 애매함, fallback 재시도 여부를 합쳐 한 문장으로 만든다.
+            String notice = fallback.fallbackNotice();
+            if (expansion.expansionUsed()) {
+                notice = mergeNotice(NOTICE_ADJACENT_INCLUDED, notice);
+                metrics.recordRegionExpansion();
+            }
+            int effectivePoolSizeForNotice = poolSize(expansion.candidates());
+            if (effectivePoolSizeForNotice == 1 && finalBase.getTotalCount() > 0) {
+                notice = mergeNotice(NOTICE_SPARSE_GUIDE_POOL, notice);
+                metrics.recordSparsePoolNotice();
+            }
+            notice = enrichNoticeForParseQuality(notice, parseConfidence, ambiguityCodes);
 
+            if (fallback.attemptedRelaxChain()) {
+                String metricStage = fallback.winningRelaxStage() != RelaxStage.NONE
+                        ? fallback.winningRelaxStage().name()
+                        : "STRATEGIC_EXHAUSTED";
+                metrics.recordFallback(metricStage);
+                boolean adopted = fallback.winningRelaxStage() != RelaxStage.NONE;
+                metrics.recordStrategicFallbackOutcome(adopted, POLICY_VERSION);
+            }
+
+            // 9) 프론트가 기계적으로 처리할 수 있도록 notice를 코드 목록으로도 만든다.
             List<String> noticeCodes = buildNoticeCodes(
                     fallback,
                     expansion.expansionUsed(),
@@ -177,6 +208,7 @@ public class PromptRecommendationService {
             );
             metrics.recordOutcome(finalBase.getTotalCount() > 0 ? "success" : "empty");
 
+            // 10) 운영 디버깅용 구조화 로그를 남긴다.
             logRecommendation(
                     prompt,
                     parsed,
@@ -190,6 +222,9 @@ public class PromptRecommendationService {
                     expansion.exactCount()
             );
 
+            // 11) 최종 응답을 만든다.
+            // conceptSummary/keywords는 설명용, matchRequestDraft는 이후 매칭 요청 생성 단계 재사용용,
+            // recommendations는 실제 카드 UI에 쓰이는 추천 결과 목록이다.
             GuideRecommendResponse out = GuideRecommendResponse.builder()
                     .conceptSummary(ConceptSummaryGenerator.generate(parsed))
                     .keywords(keywordsFrom(parsed))
@@ -204,6 +239,7 @@ public class PromptRecommendationService {
             recordDistributionMetrics(out, poolSize(expansion.candidates()));
             return out;
         } finally {
+            // 성공/실패와 상관없이 전체 추천 파이프라인 소요 시간을 남긴다.
             metrics.recordRecommendationLatencyNanos(System.nanoTime() - startNs, POLICY_VERSION);
         }
     }
@@ -265,6 +301,8 @@ public class PromptRecommendationService {
     }
 
     private void recordDistributionMetrics(GuideRecommendResponse response, int effectivePoolSize) {
+        // 추천 품질을 운영에서 관찰하기 위한 보조 지표.
+        // Top1 점수와 실제 계산에 쓴 후보 풀 크기를 함께 기록한다.
         metrics.recordEffectivePoolSize(effectivePoolSize, POLICY_VERSION);
         if (response.getRecommendations() != null && !response.getRecommendations().isEmpty()) {
             metrics.recordTop1Score(response.getRecommendations().get(0).getScore(), POLICY_VERSION);
@@ -272,6 +310,8 @@ public class PromptRecommendationService {
     }
 
     private static GuideRecommendResponse.Keywords keywordsFrom(GuideRecommendRequest request) {
+        // 파서가 읽어낸 조건을 프론트에 구조화 형태로 다시 노출한다.
+        // 디버깅, UI 표시, 이후 매칭 요청 폼 기본값 구성에 함께 쓸 수 있다.
         return GuideRecommendResponse.Keywords.builder()
                 .region(request.getRegion())
                 .travelStyle(request.getTravelStyle())
@@ -287,6 +327,8 @@ public class PromptRecommendationService {
     }
 
     private static GuideRecommendResponse.MatchRequestDraft matchRequestDraftFrom(GuideRecommendRequest request) {
+        // AI 추천 응답을 바로 매칭 요청 생성 화면으로 연결하기 위한 초안 데이터다.
+        // matching 모듈을 직접 호출하는 건 아니고, 프론트가 이 draft를 읽어 요청 폼 기본값으로 쓴다.
         return GuideRecommendResponse.MatchRequestDraft.builder()
                 .destination(request.getRegion())
                 .concept(ConceptSummaryGenerator.generateMatchRequestConcept(request))
@@ -322,6 +364,7 @@ public class PromptRecommendationService {
             List<String> ambiguityCodes,
             String parseConfidence
     ) {
+        // 사람이 읽는 notice와 별개로, 프론트가 로직 분기/배지 처리에 쓸 수 있도록 코드 형태도 함께 만든다.
         LinkedHashSet<String> codes = new LinkedHashSet<>();
         if (fallback.coreNoticeCodes() != null) {
             codes.addAll(fallback.coreNoticeCodes());
@@ -364,6 +407,7 @@ public class PromptRecommendationService {
             String parseConfidence,
             List<String> ambiguityCodes
     ) {
+        // 파싱이 애매했던 경우에는 사용자에게 "예산/기간을 더 구체적으로 적어달라"는 힌트를 notice에 덧붙인다.
         String out = notice;
         if (ambiguityCodes != null && ambiguityCodes.contains(RecommendationNoticeCodes.PROMPT_BUDGET_AMBIGUOUS)) {
             out = mergeNotice(out, NOTICE_BUDGET_VAGUE);
@@ -418,6 +462,8 @@ public class PromptRecommendationService {
      * 지역은 파싱됐을 때, 그 외 신호가 얼마나 풍부한지에 대한 룰 기반 등급.
      */
     private static String computePromptParseConfidence(GuideRecommendRequest p) {
+        // region만 있는 프롬프트와, region/style/budget/tags/langs/...가 풍부한 프롬프트를 구분해
+        // 추천 결과 해석 난이도를 HIGH/MEDIUM/LOW로 표시하는 간단 룰이다.
         int dims = 0;
         if (notBlank(p.getRegion())) {
             dims++;
@@ -506,6 +552,8 @@ public class PromptRecommendationService {
             GuideRecommendRequest effective,
             GuideRecommendResponse base
     ) {
+        // fallback은 "아무 기준 없이 다 풀어버리는" 방식이 아니라,
+        // 정보 손실이 상대적으로 적은 조건부터 차례대로 완화하는 전략을 쓴다.
         int candidateCount = effective.getGuideCandidates() == null ? 0 : effective.getGuideCandidates().size();
         if (candidateCount == 0) {
             return FallbackOutcome.errorNotice(
@@ -527,6 +575,7 @@ public class PromptRecommendationService {
         int score = topScore(base);
         boolean lowScore = !noResults && score < scoringPolicy.lowSignalScoreThreshold();
         if (!noResults && !lowScore) {
+            // 결과가 충분하면 fallback 없이 그대로 채택한다.
             return FallbackOutcome.noRelax(base);
         }
 
@@ -560,6 +609,8 @@ public class PromptRecommendationService {
             GuideRecommendResponse baseline,
             ScoringPolicySnapshot scoring
     ) {
+        // 언어는 사용자가 강하게 원하는 경우가 많아서 끝까지 고정하고,
+        // activity -> style -> region 순으로만 하나씩 완화한다.
         GuideRecommendRequest current = languageAnchor;
         for (RelaxStage step : STRATEGIC_RELAX_ORDER) {
             if (!isStrategicRelaxApplicable(current, step)) {
@@ -678,6 +729,8 @@ public class PromptRecommendationService {
             int expansionExactCount
     ) {
         try {
+            // 추천 품질 이슈가 생겼을 때 promptHash, 후보 수, fallback 단계, Top1 reason code 등으로
+            // 운영 로그에서 빠르게 역추적할 수 있게 남기는 구조화 로그다.
             int promptHash = promptHash(prompt);
             int candidateCount = guideCandidates == null ? 0 : guideCandidates.size();
             int baseTopScore = topScore(base);


### PR DESCRIPTION
## 변경 범위
- `backend/module-ai/F03_FLOW_GUIDE.md`: F03 추천 파이프라인·DTO·모듈 경계·API 예시를 정리(링크는 `module-ai` 기준 상대 경로로 팀원/ GitHub에서 동작하도록 수정)
- `AiController`, `PromptRecommendationService`, `MatchingEngine`: 입구~엔진 단계별 역할·호출 순서 주석 보강
- OpenAPI 헤더 예시의 policy 버전을 `AiRecommendationTuning.POLICY_VERSION`(`2026.04.20`)과 맞춤

## 스키마 영향
- 없음 (문서·주석·OpenAPI 예시 문자열만)

## 검증
```bash
cd backend && ./gradlew :module-ai:test
```

Closes #226

Made with [Cursor](https://cursor.com)