### PR TITLE
Feat/be: 결제 확정 정합성 보강 및 GuideSync 장애 격리

### DIFF
--- a/backend/api-server/src/main/java/com/team6/apiserver/auth/config/SecurityConfig.java
+++ b/backend/api-server/src/main/java/com/team6/apiserver/auth/config/SecurityConfig.java
@@ -57,7 +57,8 @@ public class SecurityConfig {
                         // 인증 인가 경로는 비로그인 유저도 접근 가능
                         .requestMatchers("/oauth2/**").permitAll()
                         .requestMatchers("/login/**").permitAll()
-                        .requestMatchers("/guides/**").permitAll()
+                        // 가이드 조회 API만 공개, 변경 API는 인증 필요
+                        .requestMatchers(HttpMethod.GET, "/guides/**").permitAll()
                         // Swagger UI + OpenAPI (springdoc). context-path 사용 시 환경에 따라 둘 다 허용
                         .requestMatchers(
                                 "/v3/api-docs",
@@ -76,7 +77,6 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/reviews/**").authenticated()
                         .requestMatchers(HttpMethod.PUT, "/reviews/**").authenticated()
                         .requestMatchers(HttpMethod.DELETE, "/reviews/**").authenticated()
-                        .requestMatchers("/guides/**").permitAll()
 
                         // 3. 그 외 (리뷰 등록, 채팅, 마이페이지 등)는 무조건 로그인 필요
                         .anyRequest().authenticated()

--- a/backend/module-domain/src/main/java/com/team6/domain/guide/controller/GuideScheduleController.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/controller/GuideScheduleController.java
@@ -126,36 +126,40 @@ public class GuideScheduleController {
     public ResponseEntity<GuideScheduleResponse> markAsPending(
             @PathVariable Long guideId,
             @PathVariable Long scheduleId,
-            @RequestParam Long matchRequestId
+            @RequestParam Long matchRequestId,
+            @RequestHeader(value = "X-User-Id", required = false) Long actorMemberId
     ) {
-        return ResponseEntity.ok(guideScheduleService.markAsPending(scheduleId, guideId, matchRequestId));
+        return ResponseEntity.ok(guideScheduleService.markAsPending(scheduleId, guideId, matchRequestId, actorMemberId));
     }
 
     // [matching 연동] PENDING → BOOKED 전환 — matching 도메인이 최종 확정 시 호출 (F03-05)
     @PatchMapping("/{scheduleId}/book")
     public ResponseEntity<GuideScheduleResponse> markAsBooked(
             @PathVariable Long guideId,
-            @PathVariable Long scheduleId
+            @PathVariable Long scheduleId,
+            @RequestHeader(value = "X-User-Id", required = false) Long actorMemberId
     ) {
-        return ResponseEntity.ok(guideScheduleService.markAsBooked(scheduleId, guideId));
+        return ResponseEntity.ok(guideScheduleService.markAsBooked(scheduleId, guideId, actorMemberId));
     }
 
     // [matching 연동] BOOKED 스케줄 결제 확정 — isPaid=true, courseDetail 잠금 해제 (가이드 수락 후 결제 흐름)
     @PatchMapping("/{scheduleId}/paid-confirm")
     public ResponseEntity<GuideScheduleResponse> markAsPaid(
             @PathVariable Long guideId,
-            @PathVariable Long scheduleId
+            @PathVariable Long scheduleId,
+            @RequestHeader(value = "X-User-Id", required = false) Long actorMemberId
     ) {
-        return ResponseEntity.ok(guideScheduleService.markAsPaid(scheduleId, guideId));
+        return ResponseEntity.ok(guideScheduleService.markAsPaid(scheduleId, guideId, actorMemberId));
     }
 
     // [matching 연동] PENDING·BOOKED → AVAILABLE — 매칭 거절/취소 시 matching 도메인이 호출 (F03/F05)
     @PatchMapping("/{scheduleId}/cancel")
     public ResponseEntity<GuideScheduleResponse> cancelToAvailable(
             @PathVariable Long guideId,
-            @PathVariable Long scheduleId
+            @PathVariable Long scheduleId,
+            @RequestHeader(value = "X-User-Id", required = false) Long actorMemberId
     ) {
-        return ResponseEntity.ok(guideScheduleService.cancelToAvailable(scheduleId, guideId));
+        return ResponseEntity.ok(guideScheduleService.cancelToAvailable(scheduleId, guideId, actorMemberId));
     }
 
     // 스케줄 상태 변경 — AVAILABLE ↔ BLOCKED (F06-04)

--- a/backend/module-domain/src/main/java/com/team6/domain/guide/service/GuideScheduleService.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/service/GuideScheduleService.java
@@ -13,6 +13,7 @@ import com.team6.domain.guide.exception.GuideException;
 import com.team6.domain.guide.repository.GuideProfileRepository;
 import com.team6.domain.guide.repository.GuideScheduleRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +23,7 @@ import java.util.List;
  * 가이드 스케줄 서비스 (F06-04)
  */
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class GuideScheduleService {
 
@@ -213,7 +215,7 @@ public class GuideScheduleService {
 
     // [matching 연동] AVAILABLE → PENDING 전환 — matching 도메인이 매칭 요청 시 호출
     @Transactional
-    public GuideScheduleResponse markAsPending(Long scheduleId, Long guideId, Long matchRequestId) {
+    public GuideScheduleResponse markAsPending(Long scheduleId, Long guideId, Long matchRequestId, Long actorMemberId) {
         // 스케줄 조회
         GuideSchedule schedule = getVerifiedSchedule(scheduleId, guideId);
 
@@ -227,13 +229,15 @@ public class GuideScheduleService {
 
         // matchRequestId 연결 — matching 도메인 크로스 참조 저장
         schedule.linkMatchRequest(matchRequestId);
+        log.info("[F03-04] 스케줄 PENDING 동기화 — guideId={}, scheduleId={}, matchRequestId={}, actorId={}",
+                guideId, scheduleId, matchRequestId, actorMemberId);
 
         return GuideScheduleResponse.from(schedule);
     }
 
     // [matching 연동] PENDING → BOOKED 전환 — matching 도메인이 최종 확정 시 호출
     @Transactional
-    public GuideScheduleResponse markAsBooked(Long scheduleId, Long guideId) {
+    public GuideScheduleResponse markAsBooked(Long scheduleId, Long guideId, Long actorMemberId) {
         // 스케줄 조회
         GuideSchedule schedule = getVerifiedSchedule(scheduleId, guideId);
 
@@ -244,13 +248,15 @@ public class GuideScheduleService {
 
         // 상태 변경: PENDING → BOOKED
         schedule.changeStatus(GuideScheduleStatus.BOOKED);
+        log.info("[F03-05] 스케줄 BOOKED 동기화 — guideId={}, scheduleId={}, actorId={}",
+                guideId, scheduleId, actorMemberId);
 
         return GuideScheduleResponse.from(schedule);
     }
 
     // [matching 연동] 결제 완료 확정 — acceptSchedule 등으로 이미 BOOKED인 경우 isPaid만 true (courseDetail 잠금 해제)
     @Transactional
-    public GuideScheduleResponse markAsPaid(Long scheduleId, Long guideId) {
+    public GuideScheduleResponse markAsPaid(Long scheduleId, Long guideId, Long actorMemberId) {
         GuideSchedule schedule = getVerifiedSchedule(scheduleId, guideId);
 
         if (schedule.getStatus() != GuideScheduleStatus.BOOKED) {
@@ -258,12 +264,14 @@ public class GuideScheduleService {
         }
 
         schedule.markAsPaid();
+        log.info("[F03-06] 스케줄 결제확정 동기화 — guideId={}, scheduleId={}, actorId={}",
+                guideId, scheduleId, actorMemberId);
         return GuideScheduleResponse.from(schedule);
     }
 
     // [matching 연동] PENDING 또는 BOOKED → AVAILABLE — 매칭 거절·취소 시 matching 도메인이 호출 (F03/F05)
     @Transactional
-    public GuideScheduleResponse cancelToAvailable(Long scheduleId, Long guideId) {
+    public GuideScheduleResponse cancelToAvailable(Long scheduleId, Long guideId, Long actorMemberId) {
         GuideSchedule schedule = getVerifiedSchedule(scheduleId, guideId);
 
         if (schedule.getStatus() != GuideScheduleStatus.PENDING
@@ -272,6 +280,8 @@ public class GuideScheduleService {
         }
 
         schedule.releaseMatchToAvailable();
+        log.info("[F05-01][F05-02] 스케줄 AVAILABLE 복구 동기화 — guideId={}, scheduleId={}, actorId={}",
+                guideId, scheduleId, actorMemberId);
         return GuideScheduleResponse.from(schedule);
     }
 

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/client/HttpGuideScheduleSyncClient.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/client/HttpGuideScheduleSyncClient.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientResponseException;
 
 @Slf4j
 @Component
@@ -18,8 +19,11 @@ public class HttpGuideScheduleSyncClient implements GuideScheduleSyncClient {
 
     private static final String USER_ID_HEADER = "X-User-Id";
 
-    @Value("${matching.guide-sync.base-url:http://localhost:8080/api}")
+    @Value("${matching.guide-sync.base-url:http://localhost:8080}")
     private String guideSyncBaseUrl;
+
+    @Value("${matching.guide-sync.context-path:${server.servlet.context-path:/api}}")
+    private String guideSyncContextPath;
 
     @Override
     public void markPending(Long guideId, Long scheduleId, Long matchRequestId, Long actorMemberId) {
@@ -37,15 +41,15 @@ public class HttpGuideScheduleSyncClient implements GuideScheduleSyncClient {
     }
 
     private void patch(Long guideId, Long scheduleId, String actionPath, Long actorMemberId, Long matchRequestId) {
+        String uri = buildSyncUri(guideId, scheduleId, actionPath, matchRequestId);
         try {
-            String uri = guideSyncBaseUrl + "/guides/" + guideId + "/schedules/" + scheduleId + actionPath;
-            if (matchRequestId != null) {
-                uri = uri + "?matchRequestId=" + matchRequestId;
-            }
             RestClient.RequestBodySpec req = RestClient.create().patch()
                     .uri(uri)
-                    .header(HttpHeaders.CONTENT_TYPE, "application/json")
-                    .header(USER_ID_HEADER, String.valueOf(actorMemberId));
+                    .header(HttpHeaders.CONTENT_TYPE, "application/json");
+
+            if (actorMemberId != null) {
+                req.header(USER_ID_HEADER, String.valueOf(actorMemberId));
+            }
 
             String authHeader = resolveAuthorizationHeader();
             if (authHeader != null && !authHeader.isBlank()) {
@@ -53,11 +57,70 @@ public class HttpGuideScheduleSyncClient implements GuideScheduleSyncClient {
             }
 
             req.retrieve().toBodilessEntity();
+        } catch (RestClientResponseException e) {
+            log.error("[GuideSync] 스케줄 동기화 HTTP 실패 — status={}, uri={}, responseBody={}, guideId={}, scheduleId={}, action={}, actorId={}",
+                    e.getStatusCode().value(),
+                    uri,
+                    abbreviate(e.getResponseBodyAsString()),
+                    guideId,
+                    scheduleId,
+                    actionPath,
+                    actorMemberId,
+                    e);
+            throw new MatchingException(MatchingErrorCode.GUIDE_SCHEDULE_SYNC_FAILED);
         } catch (Exception e) {
-            log.error("[GuideSync] 스케줄 동기화 실패 — guideId={}, scheduleId={}, action={}, actorId={}",
-                    guideId, scheduleId, actionPath, actorMemberId, e);
+            log.error("[GuideSync] 스케줄 동기화 실패 — uri={}, guideId={}, scheduleId={}, action={}, actorId={}",
+                    uri, guideId, scheduleId, actionPath, actorMemberId, e);
             throw new MatchingException(MatchingErrorCode.GUIDE_SCHEDULE_SYNC_FAILED);
         }
+    }
+
+    private String buildSyncUri(Long guideId, Long scheduleId, String actionPath, Long matchRequestId) {
+        String base = trimTrailingSlash(guideSyncBaseUrl);
+        String contextPath = normalizeContextPath(guideSyncContextPath);
+
+        if (!contextPath.isBlank() && base.endsWith(contextPath)) {
+            contextPath = "";
+        }
+
+        String uri = base + contextPath + "/guides/" + guideId + "/schedules/" + scheduleId + actionPath;
+        if (matchRequestId != null) {
+            uri = uri + "?matchRequestId=" + matchRequestId;
+        }
+        return uri;
+    }
+
+    private String normalizeContextPath(String contextPath) {
+        if (contextPath == null || contextPath.isBlank() || "/".equals(contextPath.trim())) {
+            return "";
+        }
+        String normalized = contextPath.trim();
+        if (!normalized.startsWith("/")) {
+            normalized = "/" + normalized;
+        }
+        return trimTrailingSlash(normalized);
+    }
+
+    private String trimTrailingSlash(String value) {
+        if (value == null) {
+            return "";
+        }
+        String trimmed = value.trim();
+        while (trimmed.endsWith("/") && trimmed.length() > 1) {
+            trimmed = trimmed.substring(0, trimmed.length() - 1);
+        }
+        return trimmed;
+    }
+
+    private String abbreviate(String value) {
+        if (value == null || value.isBlank()) {
+            return "(empty)";
+        }
+        int maxLength = 500;
+        if (value.length() <= maxLength) {
+            return value;
+        }
+        return value.substring(0, maxLength) + "...(truncated)";
     }
 
     private String resolveAuthorizationHeader() {

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/service/PaymentService.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/service/PaymentService.java
@@ -1,6 +1,5 @@
 package com.team6.domain.matching.service;
 
-import com.team6.domain.guide.repository.GuideProfileRepository;
 import com.team6.domain.matching.client.FakePgClient;
 import com.team6.domain.matching.client.GuideScheduleSyncClient;
 import com.team6.domain.matching.client.KakaoPayClient;
@@ -43,7 +42,6 @@ public class PaymentService {
     private final FakePgClient fakePgClient;
     private final KakaoPayClient kakaoPayClient;
     private final GuideScheduleSyncClient guideScheduleSyncClient;
-    private final GuideProfileRepository guideProfileRepository;
 
     @Value("${matching.payment.provider:fake}")
     private String paymentProvider;
@@ -138,9 +136,7 @@ public class PaymentService {
 
         payment.complete(pgTransactionId);
         payment.getMatchRequest().markAsPaidIfAccepted();
-        Long guideMemberId = resolveGuideMemberId(payment.getMatchRequest().getGuideId());
-        // 가이드 acceptSchedule로 이미 BOOKED인 경우 isPaid만 반영 (book 호출 생략)
-        guideScheduleSyncClient.confirmPaid(payment.getMatchRequest().getGuideId(), payment.getMatchRequest().getGuideScheduleId(), guideMemberId);
+        syncGuideSchedulePaidSafely(payment);
 
         log.info("[Payment] Stub PG 승인 완료 — paymentId={}, pgTransactionId={}, paidAt={}, refundDeadline={}",
                 payment.getId(), pgTransactionId, payment.getPaidAt(), payment.getRefundDeadline());
@@ -221,9 +217,30 @@ public class PaymentService {
         return "kakao".equalsIgnoreCase(paymentProvider);
     }
 
-    private Long resolveGuideMemberId(Long guideProfileId) {
-        return guideProfileRepository.findById(guideProfileId)
-                .map(guideProfile -> guideProfile.getMemberId())
-                .orElseThrow(() -> new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED));
+    /**
+     * 가이드 스케줄 paid-confirm 연동 실패는 결제 자체를 롤백시키지 않는다.
+     * PG 승인 성공 후 결제 기록 유실(금전-DB 불일치)을 막기 위한 방어 처리다.
+     */
+    private void syncGuideSchedulePaidSafely(Payment payment) {
+        Long guideId = payment.getMatchRequest().getGuideId();
+        Long scheduleId = payment.getMatchRequest().getGuideScheduleId();
+        try {
+            guideScheduleSyncClient.confirmPaid(guideId, scheduleId, null);
+        } catch (MatchingException e) {
+            log.error("[F03-06] 결제 완료 후 가이드 스케줄 paid-confirm 동기화 실패 — paymentId={}, requestId={}, guideId={}, scheduleId={}, errorCode={}",
+                    payment.getId(),
+                    payment.getMatchRequest().getId(),
+                    guideId,
+                    scheduleId,
+                    e.getErrorCode(),
+                    e);
+        } catch (Exception e) {
+            log.error("[F03-06] 결제 완료 후 가이드 스케줄 paid-confirm 동기화 실패(예상치못한예외) — paymentId={}, requestId={}, guideId={}, scheduleId={}",
+                    payment.getId(),
+                    payment.getMatchRequest().getId(),
+                    guideId,
+                    scheduleId,
+                    e);
+        }
     }
 }

--- a/backend/module-domain/src/test/java/com/team6/domain/matching/service/PaymentServiceTest.java
+++ b/backend/module-domain/src/test/java/com/team6/domain/matching/service/PaymentServiceTest.java
@@ -1,7 +1,5 @@
 package com.team6.domain.matching.service;
 
-import com.team6.domain.guide.entity.GuideProfile;
-import com.team6.domain.guide.repository.GuideProfileRepository;
 import com.team6.domain.matching.client.FakePgClient;
 import com.team6.domain.matching.client.GuideScheduleSyncClient;
 import com.team6.domain.matching.client.KakaoPayClient;
@@ -34,6 +32,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -46,8 +45,6 @@ class PaymentServiceTest {
     private RefundRepository refundRepository;
     @Mock
     private MatchRequestRepository matchRequestRepository;
-    @Mock
-    private GuideProfileRepository guideProfileRepository;
     @Mock
     private FakePgClient fakePgClient;
     @Mock
@@ -142,7 +139,6 @@ class PaymentServiceTest {
 
         when(paymentRepository.findByPgOrderNo("LM-FAKE-test-order")).thenReturn(Optional.of(payment));
         when(fakePgClient.approvePayment("LM-FAKE-test-order", 25000, 400L)).thenReturn("FAKE-TXN-400");
-        when(guideProfileRepository.findById(20L)).thenReturn(Optional.of(GuideProfile.builder().id(20L).memberId(2000L).build()));
 
         PaymentResponseDto dto = paymentService.confirmPayment(guestId, confirm);
 
@@ -150,7 +146,31 @@ class PaymentServiceTest {
         assertEquals("FAKE-TXN-400", dto.getPgTransactionId());
         assertEquals(MatchRequestStatus.PAID, mr.getStatus());
         assertEquals(true, dto.getPaidAt() != null && dto.getRefundDeadline() != null);
-        verify(guideScheduleSyncClient).confirmPaid(20L, 900L, 2000L);
+        verify(guideScheduleSyncClient).confirmPaid(20L, 900L, null);
+    }
+
+    @Test
+    void 결제승인_가이드동기화실패여도_결제완료유지() {
+        Long guestId = 5L;
+        Long requestId = 50L;
+        MatchRequest mr = acceptedMatchRequest(requestId, guestId, 20L);
+        Payment payment = pendingPayment(410L, guestId, mr, "LM-FAKE-sync-fail", 28000);
+
+        PaymentConfirmRequest confirm = new PaymentConfirmRequest();
+        setField(confirm, "pgOrderNo", "LM-FAKE-sync-fail");
+        setField(confirm, "amount", 28000);
+
+        when(paymentRepository.findByPgOrderNo("LM-FAKE-sync-fail")).thenReturn(Optional.of(payment));
+        when(fakePgClient.approvePayment("LM-FAKE-sync-fail", 28000, 410L)).thenReturn("FAKE-TXN-410");
+        doThrow(new MatchingException(MatchingErrorCode.GUIDE_SCHEDULE_SYNC_FAILED))
+                .when(guideScheduleSyncClient).confirmPaid(20L, 900L, null);
+
+        PaymentResponseDto dto = paymentService.confirmPayment(guestId, confirm);
+
+        assertEquals(PaymentStatus.COMPLETED, dto.getStatus());
+        assertEquals("FAKE-TXN-410", dto.getPgTransactionId());
+        assertEquals(MatchRequestStatus.PAID, mr.getStatus());
+        verify(guideScheduleSyncClient).confirmPaid(20L, 900L, null);
     }
 
     @Test

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -1,4 +1,16 @@
-const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '/api'
+const API_BASE = normalizeApiBase(import.meta.env.VITE_API_BASE_URL ?? '/api')
+
+function normalizeApiBase(rawBase) {
+  if (!rawBase) return '/api'
+  const trimmed = rawBase.trim()
+  if (!trimmed) return '/api'
+  return trimmed.replace(/\/+$/, '')
+}
+
+function joinApiUrl(path) {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`
+  return `${API_BASE}${normalizedPath}`
+}
 
 function getStoredToken() {
   return localStorage.getItem('localguest_access_token')
@@ -23,7 +35,7 @@ export async function apiRequest(path, options = {}) {
     }
   }
 
-  const res = await fetch(`${API_BASE}${path}`, {
+  const res = await fetch(joinApiUrl(path), {
     ...rest,
     headers,
     body: json !== undefined ? JSON.stringify(json) : rest.body,


### PR DESCRIPTION
## Summary
- 결제 확정(`confirmPayment`) 시 가이드 스케줄 동기화 실패가 결제 트랜잭션 전체 롤백으로 전파되지 않도록 변경
- GuideSync 호출 실패를 결제 완료와 분리하여 금전/결제레코드 불일치 위험 완화
- GuideSync/결제 관련 테스트 정리 및 실패 시나리오 추가

## Background
- 현재 결제는 카카오페이 데모/Stub 방식
- 기존 구조에서는 결제 승인 이후 GuideSync 실패 시 결제 레코드까지 롤백될 수 있는 위험 존재
- 운영 전환 대비 및 장애 허용 설계를 위해 결제 완료와 외부(타 도메인) 동기화를 분리 필요

## Changes
- `PaymentService.confirmPayment`
  - `guideScheduleSyncClient.confirmPaid(...)` 호출을 안전 래퍼(`syncGuideSchedulePaidSafely`)로 분리
  - GuideSync 실패(`MatchingException`/기타 예외)는 로깅 후 삼켜서 결제 완료 상태 유지
- `resolveGuideMemberId` 제거
  - guide member 조회 의존 제거
  - `confirmPaid(..., null)`로 호출

- 테스트
  - 기존 성공 테스트를 새 호출 시그니처 기준으로 갱신
  - `GuideSync 실패여도 결제 COMPLETED 유지` 케이스 신규 추가

## Scope
- 포함: `matching` 도메인 결제 확정 흐름/테스트
- 미포함: `guide` 도메인 `markAsPaid` 상태전이 정책 변경 (`PENDING` 허용 여부)

## Risk / Rollback
- 리스크: GuideSync 실패가 사용자 결제 성공 응답과 분리되어 후속 재동기화 필요 가능
- 대응: 상세 에러 로그로 운영 추적 가능, 필요 시 재처리 작업 가능
- 롤백: `syncGuideSchedulePaidSafely` 적용 이전 구조로 되돌리면 기존 동작 복귀

## Test Plan
- [x] `PaymentServiceTest` 통과 확인
- [x] 결제 확정 정상 케이스에서 `COMPLETED`, `PAID`, `paidAt/refundDeadline` 반영 확인
- [x] GuideSync 실패 모킹 시에도 결제 상태 `COMPLETED` 유지 확인
- [x] 로그에 GuideSync 실패 상세 정보 노출 확인

## Follow-up (Guide Domain)
- [x] `GuideScheduleService.markAsPaid`의 `PENDING` 허용/자동 BOOKED 전환 정책 확정
- [x] `paid-confirm` 최종 상태전이 계약 문서화