### PR TITLE
Feat/be#241 AI 추천 카드 클릭 로그 수집(1단계)

### DIFF
--- a/backend/module-ai/src/main/java/com/team6/module/ai/controller/AiController.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/controller/AiController.java
@@ -1,6 +1,7 @@
 package com.team6.module.ai.controller;
 
 import com.team6.module.ai.dto.openapi.OpenApiStandardErrorBody;
+import com.team6.module.ai.dto.request.AiRecommendClickRequest;
 import com.team6.module.ai.dto.request.PromptRecommendApiRequest;
 import com.team6.module.ai.support.GuideCandidateProvider;
 import com.team6.module.ai.dto.request.GuideRecommendRequest;
@@ -10,7 +11,9 @@ import com.team6.module.ai.http.RecommendationHttpHeaders;
 import com.team6.module.ai.service.PromptRecommendationService;
 import com.team6.module.ai.support.GuideCandidateBundle;
 import com.team6.module.ai.parser.PromptParser;
+import com.team6.module.ai.support.AiRecommendationMetrics;
 import com.team6.module.ai.support.GuideAvailabilityProvider;
+import com.team6.module.ai.support.AiRecommendationTuning;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -20,6 +23,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -31,11 +35,16 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.CRC32;
 
 @Tag(name = "AI", description = "룰 기반 가이드 추천(프롬프트 파싱 + 스코어링)")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/ai")
+@Slf4j
 public class AiController {
 
     // F03 추천 파이프라인의 메인 조립자.
@@ -54,6 +63,9 @@ public class AiController {
 
     // 일정 필터에 걸려 메인 추천에서 빠진 가이드에 대해, 가능한 날짜를 안내하기 위한 조회용 provider다.
     private final GuideAvailabilityProvider guideAvailabilityProvider;
+
+    // 추천 클릭 같은 탐색 신호를 관측한다(1단계: 메트릭+로그).
+    private final AiRecommendationMetrics recommendationMetrics;
 
     @Operation(
             summary = "프롬프트 기반 가이드 추천",
@@ -161,6 +173,40 @@ public class AiController {
         return ResponseEntity.ok()
                 .header(RecommendationHttpHeaders.X_RECOMMENDATION_POLICY, policy)
                 .body(body);
+    }
+
+    @Operation(
+            summary = "추천 카드 클릭 이벤트 수집",
+            description = "추천 결과 카드 클릭 로그(관심/탐색 신호). 1단계는 서버 로그+Micrometer로 수집합니다."
+    )
+    @ApiResponse(responseCode = "204", description = "수집 성공(응답 바디 없음)")
+    @PostMapping(value = "/recommend/click", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void recordRecommendClick(@RequestBody AiRecommendClickRequest request) {
+        String pv = (request == null || request.getPolicyVersion() == null || request.getPolicyVersion().isBlank())
+                ? AiRecommendationTuning.POLICY_VERSION
+                : request.getPolicyVersion();
+        Integer rank = request == null ? null : request.getRank();
+        Long guideId = request == null ? null : request.getGuideId();
+        String clientReqId = request == null ? null : request.getClientRequestId();
+
+        recommendationMetrics.recordRecommendationClick(rank, pv);
+
+        // 프롬프트는 원문 저장을 피하고 해시로만 남긴다(민감정보 최소화).
+        String prompt = request == null ? null : request.getPrompt();
+        Integer promptHash = (prompt == null || prompt.isBlank()) ? null : promptHash(prompt);
+        log.info("[AI_RECOMMEND_CLICK] policyVer={} guideId={} rank={} promptHash={} clientReqId={}",
+                pv, guideId, rank, promptHash, clientReqId);
+    }
+
+    private static int promptHash(String prompt) {
+        if (prompt == null || prompt.isBlank()) {
+            return 0;
+        }
+        CRC32 crc32 = new CRC32();
+        crc32.update(prompt.getBytes(StandardCharsets.UTF_8));
+        long v = crc32.getValue();
+        return (int) (v ^ (v >>> 32));
     }
 
     private static GuideRecommendResponse enrichNoticeForDateFilteredEmpty(

--- a/backend/module-ai/src/main/java/com/team6/module/ai/dto/request/AiRecommendClickRequest.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/dto/request/AiRecommendClickRequest.java
@@ -1,0 +1,27 @@
+package com.team6.module.ai.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+@Schema(name = "AiRecommendClickRequest", description = "추천 카드 클릭 이벤트(관심/탐색 신호)")
+@Getter
+@Setter
+public class AiRecommendClickRequest {
+
+    @Schema(description = "추천에 사용된 policyVersion(응답 헤더/바디와 동일)", example = "2026.04.25")
+    private String policyVersion;
+
+    @Schema(description = "클릭된 가이드 ID", example = "12")
+    private Long guideId;
+
+    @Schema(description = "추천 리스트 내 노출 순서(1부터)", example = "1")
+    private Integer rank;
+
+    @Schema(description = "추천 요청 프롬프트 원문(선택). 민감정보 우려 시 미전달 권장", example = "제주 힐링 여행")
+    private String prompt;
+
+    @Schema(description = "프론트가 만든 세션/요청 상관 ID(선택)", example = "web-req-9f12")
+    private String clientRequestId;
+}
+

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationMetrics.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationMetrics.java
@@ -151,4 +151,15 @@ public class AiRecommendationMetrics {
         registry.summary(PREFIX + ".diversity_penalty_magnitude", Tags.of("policy_version", pv))
                 .record(penaltyPoints);
     }
+
+    /**
+     * 추천 카드 클릭 이벤트. 저장소/파이프라인이 없더라도 1단계에서는 메트릭으로 수집한다.
+     *
+     * @param rank 추천 리스트 내 노출 순서(1부터). 미전달/비정상이면 unknown.
+     */
+    public void recordRecommendationClick(Integer rank, String policyVersion) {
+        String pv = policyVersion == null ? "unknown" : policyVersion;
+        String r = (rank == null || rank <= 0) ? "unknown" : String.valueOf(rank);
+        registry.counter(PREFIX + ".click", Tags.of("policy_version", pv, "rank", r)).increment();
+    }
 }

--- a/backend/module-ai/src/test/java/com/team6/module/ai/controller/AiRecommendEndpointMockMvcTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/controller/AiRecommendEndpointMockMvcTest.java
@@ -8,6 +8,7 @@ import com.team6.module.ai.dto.response.GuideRecommendResponse;
 import com.team6.module.ai.http.RecommendationHttpHeaders;
 import com.team6.module.ai.parser.PromptParser;
 import com.team6.module.ai.service.PromptRecommendationService;
+import com.team6.module.ai.support.AiRecommendationMetrics;
 import com.team6.module.ai.support.GuideAvailabilityProvider;
 import com.team6.module.ai.support.GuideCandidateBundle;
 import com.team6.module.ai.support.GuideCandidateProvider;
@@ -57,6 +58,8 @@ class AiRecommendEndpointMockMvcTest {
     private PromptParser promptParser;
     @MockitoBean
     private GuideAvailabilityProvider guideAvailabilityProvider;
+    @MockitoBean
+    private AiRecommendationMetrics recommendationMetrics;
 
     @Test
     void postRecommend_returnsJson_andPolicyHeader() throws Exception {

--- a/backend/module-ai/src/test/java/com/team6/module/ai/regression/AiRecommendOrchestrationRegressionTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/regression/AiRecommendOrchestrationRegressionTest.java
@@ -10,6 +10,7 @@ import com.team6.module.ai.service.PromptRecommendationService;
 import com.team6.module.ai.support.GuideAvailabilityProvider;
 import com.team6.module.ai.support.GuideCandidateBundle;
 import com.team6.module.ai.support.GuideCandidateProvider;
+import com.team6.module.ai.support.AiRecommendationMetrics;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,6 +21,7 @@ import org.springframework.http.ResponseEntity;
 
 import java.time.LocalDate;
 import java.util.List;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -50,11 +52,13 @@ class AiRecommendOrchestrationRegressionTest {
 
     @BeforeEach
     void setUp() {
+        AiRecommendationMetrics metrics = new AiRecommendationMetrics(new SimpleMeterRegistry());
         aiController = new AiController(
                 promptRecommendationService,
                 guideCandidateProvider,
                 promptParser,
-                guideAvailabilityProvider
+                guideAvailabilityProvider,
+                metrics
         );
     }
 


### PR DESCRIPTION
## 변경
- `POST /ai/recommend/click` 추가: 추천 카드 클릭 이벤트 수집
  - 요청: `policyVersion`, `guideId`, `rank` (+ 선택: `prompt`, `clientRequestId`)
  - 응답: 204
- 구조화 로그: `[AI_RECOMMEND_CLICK]` 태그로 policyVer/guideId/rank/promptHash/clientReqId 기록
- Micrometer: `localguest.ai.recommend.click` 카운터(policy_version, rank 태그)

## 비고
- 1단계는 저장소 없이 로그+메트릭으로만 수집(추후 DB/스트림 연동 가능)
- 프롬프트 원문은 저장하지 않고 해시로만 로깅

## 검증
```bash
cd backend && ./gradlew :module-ai:test :api-server:compileJava :module-ai-integration:compileJava
```

Closes #241

Made with [Cursor](https://cursor.com)