### PR TITLE
Feat/be#248: paid-confirm 상태전이 완화 (PENDING 허용)

### DIFF
--- a/backend/module-domain/src/main/java/com/team6/domain/guide/service/GuideScheduleService.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/service/GuideScheduleService.java
@@ -254,12 +254,14 @@ public class GuideScheduleService {
         return GuideScheduleResponse.from(schedule);
     }
 
-    // [matching 연동] 결제 완료 확정 — acceptSchedule 등으로 이미 BOOKED인 경우 isPaid만 true (courseDetail 잠금 해제)
+    // [matching 연동] 결제 완료 확정 — PENDING이면 BOOKED로 자동 전환 후 isPaid=true 처리
     @Transactional
     public GuideScheduleResponse markAsPaid(Long scheduleId, Long guideId, Long actorMemberId) {
         GuideSchedule schedule = getVerifiedSchedule(scheduleId, guideId);
 
-        if (schedule.getStatus() != GuideScheduleStatus.BOOKED) {
+        if (schedule.getStatus() == GuideScheduleStatus.PENDING) {
+            schedule.changeStatus(GuideScheduleStatus.BOOKED);
+        } else if (schedule.getStatus() != GuideScheduleStatus.BOOKED) {
             throw new GuideException(GuideErrorCode.SCHEDULE_NOT_BOOKED);
         }
 

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/service/MatchRequestService.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/service/MatchRequestService.java
@@ -32,7 +32,8 @@ public class MatchRequestService {
 
     // 매칭 요청 생성
     public MatchRequestCreateResponse createMatchRequest(Long guestId, MatchRequestCreateRequest request) {
-        validateCreateRequest(guestId, request);
+        Long guideMemberId = resolveGuideMemberId(request.getGuideId());
+        validateCreateRequest(guestId, guideMemberId);
 
         String conceptSummary = resolveConceptSummary(request);
         MatchRequest matchRequest = MatchRequest.create(
@@ -47,7 +48,6 @@ public class MatchRequestService {
         );
 
         MatchRequest saved = matchRequestRepository.save(matchRequest);
-        Long guideMemberId = resolveGuideMemberId(saved.getGuideId());
         guideScheduleSyncClient.markPending(saved.getGuideId(), saved.getGuideScheduleId(), saved.getId(), guideMemberId);
         log.info("[F03-04] 매칭 요청 생성 — guestId={}, guideId={}", guestId, request.getGuideId());
         return MatchRequestCreateResponse.from(saved);
@@ -164,8 +164,8 @@ public class MatchRequestService {
     //.from()이라는 정적 팩토리 메서드를 호출하여 D
     // DTO로 변환한 뒤 반환
 
-    private void validateCreateRequest(Long guestId, MatchRequestCreateRequest request) {
-        if (guestId.equals(request.getGuideId())) {
+    private void validateCreateRequest(Long guestId, Long guideMemberId) {
+        if (guestId.equals(guideMemberId)) {
             throw new MatchingException(MatchingErrorCode.GUEST_GUIDE_SAME);
         }
     }

--- a/backend/module-domain/src/test/java/com/team6/domain/guide/service/GuideScheduleServiceTest.java
+++ b/backend/module-domain/src/test/java/com/team6/domain/guide/service/GuideScheduleServiceTest.java
@@ -1,0 +1,93 @@
+package com.team6.domain.guide.service;
+
+import com.team6.domain.guide.dto.response.GuideScheduleResponse;
+import com.team6.domain.guide.entity.GuideProfile;
+import com.team6.domain.guide.entity.GuideSchedule;
+import com.team6.domain.guide.entity.enums.GuideScheduleStatus;
+import com.team6.domain.guide.exception.GuideErrorCode;
+import com.team6.domain.guide.exception.GuideException;
+import com.team6.domain.guide.repository.GuideProfileRepository;
+import com.team6.domain.guide.repository.GuideScheduleRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GuideScheduleServiceTest {
+
+    @Mock
+    private GuideScheduleRepository guideScheduleRepository;
+
+    @Mock
+    private GuideProfileRepository guideProfileRepository;
+
+    @InjectMocks
+    private GuideScheduleService guideScheduleService;
+
+    @Test
+    void markAsPaid_결제확정시_PENDING이면_BOOKED로_전환후_isPaid_true() {
+        Long guideId = 10L;
+        Long scheduleId = 100L;
+        GuideSchedule schedule = createSchedule(scheduleId, guideId, GuideScheduleStatus.PENDING, false);
+        when(guideScheduleRepository.findById(scheduleId)).thenReturn(Optional.of(schedule));
+
+        GuideScheduleResponse response = guideScheduleService.markAsPaid(scheduleId, guideId, null);
+
+        assertEquals(GuideScheduleStatus.BOOKED, response.getStatus());
+        assertEquals(true, response.getIsPaid());
+    }
+
+    @Test
+    void markAsPaid_결제확정시_BOOKED이면_isPaid만_true_유지() {
+        Long guideId = 10L;
+        Long scheduleId = 101L;
+        GuideSchedule schedule = createSchedule(scheduleId, guideId, GuideScheduleStatus.BOOKED, false);
+        when(guideScheduleRepository.findById(scheduleId)).thenReturn(Optional.of(schedule));
+
+        GuideScheduleResponse response = guideScheduleService.markAsPaid(scheduleId, guideId, null);
+
+        assertEquals(GuideScheduleStatus.BOOKED, response.getStatus());
+        assertEquals(true, response.getIsPaid());
+    }
+
+    @Test
+    void markAsPaid_결제확정시_PENDING_BOOKED_아닌경우_예외() {
+        Long guideId = 10L;
+        Long scheduleId = 102L;
+        GuideSchedule schedule = createSchedule(scheduleId, guideId, GuideScheduleStatus.AVAILABLE, false);
+        when(guideScheduleRepository.findById(scheduleId)).thenReturn(Optional.of(schedule));
+
+        GuideException ex = assertThrows(GuideException.class,
+                () -> guideScheduleService.markAsPaid(scheduleId, guideId, null));
+
+        assertEquals(GuideErrorCode.SCHEDULE_NOT_BOOKED, ex.getErrorCode());
+    }
+
+    private GuideSchedule createSchedule(Long scheduleId, Long guideId, GuideScheduleStatus status, boolean isPaid) {
+        GuideProfile profile = GuideProfile.builder()
+                .id(guideId)
+                .memberId(999L)
+                .build();
+
+        return GuideSchedule.builder()
+                .id(scheduleId)
+                .guideProfile(profile)
+                .availableDate(LocalDate.of(2026, 4, 20))
+                .startTime(LocalTime.of(9, 0))
+                .endTime(LocalTime.of(12, 0))
+                .status(status)
+                .isPaid(isPaid)
+                .build();
+    }
+}
+

--- a/backend/module-domain/src/test/java/com/team6/domain/matching/service/MatchRequestServiceTest.java
+++ b/backend/module-domain/src/test/java/com/team6/domain/matching/service/MatchRequestServiceTest.java
@@ -1,0 +1,113 @@
+package com.team6.domain.matching.service;
+
+import com.team6.domain.guide.entity.GuideProfile;
+import com.team6.domain.guide.repository.GuideProfileRepository;
+import com.team6.domain.matching.client.GuideScheduleSyncClient;
+import com.team6.domain.matching.dto.request.MatchRequestCreateRequest;
+import com.team6.domain.matching.entity.MatchRequest;
+import com.team6.domain.matching.entity.enums.MatchRequestStatus;
+import com.team6.domain.matching.exception.MatchingErrorCode;
+import com.team6.domain.matching.exception.MatchingException;
+import com.team6.domain.matching.repository.MatchRequestRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MatchRequestServiceTest {
+
+    @Mock
+    private MatchRequestRepository matchRequestRepository;
+
+    @Mock
+    private GuideScheduleSyncClient guideScheduleSyncClient;
+
+    @Mock
+    private GuideProfileRepository guideProfileRepository;
+
+    @InjectMocks
+    private MatchRequestService matchRequestService;
+
+    @Test
+    void 매칭요청_생성시_본인_가이드프로필이면_예외() {
+        Long guestId = 100L;
+        Long guideProfileId = 20L;
+        MatchRequestCreateRequest request = createRequest(guideProfileId, 300L);
+
+        GuideProfile profile = GuideProfile.builder()
+                .id(guideProfileId)
+                .memberId(guestId)
+                .nickname("self-guide")
+                .region("Seoul")
+                .build();
+        when(guideProfileRepository.findById(guideProfileId)).thenReturn(Optional.of(profile));
+
+        MatchingException ex = assertThrows(MatchingException.class,
+                () -> matchRequestService.createMatchRequest(guestId, request));
+
+        assertEquals(MatchingErrorCode.GUEST_GUIDE_SAME, ex.getErrorCode());
+        verify(matchRequestRepository, never()).save(any());
+        verify(guideScheduleSyncClient, never()).markPending(any(), any(), any(), any());
+    }
+
+    @Test
+    void 매칭요청_생성시_다른가이드면_markPending_정상호출() {
+        Long guestId = 100L;
+        Long guideProfileId = 20L;
+        Long guideMemberId = 999L;
+        MatchRequestCreateRequest request = createRequest(guideProfileId, 300L);
+
+        GuideProfile profile = GuideProfile.builder()
+                .id(guideProfileId)
+                .memberId(guideMemberId)
+                .nickname("other-guide")
+                .region("Busan")
+                .build();
+        when(guideProfileRepository.findById(guideProfileId)).thenReturn(Optional.of(profile));
+        when(matchRequestRepository.save(any(MatchRequest.class))).thenAnswer(invocation -> {
+            MatchRequest saved = invocation.getArgument(0);
+            setField(saved, "id", 1L);
+            setField(saved, "status", MatchRequestStatus.PENDING);
+            return saved;
+        });
+
+        matchRequestService.createMatchRequest(guestId, request);
+
+        verify(guideScheduleSyncClient).markPending(guideProfileId, 300L, 1L, guideMemberId);
+    }
+
+    private MatchRequestCreateRequest createRequest(Long guideId, Long scheduleId) {
+        MatchRequestCreateRequest request = new MatchRequestCreateRequest();
+        setField(request, "guideId", guideId);
+        setField(request, "guideScheduleId", scheduleId);
+        setField(request, "destination", "Seoul");
+        setField(request, "concept", "food");
+        setField(request, "desiredDate", LocalDate.of(2026, 4, 20));
+        setField(request, "desiredBudget", 50000);
+        return request;
+    }
+
+    private void setField(Object target, String fieldName, Object value) {
+        try {
+            Field field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- `GuideScheduleService.markAsPaid`를 완화해 `PENDING` 상태에서도 결제 확정이 가능하도록 수정
- 결제 확정 시 `PENDING -> BOOKED + isPaid=true`로 처리
- 기존 `BOOKED -> isPaid=true` 동작 유지
- 비허용 상태는 기존처럼 `SCHEDULE_NOT_BOOKED` 예외 유지

## Background
- 결제는 카카오페이 데모/Stub 기반이지만, 운영 전환 대비 정합성 확보 필요
- 기존에는 `BOOKED` 강제 조건 때문에 결제 시점 상태 불일치 시 실패 가능
- Option B(HTTP 2회 분리) 대신 Option A(1회 처리)로 실패 지점 최소화

## Changes
- `backend/module-domain/src/main/java/com/team6/domain/guide/service/GuideScheduleService.java`
  - `markAsPaid`:
    - `PENDING`이면 `BOOKED`로 전환 후 결제 확정
    - `BOOKED`면 그대로 결제 확정
    - 그 외 상태는 예외 유지
- `backend/module-domain/src/test/java/com/team6/domain/guide/service/GuideScheduleServiceTest.java` (신규)
  - `markAsPaid` PENDING 성공 케이스
  - `markAsPaid` BOOKED 성공 케이스
  - 비허용 상태 예외 케이스
- MatchRequestService
  - createMatchRequest에서 resolveGuideMemberId(request.getGuideId())를 먼저 구함
  - validateCreateRequest(guestId, guideMemberId)로 검증
  - 같은 guideMemberId를 markPending 호출에도 재사용 (중복 조회 방지)

## Scope
- 포함: guide 도메인 `paid-confirm` 상태전이 완화
- 미포함: PROPOSED 상태 도입/DB enum 확장

## Test Plan
- [ ] `./gradlew :module-domain:test --tests "com.team6.domain.guide.service.GuideScheduleServiceTest"`
- [ ] `./gradlew :module-domain:test --tests "com.team6.domain.matching.service.PaymentServiceTest"`
- [ ] 수동 API 테스트:
  - [ ] PENDING 스케줄 `paid-confirm` 호출 성공
  - [ ] BOOKED 스케줄 `paid-confirm` 호출 성공
  - [ ] AVAILABLE 스케줄 `paid-confirm` 호출 시 `SCHEDULE_NOT_BOOKED`

## Risk / Rollback
- 리스크: 기존에 BOOKED 전제 로직을 강하게 가정한 외부 흐름이 있으면 상태 변화 타이밍 차이 가능
- 롤백: `markAsPaid`의 PENDING 허용 분기 제거 시 기존 동작으로 복귀 가능