### PR TITLE
Feat/be#251 노출 로그 + 포지션 바이어스 보정 + Redis 영속화

### DIFF
--- a/backend/module-ai/build.gradle
+++ b/backend/module-ai/build.gradle
@@ -5,6 +5,9 @@ dependencies {
     // Web Server
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    // Redis (click/exposure signals persistence)
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     implementation 'io.micrometer:micrometer-core'
     implementation 'io.swagger.core.v3:swagger-annotations-jakarta:2.2.22'
 

--- a/backend/module-ai/src/main/java/com/team6/module/ai/controller/AiController.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/controller/AiController.java
@@ -86,7 +86,7 @@ public class AiController {
             headers = @Header(
                     name = RecommendationHttpHeaders.X_RECOMMENDATION_POLICY,
                     description = "룰 정책 버전(응답 body의 policyVersion과 동일). 캐시 키·디버깅에 활용 가능.",
-                    schema = @Schema(implementation = String.class, example = "2026.04.27")
+                    schema = @Schema(implementation = String.class, example = "2026.04.28")
             ),
             content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = GuideRecommendResponse.class))
     )
@@ -202,7 +202,7 @@ public class AiController {
         String clientReqId = request == null ? null : request.getClientRequestId();
 
         recommendationMetrics.recordRecommendationClick(rank, pv);
-        clickStore.recordClick(guideId);
+        clickStore.recordClick(guideId, rank);
         String prompt = request == null ? null : request.getPrompt();
         Integer promptHash = (prompt == null || prompt.isBlank()) ? null : promptHash(prompt);
         log.info("[AI_RECOMMEND_CLICK] policyVer={} guideId={} rank={} promptHash={} clientReqId={}",
@@ -233,6 +233,7 @@ public class AiController {
                 continue;
             }
             int clicks = clickStore.recentClickCount(c.getGuideId());
+            int debiasedClicks = clickStore.debiasedClickScore(c.getGuideId());
             int exposures = exposureStore.recentExposureCount(sessionId, c.getGuideId());
             out.add(GuideRecommendRequest.GuideCandidateDto.builder()
                     .guideId(c.getGuideId())
@@ -251,6 +252,7 @@ public class AiController {
                     .representativeImageUrl(c.getRepresentativeImageUrl())
                     .publicFeedThumbnailUrls(c.getPublicFeedThumbnailUrls())
                     .recommendClickCount(clicks)
+                    .recommendClickDebiasedScore(debiasedClicks)
                     .recommendExposureCount(exposures)
                     .build());
         }
@@ -261,11 +263,14 @@ public class AiController {
         if (sessionId == null || sessionId.isBlank() || main == null || main.getRecommendations() == null) {
             return;
         }
+        int rank = 1;
         for (GuideRecommendItem item : main.getRecommendations()) {
             if (item == null) {
                 continue;
             }
             exposureStore.recordExposure(sessionId, item.getGuideId());
+            clickStore.recordExposure(item.getGuideId(), rank);
+            rank++;
         }
     }
     private static int promptHash(String prompt) {

--- a/backend/module-ai/src/main/java/com/team6/module/ai/dto/request/AiRecommendClickRequest.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/dto/request/AiRecommendClickRequest.java
@@ -9,7 +9,7 @@ import lombok.Setter;
 @Setter
 public class AiRecommendClickRequest {
 
-    @Schema(description = "추천에 사용된 policyVersion(응답 헤더/바디와 동일)", example = "2026.04.27")
+    @Schema(description = "추천에 사용된 policyVersion(응답 헤더/바디와 동일)", example = "2026.04.28")
     private String policyVersion;
 
     @Schema(description = "클릭된 가이드 ID", example = "12")

--- a/backend/module-ai/src/main/java/com/team6/module/ai/dto/request/GuideRecommendRequest.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/dto/request/GuideRecommendRequest.java
@@ -112,6 +112,9 @@ public class GuideRecommendRequest {
         @Schema(description = "추천 카드 클릭 집계(관심/탐색 신호). 미전달 시 미반영")
         private Integer recommendClickCount;
 
+        @Schema(description = "포지션(노출 순위) 편향을 보정한 클릭 신호 점수. 미전달 시 미반영")
+        private Integer recommendClickDebiasedScore;
+
         @Schema(description = "동일 세션 내 최근 추천 노출 횟수(반복 추천 완화용). 미전달 시 미반영")
         private Integer recommendExposureCount;
     }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/model/GuideAiProfile.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/model/GuideAiProfile.java
@@ -34,6 +34,9 @@ public class GuideAiProfile {
     /** 추천 카드 클릭(관심/탐색) 집계. null이면 미반영. */
     private Integer recommendClickCount;
 
+    /** 포지션(노출 순위) 편향을 보정한 클릭 신호 점수. null이면 미반영. */
+    private Integer recommendClickDebiasedScore;
+
     /** 동일 세션 내 최근 추천 노출 횟수(반복 추천 완화). null이면 미반영. */
     private Integer recommendExposureCount;
 

--- a/backend/module-ai/src/main/java/com/team6/module/ai/policy/FeedbackMatchPolicy.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/policy/FeedbackMatchPolicy.java
@@ -67,9 +67,11 @@ public class FeedbackMatchPolicy {
         }
 
         Integer clicks = guide.getRecommendClickCount();
-        if (clicks != null && clicks > 0) {
+        Integer debiased = guide.getRecommendClickDebiasedScore();
+        int clickSignal = (debiased != null && debiased > 0) ? debiased : (clicks == null ? 0 : clicks);
+        if (clickSignal > 0) {
             bonus += Math.min(
-                    clicks * scoring.recommendClickBonusPerCount(),
+                    clickSignal * scoring.recommendClickBonusPerCount(),
                     scoring.recommendClickBonusMax()
             );
         }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendClickStore.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendClickStore.java
@@ -1,12 +1,18 @@
 package com.team6.module.ai.support;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
+import org.springframework.data.redis.core.RedisTemplate;
 
 import java.time.Clock;
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -18,10 +24,21 @@ import java.util.concurrent.ConcurrentHashMap;
 public class AiRecommendClickStore {
 
     private static final Duration DEFAULT_WINDOW = Duration.ofDays(7);
+    private static final int MAX_RANK = 10;
+    private static final Duration RANK_STATS_TTL = Duration.ofDays(30);
 
     private final Map<Long, Deque<Long>> clicksByGuideId = new ConcurrentHashMap<>();
+    private final Map<Long, Map<Integer, Long>> clicksByGuideRank = new ConcurrentHashMap<>();
+    private final Map<Long, Map<Integer, Long>> exposuresByGuideRank = new ConcurrentHashMap<>();
+    private final Map<Integer, Long> globalClicksByRank = new ConcurrentHashMap<>();
+    private final Map<Integer, Long> globalExposuresByRank = new ConcurrentHashMap<>();
+
     private final Clock clock;
     private final Duration window;
+
+    @Autowired(required = false)
+    @Qualifier("memberRedisTemplate")
+    private RedisTemplate<String, String> redisTemplate;
 
     public AiRecommendClickStore() {
         this(Clock.systemUTC(), DEFAULT_WINDOW);
@@ -33,21 +50,33 @@ public class AiRecommendClickStore {
     }
 
     public void recordClick(Long guideId) {
+        recordClick(guideId, null);
+    }
+
+    public void recordClick(Long guideId, Integer rank) {
         if (guideId == null) {
             return;
         }
-        long now = clock.millis();
-        Deque<Long> q = clicksByGuideId.computeIfAbsent(guideId, ignored -> new ArrayDeque<>());
-        synchronized (q) {
-            q.addLast(now);
-            pruneLocked(q, now);
+
+        if (redisTemplate != null) {
+            recordRecentClickRedis(guideId);
+            recordRankClickRedis(guideId, rank);
+            return;
         }
+
+        recordRecentClickInMemory(guideId);
+        recordRankClickInMemory(guideId, rank);
     }
 
     public int recentClickCount(Long guideId) {
         if (guideId == null) {
             return 0;
         }
+
+        if (redisTemplate != null) {
+            return recentClickCountRedis(guideId);
+        }
+
         Deque<Long> q = clicksByGuideId.get(guideId);
         if (q == null) {
             return 0;
@@ -59,6 +88,38 @@ public class AiRecommendClickStore {
         }
     }
 
+    /**
+     * 추천 결과가 사용자에게 "노출"되었다고 기록한다(랭크 포함).
+     * <p>
+     * - 세션 반복 완화는 별도 {@link AiRecommendExposureStore}가 담당한다.
+     * - 이 메서드는 포지션 바이어스 보정(랭크별 노출/클릭 통계)에만 사용한다.
+     */
+    public void recordExposure(Long guideId, Integer rank) {
+        if (guideId == null) {
+            return;
+        }
+        if (redisTemplate != null) {
+            recordRankExposureRedis(guideId, rank);
+            return;
+        }
+        recordRankExposureInMemory(guideId, rank);
+    }
+
+    /**
+     * 포지션(랭크) 편향을 완화한 클릭 신호 점수.
+     * <p>
+     * 글로벌 랭크별 CTR을 이용해, 하위 랭크에서 발생한 클릭을 상대적으로 더 큰 신호로 본다(상한/완충 포함).
+     */
+    public int debiasedClickScore(Long guideId) {
+        if (guideId == null) {
+            return 0;
+        }
+        if (redisTemplate != null) {
+            return debiasedClickScoreRedis(guideId);
+        }
+        return debiasedClickScoreInMemory(guideId);
+    }
+
     private void pruneLocked(Deque<Long> q, long nowEpochMs) {
         long cutoff = nowEpochMs - window.toMillis();
         while (!q.isEmpty()) {
@@ -68,6 +129,127 @@ public class AiRecommendClickStore {
             }
             q.removeFirst();
         }
+    }
+
+    private void recordRecentClickInMemory(Long guideId) {
+        long now = clock.millis();
+        Deque<Long> q = clicksByGuideId.computeIfAbsent(guideId, ignored -> new ArrayDeque<>());
+        synchronized (q) {
+            q.addLast(now);
+            pruneLocked(q, now);
+        }
+    }
+
+    private void recordRankClickInMemory(Long guideId, Integer rank) {
+        int r = normalizeRank(rank);
+        clicksByGuideRank.computeIfAbsent(guideId, ignored -> new ConcurrentHashMap<>())
+                .merge(r, 1L, Long::sum);
+        globalClicksByRank.merge(r, 1L, Long::sum);
+    }
+
+    private void recordRankExposureInMemory(Long guideId, Integer rank) {
+        int r = normalizeRank(rank);
+        exposuresByGuideRank.computeIfAbsent(guideId, ignored -> new ConcurrentHashMap<>())
+                .merge(r, 1L, Long::sum);
+        globalExposuresByRank.merge(r, 1L, Long::sum);
+    }
+
+    private int debiasedClickScoreInMemory(Long guideId) {
+        Map<Integer, Long> guideClicks = clicksByGuideRank.getOrDefault(guideId, Map.of());
+        if (guideClicks.isEmpty()) {
+            return 0;
+        }
+        double ctr1 = ctr(globalClicksByRank.getOrDefault(1, 0L), globalExposuresByRank.getOrDefault(1, 0L));
+        if (ctr1 <= 0.0) {
+            ctr1 = 0.05;
+        }
+        double sum = 0.0;
+        for (int r = 1; r <= MAX_RANK; r++) {
+            long c = guideClicks.getOrDefault(r, 0L);
+            if (c <= 0) continue;
+            double ctrR = ctr(globalClicksByRank.getOrDefault(r, 0L), globalExposuresByRank.getOrDefault(r, 0L));
+            double w = ctrR <= 0.0 ? 1.0 : Math.min(5.0, ctr1 / ctrR);
+            sum += c * w;
+        }
+        return (int) Math.round(Math.min(50.0, sum));
+    }
+
+    private void recordRecentClickRedis(Long guideId) {
+        long now = clock.millis();
+        long cutoff = now - window.toMillis();
+        String key = "ai:click:z:" + guideId;
+        redisTemplate.opsForZSet().add(key, now + "-" + UUID.randomUUID(), now);
+        redisTemplate.opsForZSet().removeRangeByScore(key, 0, cutoff);
+        redisTemplate.expire(key, window.plus(Duration.ofDays(1)));
+    }
+
+    private int recentClickCountRedis(Long guideId) {
+        long now = clock.millis();
+        long cutoff = now - window.toMillis();
+        String key = "ai:click:z:" + guideId;
+        Long count = redisTemplate.opsForZSet().count(key, cutoff, now);
+        return count == null ? 0 : count.intValue();
+    }
+
+    private void recordRankClickRedis(Long guideId, Integer rank) {
+        int r = normalizeRank(rank);
+        incrWithTtl("ai:click:rank:" + r, RANK_STATS_TTL);
+        incrWithTtl("ai:click:guide:" + guideId + ":rank:" + r, RANK_STATS_TTL);
+    }
+
+    private void recordRankExposureRedis(Long guideId, Integer rank) {
+        int r = normalizeRank(rank);
+        incrWithTtl("ai:expo:rank:" + r, RANK_STATS_TTL);
+        incrWithTtl("ai:expo:guide:" + guideId + ":rank:" + r, RANK_STATS_TTL);
+    }
+
+    private int debiasedClickScoreRedis(Long guideId) {
+        double ctr1 = ctr(readLong("ai:click:rank:1"), readLong("ai:expo:rank:1"));
+        if (ctr1 <= 0.0) {
+            ctr1 = 0.05;
+        }
+        double sum = 0.0;
+        for (int r = 1; r <= MAX_RANK; r++) {
+            long c = readLong("ai:click:guide:" + guideId + ":rank:" + r);
+            if (c <= 0) continue;
+            double ctrR = ctr(readLong("ai:click:rank:" + r), readLong("ai:expo:rank:" + r));
+            double w = ctrR <= 0.0 ? 1.0 : Math.min(5.0, ctr1 / ctrR);
+            sum += c * w;
+        }
+        return (int) Math.round(Math.min(50.0, sum));
+    }
+
+    private void incrWithTtl(String key, Duration ttl) {
+        Long v = redisTemplate.opsForValue().increment(key);
+        if (v != null && v == 1L) {
+            redisTemplate.expire(key, ttl);
+        }
+    }
+
+    private long readLong(String key) {
+        String v = redisTemplate.opsForValue().get(key);
+        if (v == null || v.isBlank()) {
+            return 0L;
+        }
+        try {
+            return Long.parseLong(v.trim());
+        } catch (NumberFormatException ignored) {
+            return 0L;
+        }
+    }
+
+    private static double ctr(long clicks, long exposures) {
+        if (exposures <= 0) {
+            return 0.0;
+        }
+        return (double) clicks / (double) exposures;
+    }
+
+    private static int normalizeRank(Integer rank) {
+        if (rank == null || rank <= 0) {
+            return 0;
+        }
+        return Math.min(MAX_RANK, rank);
     }
 }
 

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendExposureStore.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendExposureStore.java
@@ -1,5 +1,8 @@
 package com.team6.module.ai.support;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
@@ -22,10 +25,24 @@ public class AiRecommendExposureStore {
 
     private final Map<String, Deque<Event>> bySession = new ConcurrentHashMap<>();
 
+    @Autowired(required = false)
+    @Qualifier("memberRedisTemplate")
+    private RedisTemplate<String, String> redisTemplate;
+
     public void recordExposure(String sessionId, Long guideId) {
         if (sessionId == null || sessionId.isBlank() || guideId == null) {
             return;
         }
+
+        if (redisTemplate != null) {
+            String key = redisKey(sessionId, guideId);
+            Long v = redisTemplate.opsForValue().increment(key);
+            if (v != null && v == 1L) {
+                redisTemplate.expire(key, WINDOW);
+            }
+            return;
+        }
+
         Deque<Event> deque = bySession.computeIfAbsent(sessionId, k -> new ArrayDeque<>());
         synchronized (deque) {
             pruneLocked(deque, nowMillis());
@@ -40,6 +57,19 @@ public class AiRecommendExposureStore {
         if (sessionId == null || sessionId.isBlank() || guideId == null) {
             return 0;
         }
+
+        if (redisTemplate != null) {
+            String v = redisTemplate.opsForValue().get(redisKey(sessionId, guideId));
+            if (v == null || v.isBlank()) {
+                return 0;
+            }
+            try {
+                return Integer.parseInt(v.trim());
+            } catch (NumberFormatException ignored) {
+                return 0;
+            }
+        }
+
         Deque<Event> deque = bySession.get(sessionId);
         if (deque == null) {
             return 0;
@@ -70,6 +100,10 @@ public class AiRecommendExposureStore {
 
     private static long nowMillis() {
         return System.currentTimeMillis();
+    }
+
+    private static String redisKey(String sessionId, Long guideId) {
+        return "ai:session:expo:" + sessionId + ":guide:" + guideId;
     }
 
     private record Event(Long guideId, long atMillis) {

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationMapper.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationMapper.java
@@ -83,6 +83,7 @@ public class AiRecommendationMapper {
                         .progressedMatchCount(candidate.getProgressedMatchCount())
                         .chatStartCount(candidate.getChatStartCount())
                         .recommendClickCount(candidate.getRecommendClickCount())
+                        .recommendClickDebiasedScore(candidate.getRecommendClickDebiasedScore())
                         .recommendExposureCount(candidate.getRecommendExposureCount())
                         .representativeImageUrl(candidate.getRepresentativeImageUrl())
                         .publicFeedThumbnailUrls(copyUrlList(candidate.getPublicFeedThumbnailUrls()))

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationTuning.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationTuning.java
@@ -19,7 +19,7 @@ public final class AiRecommendationTuning {
     /**
      * 룰/스코어/Reason/응답 계약이 바뀔 때마다 올린다. 로그·API에서 동일 프롬프트 비교 시 정책 변경 여부를 구분하는 데 쓴다.
      */
-    public static final String POLICY_VERSION = "2026.04.27";
+    public static final String POLICY_VERSION = "2026.04.28";
 
     public static final int DEFAULT_TOP_N = 3;
 

--- a/backend/module-ai/src/test/java/com/team6/module/ai/controller/AiRecommendEndpointMockMvcTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/controller/AiRecommendEndpointMockMvcTest.java
@@ -71,6 +71,7 @@ class AiRecommendEndpointMockMvcTest {
     void postRecommend_returnsJson_andPolicyHeader() throws Exception {
         when(promptParser.extractDesiredTourDateRange(any())).thenReturn(null);
         when(clickStore.recentClickCount(any())).thenReturn(0);
+        when(clickStore.debiasedClickScore(any())).thenReturn(0);
 
         GuideRecommendRequest.GuideCandidateDto dto = GuideRecommendRequest.GuideCandidateDto.builder()
                 .guideId(7L)
@@ -119,6 +120,7 @@ class AiRecommendEndpointMockMvcTest {
     void postRecommend_serializesSpecialSuggestion_whenOrchestrationProducesIt() throws Exception {
         when(promptParser.extractDesiredTourDateRange(any())).thenReturn(null);
         when(clickStore.recentClickCount(any())).thenReturn(0);
+        when(clickStore.debiasedClickScore(any())).thenReturn(0);
 
         LocalDate d = LocalDate.of(2026, 4, 28);
         GuideRecommendRequest.GuideCandidateDto a = GuideRecommendRequest.GuideCandidateDto.builder()
@@ -161,7 +163,7 @@ class AiRecommendEndpointMockMvcTest {
 
     @Test
     void postRecommendClick_returns204() throws Exception {
-        doNothing().when(clickStore).recordClick(7L);
+        doNothing().when(clickStore).recordClick(7L, 1);
         AiRecommendClickRequest body = new AiRecommendClickRequest();
         body.setGuideId(7L);
         body.setRank(1);


### PR DESCRIPTION
## Summary
- 추천 응답 시 랭크(1..N) 기반 노출(exposure)을 기록하고, 클릭 이벤트에 포함된 rank와 함께 포지션 바이어스 보정에 활용했습니다.
- `AiRecommendClickStore`/`AiRecommendExposureStore`를 Redis 사용 가능 시 Redis에 저장하도록 확장해 멀티 인스턴스/재시작에서도 신호가 유지됩니다(미설정 시 in-memory 폴백).
- 디바이어스된 클릭 신호(`recommendClickDebiasedScore`)를 후보 DTO/프로필에 주입하고, 피드백 스코어링에서 기존 클릭 카운트 대신 우선 사용하도록 반영했습니다.

## API impact
- 기존 `POST /ai/recommend/click`는 rank를 이미 받으며, 서버는 이를 활용해 랭크별 통계를 집계합니다.
- `POST /ai/recommend`는 기존처럼 동작하며, 서버가 추천 결과를 반환할 때 랭크 기반 노출을 자동 기록합니다.

## Ops / Config
- Redis가 설정된 환경에서는 `memberRedisTemplate`을 사용합니다.
- `module-ai`에 `spring-boot-starter-data-redis` 의존성을 추가했습니다(컴파일 목적).

## Version
- POLICY_VERSION: `2026.04.27` → `2026.04.28`

## Test
- `./gradlew :module-ai:test`
- `./gradlew :api-server:compileJava :module-ai-integration:compileJava`

Closes #251

Made with [Cursor](https://cursor.com)