### PR TITLE
Feat/be#237 한 이메일 GUEST/GUIDE 동시 보유 가능하도록 guide 인증/가입 흐름 개선

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -2,6 +2,7 @@
 <project version="4">
   <component name="CompilerConfiguration">
     <annotationProcessing>
+      <profile default="true" name="Default" enabled="true" />
       <profile name="Gradle Imported" enabled="true">
         <outputRelativeToContentRoot value="true" />
         <processorPath useClasspath="false">

--- a/backend/module-domain/src/main/java/com/team6/domain/guide/controller/GuideCareerController.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/controller/GuideCareerController.java
@@ -3,12 +3,8 @@ package com.team6.domain.guide.controller;
 import com.team6.domain.guide.dto.request.CreateGuideCareerRequest;
 import com.team6.domain.guide.dto.request.UpdateGuideCareerRequest;
 import com.team6.domain.guide.dto.response.GuideCareerResponse;
-import com.team6.domain.guide.exception.GuideErrorCode;
-import com.team6.domain.guide.exception.GuideException;
 import com.team6.domain.guide.service.GuideCareerService;
-import com.team6.domain.member.entity.Member;
-import com.team6.domain.member.repository.MemberRepository;
-import com.team6.module.common.global.util.SecurityUtil;
+import com.team6.domain.guide.support.GuideAuthenticationSupport;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -26,7 +22,7 @@ import java.util.List;
 public class GuideCareerController {
 
     private final GuideCareerService guideCareerService;
-    private final MemberRepository memberRepository;
+    private final GuideAuthenticationSupport guideAuthenticationSupport;
 
     // 경력 등록
     @PostMapping
@@ -34,7 +30,7 @@ public class GuideCareerController {
             @PathVariable Long guideId,
             @RequestBody @Valid CreateGuideCareerRequest request
     ) {
-        Long userId = getCurrentUserId();
+        Long userId = guideAuthenticationSupport.getCurrentGuideMemberId();
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(guideCareerService.addCareer(guideId, request, userId));
     }
@@ -54,7 +50,7 @@ public class GuideCareerController {
             @PathVariable Long careerId,
             @RequestBody @Valid UpdateGuideCareerRequest request
     ) {
-        Long userId = getCurrentUserId();
+        Long userId = guideAuthenticationSupport.getCurrentGuideMemberId();
         return ResponseEntity.ok(guideCareerService.updateCareer(careerId, guideId, request, userId));
     }
 
@@ -64,16 +60,8 @@ public class GuideCareerController {
             @PathVariable Long guideId,
             @PathVariable Long careerId
     ) {
-        Long userId = getCurrentUserId();
+        Long userId = guideAuthenticationSupport.getCurrentGuideMemberId();
         guideCareerService.deleteCareer(careerId, guideId, userId);
         return ResponseEntity.noContent().build();
-    }
-
-    // JWT에서 현재 로그인 사용자의 memberId 추출
-    private Long getCurrentUserId() {
-        String email = SecurityUtil.getCurrentUserEmail();
-        return memberRepository.findByEmail(email)
-                .map(Member::getId)
-                .orElseThrow(() -> new GuideException(GuideErrorCode.MEMBER_NOT_FOUND));
     }
 }

--- a/backend/module-domain/src/main/java/com/team6/domain/guide/controller/GuideFeedController.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/controller/GuideFeedController.java
@@ -3,12 +3,8 @@ package com.team6.domain.guide.controller;
 import com.team6.domain.guide.dto.request.CreateGuideFeedRequest;
 import com.team6.domain.guide.dto.request.UpdateGuideFeedRequest;
 import com.team6.domain.guide.dto.response.GuideFeedResponse;
-import com.team6.domain.guide.exception.GuideErrorCode;
-import com.team6.domain.guide.exception.GuideException;
 import com.team6.domain.guide.service.GuideFeedService;
-import com.team6.domain.member.entity.Member;
-import com.team6.domain.member.repository.MemberRepository;
-import com.team6.module.common.global.util.SecurityUtil;
+import com.team6.domain.guide.support.GuideAuthenticationSupport;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -26,7 +22,7 @@ import java.util.List;
 public class GuideFeedController {
 
     private final GuideFeedService guideFeedService;
-    private final MemberRepository memberRepository;
+    private final GuideAuthenticationSupport guideAuthenticationSupport;
 
     // 피드 등록
     @PostMapping
@@ -34,7 +30,7 @@ public class GuideFeedController {
             @PathVariable Long guideId,
             @RequestBody @Valid CreateGuideFeedRequest request
     ) {
-        Long userId = getCurrentUserId();
+        Long userId = guideAuthenticationSupport.getCurrentGuideMemberId();
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(guideFeedService.createFeed(guideId, request, userId));
     }
@@ -54,7 +50,7 @@ public class GuideFeedController {
             @PathVariable Long feedId,
             @RequestBody @Valid UpdateGuideFeedRequest request
     ) {
-        Long userId = getCurrentUserId();
+        Long userId = guideAuthenticationSupport.getCurrentGuideMemberId();
         return ResponseEntity.ok(guideFeedService.updateFeed(guideId, feedId, request, userId));
     }
 
@@ -64,16 +60,8 @@ public class GuideFeedController {
             @PathVariable Long guideId,
             @PathVariable Long feedId
     ) {
-        Long userId = getCurrentUserId();
+        Long userId = guideAuthenticationSupport.getCurrentGuideMemberId();
         guideFeedService.deleteFeed(guideId, feedId, userId);
         return ResponseEntity.noContent().build();
-    }
-
-    // JWT에서 현재 로그인 사용자의 memberId 추출
-    private Long getCurrentUserId() {
-        String email = SecurityUtil.getCurrentUserEmail();
-        return memberRepository.findByEmail(email)
-                .map(Member::getId)
-                .orElseThrow(() -> new GuideException(GuideErrorCode.MEMBER_NOT_FOUND));
     }
 }

--- a/backend/module-domain/src/main/java/com/team6/domain/guide/controller/GuideImageController.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/controller/GuideImageController.java
@@ -2,12 +2,8 @@ package com.team6.domain.guide.controller;
 
 import com.team6.domain.guide.dto.request.CreateGuideImageRequest;
 import com.team6.domain.guide.dto.response.GuideImageResponse;
-import com.team6.domain.guide.exception.GuideErrorCode;
-import com.team6.domain.guide.exception.GuideException;
 import com.team6.domain.guide.service.GuideImageService;
-import com.team6.domain.member.entity.Member;
-import com.team6.domain.member.repository.MemberRepository;
-import com.team6.module.common.global.util.SecurityUtil;
+import com.team6.domain.guide.support.GuideAuthenticationSupport;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -25,7 +21,7 @@ import java.util.List;
 public class GuideImageController {
 
     private final GuideImageService guideImageService;
-    private final MemberRepository memberRepository;
+    private final GuideAuthenticationSupport guideAuthenticationSupport;
 
     // 이미지 등록 (F06-03)
     @PostMapping
@@ -33,7 +29,7 @@ public class GuideImageController {
             @PathVariable Long guideId,
             @RequestBody @Valid CreateGuideImageRequest request
     ) {
-        Long userId = getCurrentUserId();
+        Long userId = guideAuthenticationSupport.getCurrentGuideMemberId();
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(guideImageService.addImage(guideId, request, userId));
     }
@@ -52,16 +48,8 @@ public class GuideImageController {
             @PathVariable Long guideId,
             @PathVariable Long imageId
     ) {
-        Long userId = getCurrentUserId();
+        Long userId = guideAuthenticationSupport.getCurrentGuideMemberId();
         guideImageService.deleteImage(imageId, guideId, userId);
         return ResponseEntity.noContent().build();
-    }
-
-    // JWT에서 현재 로그인 사용자의 memberId 추출
-    private Long getCurrentUserId() {
-        String email = SecurityUtil.getCurrentUserEmail();
-        return memberRepository.findByEmail(email)
-                .map(Member::getId)
-                .orElseThrow(() -> new GuideException(GuideErrorCode.MEMBER_NOT_FOUND));
     }
 }

--- a/backend/module-domain/src/main/java/com/team6/domain/guide/controller/GuideProfileController.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/controller/GuideProfileController.java
@@ -7,12 +7,8 @@ import com.team6.domain.guide.dto.response.GuideDetailResponse;
 import com.team6.domain.guide.dto.response.GuideProfileResponse;
 import com.team6.domain.guide.dto.response.GuideReviewSummaryResponse;
 import com.team6.domain.guide.dto.response.GuideSettlementResponse;
-import com.team6.domain.guide.exception.GuideErrorCode;
-import com.team6.domain.guide.exception.GuideException;
 import com.team6.domain.guide.service.GuideProfileService;
-import com.team6.domain.member.entity.Member;
-import com.team6.domain.member.repository.MemberRepository;
-import com.team6.module.common.global.util.SecurityUtil;
+import com.team6.domain.guide.support.GuideAuthenticationSupport;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -30,14 +26,14 @@ import java.util.List;
 public class GuideProfileController {
 
     private final GuideProfileService guideProfileService;
-    private final MemberRepository memberRepository;
+    private final GuideAuthenticationSupport guideAuthenticationSupport;
 
     // 가이드 프로필 등록 (F06-01)
     @PostMapping
     public ResponseEntity<GuideProfileResponse> createProfile(
             @RequestBody @Valid CreateGuideProfileRequest request
     ) {
-        Long userId = getCurrentUserId();
+        Long userId = guideAuthenticationSupport.getCurrentMemberId();
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(guideProfileService.createProfile(request, userId));
     }
@@ -53,7 +49,7 @@ public class GuideProfileController {
     // 내 가이드 프로필 조회 (GUIDE용, profile id 안정 조회)
     @GetMapping("/me")
     public ResponseEntity<GuideProfileResponse> getMyProfile() {
-        Long userId = getCurrentUserId();
+        Long userId = guideAuthenticationSupport.getCurrentGuideMemberId();
         return ResponseEntity.ok(guideProfileService.getMyProfile(userId));
     }
 
@@ -77,7 +73,7 @@ public class GuideProfileController {
             @PathVariable Long guideId,
             @RequestBody @Valid UpdateGuideProfileRequest request
     ) {
-        Long userId = getCurrentUserId();
+        Long userId = guideAuthenticationSupport.getCurrentGuideMemberId();
         return ResponseEntity.ok(guideProfileService.updateProfile(guideId, request, userId));
     }
 
@@ -94,7 +90,7 @@ public class GuideProfileController {
     public ResponseEntity<GuideSettlementResponse> getExpectedSettlement(
             @PathVariable Long guideId
     ) {
-        Long userId = getCurrentUserId();
+        Long userId = guideAuthenticationSupport.getCurrentGuideMemberId();
         return ResponseEntity.ok(guideProfileService.getExpectedSettlement(guideId, userId));
     }
 
@@ -120,18 +116,7 @@ public class GuideProfileController {
     public ResponseEntity<GuideProfileResponse> toggleActive(
             @PathVariable Long guideId
     ) {
-        Long userId = getCurrentUserId();
+        Long userId = guideAuthenticationSupport.getCurrentGuideMemberId();
         return ResponseEntity.ok(guideProfileService.toggleActive(guideId, userId));
-    }
-
-    // JWT에서 현재 로그인 사용자의 memberId 추출
-    private Long getCurrentUserId() {
-        String email = SecurityUtil.getCurrentUserEmail();
-        if (email == null || email.isBlank() || "anonymousUser".equalsIgnoreCase(email)) {
-            throw new GuideException(GuideErrorCode.GUIDE_UNAUTHORIZED);
-        }
-        return memberRepository.findByEmail(email)
-                .map(Member::getId)
-                .orElseThrow(() -> new GuideException(GuideErrorCode.GUIDE_UNAUTHORIZED));
     }
 }

--- a/backend/module-domain/src/main/java/com/team6/domain/guide/controller/GuideScheduleController.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/controller/GuideScheduleController.java
@@ -6,12 +6,8 @@ import com.team6.domain.guide.dto.request.UpdateGuideScheduleRequest;
 import com.team6.domain.guide.dto.response.GuideScheduleFormResponse;
 import com.team6.domain.guide.dto.response.GuideScheduleResponse;
 import com.team6.domain.guide.entity.enums.GuideScheduleStatus;
-import com.team6.domain.guide.exception.GuideErrorCode;
-import com.team6.domain.guide.exception.GuideException;
 import com.team6.domain.guide.service.GuideScheduleService;
-import com.team6.domain.member.entity.Member;
-import com.team6.domain.member.repository.MemberRepository;
-import com.team6.module.common.global.util.SecurityUtil;
+import com.team6.domain.guide.support.GuideAuthenticationSupport;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -29,7 +25,7 @@ import java.util.List;
 public class GuideScheduleController {
 
     private final GuideScheduleService guideScheduleService;
-    private final MemberRepository memberRepository;
+    private final GuideAuthenticationSupport guideAuthenticationSupport;
 
     // 스케줄 등록 (F06-04)
     @PostMapping
@@ -37,7 +33,7 @@ public class GuideScheduleController {
             @PathVariable Long guideId,
             @RequestBody @Valid CreateGuideScheduleRequest request
     ) {
-        Long userId = getCurrentUserId();
+        Long userId = guideAuthenticationSupport.getCurrentGuideMemberId();
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(guideScheduleService.addSchedule(guideId, request, userId));
     }
@@ -57,7 +53,7 @@ public class GuideScheduleController {
             @PathVariable Long scheduleId,
             @RequestBody @Valid UpdateGuideScheduleRequest request
     ) {
-        Long userId = getCurrentUserId();
+        Long userId = guideAuthenticationSupport.getCurrentGuideMemberId();
         return ResponseEntity.ok(guideScheduleService.updateSchedule(scheduleId, guideId, request, userId));
     }
 
@@ -67,7 +63,7 @@ public class GuideScheduleController {
             @PathVariable Long guideId,
             @PathVariable Long scheduleId
     ) {
-        Long userId = getCurrentUserId();
+        Long userId = guideAuthenticationSupport.getCurrentGuideMemberId();
         guideScheduleService.deleteSchedule(scheduleId, guideId, userId);
         return ResponseEntity.noContent().build();
     }
@@ -77,7 +73,7 @@ public class GuideScheduleController {
     public ResponseEntity<List<GuideScheduleResponse>> getPendingSchedules(
             @PathVariable Long guideId
     ) {
-        Long userId = getCurrentUserId();
+        Long userId = guideAuthenticationSupport.getCurrentGuideMemberId();
         return ResponseEntity.ok(guideScheduleService.getPendingSchedules(guideId, userId));
     }
 
@@ -87,7 +83,7 @@ public class GuideScheduleController {
             @PathVariable Long guideId,
             @PathVariable Long scheduleId
     ) {
-        Long userId = getCurrentUserId();
+        Long userId = guideAuthenticationSupport.getCurrentGuideMemberId();
         return ResponseEntity.ok(guideScheduleService.acceptSchedule(scheduleId, guideId, userId));
     }
 
@@ -97,7 +93,7 @@ public class GuideScheduleController {
             @PathVariable Long guideId,
             @PathVariable Long scheduleId
     ) {
-        Long userId = getCurrentUserId();
+        Long userId = guideAuthenticationSupport.getCurrentGuideMemberId();
         return ResponseEntity.ok(guideScheduleService.rejectSchedule(scheduleId, guideId, userId));
     }
 
@@ -121,7 +117,7 @@ public class GuideScheduleController {
             @PathVariable Long scheduleId,
             @RequestBody @Valid SubmitGuideScheduleFormRequest request
     ) {
-        Long userId = getCurrentUserId();
+        Long userId = guideAuthenticationSupport.getCurrentGuideMemberId();
         return ResponseEntity.ok(guideScheduleService.submitForm(scheduleId, guideId, request, userId));
     }
 
@@ -169,15 +165,7 @@ public class GuideScheduleController {
             @PathVariable Long scheduleId,
             @RequestParam GuideScheduleStatus status
     ) {
-        Long userId = getCurrentUserId();
+        Long userId = guideAuthenticationSupport.getCurrentGuideMemberId();
         return ResponseEntity.ok(guideScheduleService.changeStatus(scheduleId, guideId, status, userId));
-    }
-
-    // JWT에서 현재 로그인 사용자의 memberId 추출
-    private Long getCurrentUserId() {
-        String email = SecurityUtil.getCurrentUserEmail();
-        return memberRepository.findByEmail(email)
-                .map(Member::getId)
-                .orElseThrow(() -> new GuideException(GuideErrorCode.MEMBER_NOT_FOUND));
     }
 }

--- a/backend/module-domain/src/main/java/com/team6/domain/guide/service/GuideProfileService.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/service/GuideProfileService.java
@@ -20,6 +20,7 @@ import com.team6.domain.guide.repository.GuideProfileRepository;
 import com.team6.domain.matching.entity.enums.PaymentStatus;
 import com.team6.domain.matching.repository.PaymentRepository;
 import com.team6.domain.member.entity.Member;
+import com.team6.domain.member.entity.Role;
 import com.team6.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -27,6 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * 가이드 프로필 서비스 (F06-01, F06-02, F06-06)
@@ -45,14 +47,18 @@ public class GuideProfileService {
     // 가이드 프로필 등록 (F06-01)
     @Transactional
     public GuideProfileResponse createProfile(CreateGuideProfileRequest request, Long userId) {
-        // 이미 등록된 가이드인지 확인
-        if (guideProfileRepository.existsByMemberId(userId)) {
+        Member requester = memberRepository.findById(userId)
+                .orElseThrow(() -> new GuideException(GuideErrorCode.MEMBER_NOT_FOUND));
+        Member guideMember = resolveOrCreateGuideMember(requester);
+
+        // GUIDE 멤버 기준으로 이미 프로필이 있으면 중복 등록 차단
+        if (guideProfileRepository.existsByMemberId(guideMember.getId())) {
             throw new GuideException(GuideErrorCode.GUIDE_ALREADY_EXISTS);
         }
 
         // 엔티티 생성 및 저장
         GuideProfile profile = GuideProfile.builder()
-                .memberId(userId)
+                .memberId(guideMember.getId())
                 .nickname(request.getNickname())
                 .profileImage(request.getProfileImage())
                 .bio(request.getBio())
@@ -66,13 +72,44 @@ public class GuideProfileService {
                 .build();
 
         GuideProfile saved = guideProfileRepository.save(profile);
-
-        // 가이드 프로필 등록 시 Member Role을 GUIDE로 업그레이드
-        Member member = memberRepository.findById(userId)
-                .orElseThrow(() -> new GuideException(GuideErrorCode.MEMBER_NOT_FOUND));
-        member.upgradeToGuide();
-
         return GuideProfileResponse.from(saved);
+    }
+
+    private Member resolveOrCreateGuideMember(Member requester) {
+        if (requester.getRole() == Role.GUIDE) {
+            return requester;
+        }
+        return memberRepository.findByEmailAndRole(requester.getEmail(), Role.GUIDE)
+                .orElseGet(() -> {
+                    String guideNickname = resolveGuideNickname(requester.getNickname(), requester.getEmail());
+                    Member guideMember = Member.builder()
+                            .email(requester.getEmail())
+                            .password(requester.getPassword())
+                            .name(requester.getName())
+                            .nickname(guideNickname)
+                            .role(Role.GUIDE)
+                            .status(requester.getStatus())
+                            .socialType(requester.getSocialType())
+                            .build();
+                    return memberRepository.save(guideMember);
+                });
+    }
+
+    private String resolveGuideNickname(String preferredNickname, String email) {
+        if (preferredNickname != null && !preferredNickname.isBlank() && !memberRepository.existsByNickname(preferredNickname)) {
+            return preferredNickname;
+        }
+
+        String base = (preferredNickname != null && !preferredNickname.isBlank())
+                ? preferredNickname + "_guide"
+                : email.split("@")[0] + "_guide";
+
+        String candidate = base;
+        while (memberRepository.existsByNickname(candidate)) {
+            int suffix = ThreadLocalRandom.current().nextInt(1000, 10000);
+            candidate = base + "_" + suffix;
+        }
+        return candidate;
     }
 
     // 가이드 프로필 수정 (F06-01)

--- a/backend/module-domain/src/main/java/com/team6/domain/guide/support/GuideAuthenticationSupport.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/support/GuideAuthenticationSupport.java
@@ -1,0 +1,58 @@
+package com.team6.domain.guide.support;
+
+import com.team6.domain.guide.exception.GuideErrorCode;
+import com.team6.domain.guide.exception.GuideException;
+import com.team6.domain.member.entity.Member;
+import com.team6.domain.member.entity.Role;
+import com.team6.domain.member.repository.MemberRepository;
+import com.team6.module.common.global.util.SecurityUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class GuideAuthenticationSupport {
+
+    private final MemberRepository memberRepository;
+
+    public Long getCurrentMemberId() {
+        String email = SecurityUtil.getCurrentUserEmail();
+        Role role = resolveTokenRole();
+        return memberRepository.findByEmailAndRole(email, role)
+                .map(Member::getId)
+                .orElseThrow(() -> new GuideException(GuideErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    public Long getCurrentGuideMemberId() {
+        String email = SecurityUtil.getCurrentUserEmail();
+        if (resolveTokenRole() != Role.GUIDE) {
+            throw new GuideException(GuideErrorCode.GUIDE_UNAUTHORIZED);
+        }
+        return memberRepository.findByEmailAndRole(email, Role.GUIDE)
+                .map(Member::getId)
+                .orElseThrow(() -> new GuideException(GuideErrorCode.GUIDE_UNAUTHORIZED));
+    }
+
+    private Role resolveTokenRole() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated()) {
+            throw new GuideException(GuideErrorCode.GUIDE_UNAUTHORIZED);
+        }
+        for (GrantedAuthority authority : auth.getAuthorities()) {
+            String value = authority.getAuthority();
+            if ("ROLE_GUEST".equals(value)) {
+                return Role.GUEST;
+            }
+            if ("ROLE_GUIDE".equals(value)) {
+                return Role.GUIDE;
+            }
+            if ("ROLE_ADMIN".equals(value)) {
+                return Role.ADMIN;
+            }
+        }
+        throw new GuideException(GuideErrorCode.GUIDE_UNAUTHORIZED);
+    }
+}

--- a/frontend/src/pages/GuideApplyPage.jsx
+++ b/frontend/src/pages/GuideApplyPage.jsx
@@ -86,8 +86,8 @@ export function GuideApplyPage() {
         </p>
       )}
       <p className="form-hint">
-        F01-03 · <code>POST /api/guides</code> — 성공 시 서버에서 회원 역할이 GUIDE로 변경되며, JWT는{' '}
-        <strong>재로그인</strong> 후에야 갱신됩니다.
+        F01-03 · <code>POST /api/guides</code> — 성공 시 동일 이메일의 <strong>GUIDE 로그인 유형</strong>이 준비됩니다.
+        <strong> 재로그인</strong> 후 로그인 유형에서 GUIDE를 선택해 주세요.
       </p>
 
       <form className="form-card" onSubmit={(e) => void handleSubmit(e)}>

--- a/frontend/src/pages/MyPageOverview.jsx
+++ b/frontend/src/pages/MyPageOverview.jsx
@@ -11,8 +11,8 @@ export function MyPageOverview() {
       <p style={{ color: '#555', lineHeight: 1.5 }}>
         로그인 계정: <strong>{email}</strong>
         <br />
-        JWT 역할: <strong>{isGuide ? 'GUIDE' : 'GUEST'}</strong> — F01-03 승격 후에는 반드시{' '}
-        <strong>재로그인</strong>해야 토큰에 GUIDE가 반영됩니다.
+        JWT 역할: <strong>{isGuide ? 'GUIDE' : 'GUEST'}</strong> — 가이드 신청 후에는 <strong>재로그인</strong>해서
+        로그인 유형을 GUIDE로 선택하면 가이드 토큰이 발급됩니다.
       </p>
       <ul style={{ paddingLeft: '1.2rem', color: '#444', lineHeight: 1.6 }}>
         <li>


### PR DESCRIPTION
## 제목
Feat/be#<issue번호>: 한 이메일 GUEST/GUIDE 동시 보유 가능하도록 guide 인증/가입 흐름 개선
## 변경 이유
기존 가이드 신청 흐름은 GUEST row를 GUIDE로 덮어써서 로그인 유형 선택 UX와 실제 토큰 발급이 어긋났습니다.
이번 PR은 role 분리 모델에 맞춰 GUIDE 계정을 별도 생성/재사용하고, guide 인증을 role-aware 방식으로 정리합니다.

## 주요 변경사항
- `GuideProfileService`
  - 가이드 신청 시 `upgradeToGuide()` 제거
  - 요청자 role 기준으로 GUIDE member 생성/재사용 로직 추가
  - 닉네임 유니크 충돌 회피 로직 추가
- `GuideAuthenticationSupport` 신규 추가
  - JWT role 기반으로 member 조회 (`findByEmailAndRole`)
- Guide 컨트롤러 인증 로직 교체
  - `GuideProfileController`
  - `GuideFeedController`
  - `GuideCareerController`
  - `GuideImageController`
  - `GuideScheduleController`
- 프론트 문구 보정
  - `GuideApplyPage.jsx`
  - `MyPageOverview.jsx`

## 상세 파일
- `backend/module-domain/src/main/java/com/team6/domain/guide/service/GuideProfileService.java`
- `backend/module-domain/src/main/java/com/team6/domain/guide/support/GuideAuthenticationSupport.java` (new)
- `backend/module-domain/src/main/java/com/team6/domain/guide/controller/*.java` (5 files)
- `frontend/src/pages/GuideApplyPage.jsx`
- `frontend/src/pages/MyPageOverview.jsx`

## 테스트
- [x] `:module-domain:compileJava` 통과
- [x] 프론트 lint 오류 없음
- [ ] 수동 통합 테스트 (로컬)
  - [ ] GUEST 로그인
  - [ ] 가이드 신청
  - [ ] GUIDE 로그인
  - [ ] GUEST 재로그인
  - [ ] GUIDE 전용 API 인가 확인

## 리스크/주의사항
- 기존에 이미 GUIDE만 남아 있는 계정의 데이터 상태에 따라 마이그레이션 필요 가능
- nickname 유니크 정책에 따른 GUIDE 계정 닉네임 suffix 생성 동작 확인 필요

## 체크리스트
- [x] 기능 변경 의도와 코드 동작 일치
- [x] role-aware 인증 적용 범위 점검
- [x] 불필요한 자동 role 전환 제거
- [ ] QA 시나리오 완료