### PR TITLE
Feat/be#235 comparisonHint 고도화(근거 슬롯 기반)

### DIFF
--- a/backend/module-ai/src/main/java/com/team6/module/ai/controller/AiController.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/controller/AiController.java
@@ -69,7 +69,7 @@ public class AiController {
             headers = @Header(
                     name = RecommendationHttpHeaders.X_RECOMMENDATION_POLICY,
                     description = "룰 정책 버전(응답 body의 policyVersion과 동일). 캐시 키·디버깅에 활용 가능.",
-                    schema = @Schema(implementation = String.class, example = "2026.04.23")
+                    schema = @Schema(implementation = String.class, example = "2026.04.24")
             ),
             content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = GuideRecommendResponse.class))
     )

--- a/backend/module-ai/src/main/java/com/team6/module/ai/engine/MatchingEngine.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/engine/MatchingEngine.java
@@ -147,6 +147,42 @@ public class MatchingEngine {
     }
 
     private static String buildComparisonHint(GuideRecommendItem top, GuideRecommendItem second) {
+        GuideRecommendItem.MatchedEvidence a = top.getMatched();
+        GuideRecommendItem.MatchedEvidence b = second.getMatched();
+
+        if (a != null && b != null) {
+            if (a.isRegion() && !b.isRegion()) {
+                return "희망 지역과 정확히 일치해 2순위보다 더 잘 맞아요.";
+            }
+            if (a.isRegionAdjacent() && !b.isRegion() && !b.isRegionAdjacent()) {
+                return "희망 지역과 가까운 인접권이라 2순위보다 조건에 더 가깝습니다.";
+            }
+            int langDelta = safeSize(a.getLanguages()) - safeSize(b.getLanguages());
+            if (langDelta >= 1) {
+                String langs = briefList(a.getLanguages());
+                return langs == null
+                        ? "요청하신 언어 안내가 가능해 2순위보다 더 적합해요."
+                        : "요청하신 언어(" + langs + ")가 가능해 2순위보다 더 적합해요.";
+            }
+            int tagDelta = safeSize(a.getTags()) - safeSize(b.getTags());
+            if (tagDelta >= 1) {
+                String tags = briefList(a.getTags());
+                return tags == null
+                        ? "관심 활동이 더 잘 맞아 2순위보다 앞섰어요."
+                        : "관심 활동(" + tags + ")이 더 잘 맞아 2순위보다 앞섰어요.";
+            }
+            if (a.isBudget() && !b.isBudget()) {
+                return "예산 구간이 더 정확히 맞아 2순위보다 우선 추천됐어요.";
+            }
+            if (a.isStyle() && !b.isStyle()) {
+                return "여행 스타일이 더 잘 맞아 2순위보다 우선 추천됐어요.";
+            }
+            int penaltyDelta = safeSize(b.getSoftPenaltyOverlapTags()) - safeSize(a.getSoftPenaltyOverlapTags());
+            if (penaltyDelta >= 1) {
+                return "부담 요소가 덜 겹쳐 2순위보다 더 적합해요.";
+            }
+        }
+
         int diff = top.getScore() - second.getScore();
         if (diff >= 10) {
             return "2순위보다 요청 조건에 더 가깝게 점수가 높아요.";
@@ -154,7 +190,31 @@ public class MatchingEngine {
         if (diff >= 4) {
             return "2순위와 비슷하지만 전체 근거에서 앞섭니다.";
         }
-        return "2순위와 점수는 비슷하고, 세부 활동·예산 근거에서 조금 더 맞아요.";
+        return "2순위와 점수는 비슷하고, 세부 근거에서 조금 더 맞아요.";
+    }
+
+    private static int safeSize(List<?> list) {
+        return list == null ? 0 : list.size();
+    }
+
+    /**
+     * UI용 짧은 목록(최대 2개) 문자열. 비어 있으면 null.
+     */
+    private static String briefList(List<String> values) {
+        if (values == null || values.isEmpty()) {
+            return null;
+        }
+        List<String> cleaned = values.stream()
+                .filter(v -> v != null && !v.isBlank())
+                .distinct()
+                .toList();
+        if (cleaned.isEmpty()) {
+            return null;
+        }
+        if (cleaned.size() == 1) {
+            return cleaned.get(0);
+        }
+        return cleaned.get(0) + ", " + cleaned.get(1);
     }
 
     /**

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationTuning.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationTuning.java
@@ -19,7 +19,7 @@ public final class AiRecommendationTuning {
     /**
      * 룰/스코어/Reason/응답 계약이 바뀔 때마다 올린다. 로그·API에서 동일 프롬프트 비교 시 정책 변경 여부를 구분하는 데 쓴다.
      */
-    public static final String POLICY_VERSION = "2026.04.23";
+    public static final String POLICY_VERSION = "2026.04.24";
 
     public static final int DEFAULT_TOP_N = 3;
 


### PR DESCRIPTION
## 변경
- `MatchingEngine`의 `comparisonHint`를 점수 차이 기반에서 **matched evidence 슬롯 비교 기반**으로 개선
  - 지역 일치/인접, 언어, 활동 태그, 예산, 스타일, 부담(soft penalty overlap) 순으로 2순위 대비 우위를 한 줄로 생성
  - 차이를 찾기 어려우면 기존 점수 차이 기반 문구로 폴백
- `POLICY_VERSION` → `2026.04.24` (Reason/응답 문구 의미 변경)
- OpenAPI 헤더 예시 버전 동기화

## 검증
```bash
cd backend && ./gradlew :module-ai:test
```

Closes #235

Made with [Cursor](https://cursor.com)