### PR TITLE
Feat/fe#252: 라우트 도메인 분리 및 DEV 시작 경로 지원

### DIFF
--- a/backend/docs/BACKEND_MATCHING.md
+++ b/backend/docs/BACKEND_MATCHING.md
@@ -1,0 +1,52 @@
+# Backend Matching (`module-domain` / `com.team6.domain.matching`)
+
+매칭·결제·투어 연장 흐름을 담는 도메인 레이어입니다. 실행 모듈은 `api-server`이고, 코드는 `module-domain/src/main/java/com/team6/domain/matching`에 모여 있습니다.
+
+## 구성 요약
+
+| 영역 | 설명 |
+|------|------|
+| **Controller** | `MatchRequestController`, `PaymentController`, `TourExtensionController` |
+| **Service** | `MatchRequestService`, `PaymentService`, `TourExtensionService` |
+| **데이터** | `MatchRequest`, `Payment`, `Refund`, `TourExtension` + 상태 Enum |
+| **연동** | Stub/Fake PG, 선택 시 카카오페이(`KakaoPayClient`), 가이드 스케줄 확정 동기화(`GuideScheduleSyncClient`) |
+| **예외** | `MatchingException`, `MatchingErrorCode`, `MatchingExceptionHandler` |
+| **스케줄** | `@EnableScheduling` + 연장 마감/오픈 배치(`TourExtensionService`) |
+
+API 베이스는 애플리케이션의 `/api` 프리픽스 뒤에 붙는다고 가정하면, 매칭 관련 주 경로는 다음과 같습니다.
+
+- `POST/GET/PATCH … /matching/requests`
+- `GET/POST … /matching/payments`
+- `GET/PATCH … /matching/extensions`
+
+## 매칭 요청 (`/matching/requests`)
+
+- **생성**: 게스트가 가이드에게 매칭 요청을 올림(가이드 존재 여부 검증).
+- **목록**: 게스트 `/guest/list`, 가이드 `/guide/list` — 본인 데이터만.
+- **가이드**: `reject`, `propose`(제시 일정·메시지 등 반영).
+- **게스트**: `accept`, `decline`(제시안 최종 거절).
+- **취소**: `guest/cancel`, `guide/cancel` + 사유(`CancelRequestDto`).
+
+상태는 DB CHECK와 맞춘 `MatchRequestStatus`(예: `PENDING`, `ACCEPTED`, `PAID`, `IN_PROGRESS`, `COMPLETED`, `CANCELLED`, `REJECTED`)로만 전이합니다. 핵심 엔티티는 물리 삭제 대신 상태로 처리합니다.
+
+## 결제·환불 (`/matching/payments`)
+
+- **목록/단건**: 게스트 결제 목록, 역할에 따라 게스트·가이드 단건 조회.
+- **생성**: 매칭 요청이 게스트 소유이고 `ACCEPTED`일 때만; `(match_request_id, payment_type)` 중복 방지.
+- **확인**: 금액·주문번호 검증 후 완료 처리, 매칭 요청 `ACCEPTED` → `PAID` 반영; 설정에 따라 Fake PG 또는 카카오페이 승인.
+- **환불 신청** (`/refunds`): 완료된 결제에 한해, 결제 시점부터 정해진 **환불 마감 시각** 이내에만 가능; 중복 환불 요청 방지.
+
+결제 확정 후 가이드 스케줄 paid-confirm 연동은 실패해도 결제 자체는 롤백하지 않고 로그로 남깁니다.
+
+## 투어 연장 (`/matching/extensions`)
+
+- **조회**: 해당 `match_request`에 연결된 연장 건을 게스트·가이드만 조회.
+- **선택** (`PATCH …/select`): 게스트만; 마감(`deadlineAt`) 전에 연장 여부 선택.
+- **배치**: 당일 21:00(KST)에 투어일이 오늘인 일부 상태의 요청에 대해 연장 선택 레코드 생성; 마감 후 미선택 건은 분 단위 스케줄로 자동 처리(`AUTO_CANCELLED` 등 도메인 규칙에 따름).
+
+## 인증·응답
+
+- `MatchingAuthenticationSupport`로 현재 게스트 `memberId` / 가이드 `guideProfileId` 등을 해석합니다.
+- Service는 엔티티 대신 Response DTO를 반환합니다.
+
+스키마·Enum 상세는 Swagger(`v3/api-docs`)와 SQL 계약을 기준으로 맞춥니다.

--- a/frontend/docs/FRONTEND_COLLAB_STRUCTURE.md
+++ b/frontend/docs/FRONTEND_COLLAB_STRUCTURE.md
@@ -1,0 +1,68 @@
+# Frontend Collaboration Structure
+
+프론트 동시 작업 충돌을 줄이기 위한 최소 규칙입니다.
+
+## Branch Prefix
+
+- `feature/layout-*` : 공통 레이아웃/쉘
+- `feature/router-*` : 라우트 추가/변경 (`src/routes/*`, `src/App.jsx`)
+- `feature/guide-*` : 가이드 기능/페이지
+- `feature/mypage-*` : 여행자 마이페이지 기능
+- `feature/auth-*` : 로그인/회원가입/인증 UX
+
+## File Ownership (권장)
+
+- **layout owner**
+  - `src/layouts/AppLayout.jsx`
+  - `src/layouts/AppLayout.css`
+  - `src/layouts/GuideDashboardLayout.jsx`
+  - `src/layouts/GuideDashboardLayout.css`
+  - `src/layouts/MypageShell.jsx`
+- **router owner**
+  - `src/App.jsx`
+  - `src/routes/*`
+- **auth owner**
+  - `src/context/AuthProvider.jsx`
+  - `src/pages/LoginPage.jsx`
+  - `src/pages/SignupPage.jsx`
+
+다른 담당자가 공통 파일 수정이 필요하면:
+1) 이슈 등록
+2) owner 브랜치로 PR 요청
+
+## Routing Split
+
+라우트 충돌 완화를 위해 도메인별 route 파일을 사용합니다.
+
+- `src/routes/commonRoutes.jsx`
+- `src/routes/authRoutes.jsx`
+- `src/routes/mypageRoutes.jsx`
+- `src/routes/guideRoutes.jsx`
+
+새 페이지 추가 시:
+1) 해당 도메인 route 파일만 수정
+2) `App.jsx`는 가능하면 건드리지 않음
+
+## CSS Rule
+
+- 페이지/도메인 단위 CSS 우선
+- 공통 CSS 수정 최소화
+- 공통 스타일이 꼭 필요하면 `feature/layout-*`에서만 반영
+
+## Daily Workflow
+
+```bash
+git switch main
+git pull origin main
+git switch -c feature/<domain>-<topic>
+```
+
+작업 중간:
+
+```bash
+git add -A
+git commit -m "wip: <topic>"
+git fetch origin
+git rebase origin/main
+```
+

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,158 +1,29 @@
 import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom'
 
-import { ProtectedRoute } from './components/ProtectedRoute'
 import { AppLayout } from './layouts/AppLayout'
-import { MypageShell } from './layouts/MypageShell'
-import { GuideDashboardLayout } from './layouts/GuideDashboardLayout'
-import { GuideApplyPage } from './pages/GuideApplyPage'
-import { GuideTermsPage } from './pages/GuideTermsPage'
-import { GuideDetailPage } from './pages/GuideDetailPage'
-import { GuideFeedTourPage } from './pages/GuideFeedTourPage'
-import { GuideProposalPage } from './pages/GuideProposalPage'
-import { GuideMatchOptionsPage } from './pages/GuideMatchOptionsPage'
-import { GuideMatchedCoursePage } from './pages/GuideMatchedCoursePage'
-import { GuideFeedSchedulePage } from './pages/GuideFeedSchedulePage'
-import { GuideFeesPage } from './pages/GuideFeesPage'
-import { GuideInboxPage } from './pages/GuideInboxPage'
-import { GuideIntroEditPage } from './pages/GuideIntroEditPage'
-import { GuideProfileEditPage } from './pages/GuideProfileEditPage'
-import { GuideReviewsManagePage } from './pages/GuideReviewsManagePage'
-import { GuideSettlementPage } from './pages/GuideSettlementPage'
-import { GuideSettingsPage } from './pages/GuideSettingsPage'
-import { AiQuickSearchPage } from './pages/AiQuickSearchPage'
-import { MessagesPage } from './pages/MessagesPage'
-import { GuideListPage } from './pages/GuideListPage'
-import { HomePage } from './pages/HomePage'
-import { LoginPage } from './pages/LoginPage'
-import { MypageItineraryPage } from './pages/MypageItineraryPage'
-import { MypagePaymentsPage } from './pages/MypagePaymentsPage'
-import { MypagePlaceholder } from './pages/MypagePlaceholder'
-import { MypagePrivacyPage } from './pages/MypagePrivacyPage'
-import { MypageScrapbookPage } from './pages/MypageScrapbookPage'
-import { MypageTourPage } from './pages/MypageTourPage'
-import { MyPageOverview } from './pages/MyPageOverview'
-import { PaymentKakaoStubPage } from './pages/PaymentKakaoStubPage'
-import { SignupPage } from './pages/SignupPage'
+import { authRoutes } from './routes/authRoutes'
+import { commonRoutes } from './routes/commonRoutes'
+import { guideRoutes } from './routes/guideRoutes'
+import { mypageRoutes } from './routes/mypageRoutes'
+
+const rawDevStartPath = String(import.meta.env.VITE_DEV_START_PATH ?? '').trim()
+const devStartPath = rawDevStartPath ? (rawDevStartPath.startsWith('/') ? rawDevStartPath : `/${rawDevStartPath}`) : ''
+const resolvedCommonRoutes = commonRoutes.map((route) => {
+  if (!route.index) return route
+  if (!import.meta.env.DEV || !devStartPath) return route
+  return { ...route, element: <Navigate to={devStartPath} replace /> }
+})
 
 const router = createBrowserRouter([
   {
     path: '/',
     element: <AppLayout />,
     children: [
-      { index: true, element: <HomePage /> },
-      { path: 'auth/login', element: <LoginPage /> },
-      { path: 'auth/signup', element: <SignupPage /> },
-      { path: 'messages', element: <MessagesPage /> },
-      { path: 'ai-search', element: <AiQuickSearchPage /> },
-      { path: 'ai-quick', element: <Navigate to="/ai-search" replace /> },
-      { path: 'guides', element: <GuideListPage /> },
-      { path: 'guides/:guideId/proposal', element: <GuideProposalPage /> },
-      { path: 'guides/:guideId/match', element: <GuideMatchOptionsPage /> },
-      { path: 'guides/:guideId/match/complete', element: <GuideMatchedCoursePage /> },
-      { path: 'guides/:guideId/feeds/:feedId', element: <GuideFeedTourPage /> },
-      { path: 'guides/:guideId', element: <GuideDetailPage /> },
-      { path: 'pay/kakao-stub', element: <PaymentKakaoStubPage /> },
-      {
-        path: 'mypage',
-        element: (
-          <ProtectedRoute>
-            <MypageShell />
-          </ProtectedRoute>
-        ),
-        children: [
-          { index: true, element: <MyPageOverview /> },
-          {
-            path: 'profile',
-            element: (
-              <MypagePlaceholder
-                title="프로필"
-                description="회원 프로필 조회·수정 API가 추가되면 이 화면에서 연동합니다."
-              />
-            ),
-          },
-          {
-            path: 'scrapbook',
-            element: <MypageScrapbookPage />,
-          },
-          {
-            path: 'itinerary',
-            element: <MypageItineraryPage />,
-          },
-          {
-            path: 'payments',
-            element: <MypagePaymentsPage />,
-          },
-          {
-            path: 'privacy',
-            element: <MypagePrivacyPage />,
-          },
-          {
-            path: 'tour',
-            element: <MypageTourPage />,
-          },
-          {
-            path: 'reviews',
-            element: <MypagePlaceholder title="내 리뷰" description="/api/reviews 기반 목록·작성 화면 연동 예정." />,
-          },
-        ],
-      },
-      {
-        path: 'guide/register',
-        element: (
-          <ProtectedRoute>
-            <GuideTermsPage />
-          </ProtectedRoute>
-        ),
-      },
-      {
-        path: 'guide/apply',
-        element: (
-          <ProtectedRoute>
-            <GuideApplyPage />
-          </ProtectedRoute>
-        ),
-      },
-      {
-        path: 'guide/inbox',
-        element: (
-          <ProtectedRoute>
-            <GuideInboxPage />
-          </ProtectedRoute>
-        ),
-      },
-      {
-        path: 'guide/mypage',
-        element: (
-          <ProtectedRoute>
-            <GuideDashboardLayout />
-          </ProtectedRoute>
-        ),
-        children: [
-          { index: true, element: <Navigate to="fees" replace /> },
-          { path: 'fees', element: <GuideFeesPage /> },
-          { path: 'settlement', element: <GuideSettlementPage /> },
-          {
-            path: 'profile',
-            element: <GuideProfileEditPage />,
-          },
-          {
-            path: 'intro',
-            element: <GuideIntroEditPage />,
-          },
-          {
-            path: 'feed-schedule',
-            element: <GuideFeedSchedulePage />,
-          },
-          {
-            path: 'settings',
-            element: <GuideSettingsPage />,
-          },
-          {
-            path: 'reviews',
-            element: <GuideReviewsManagePage />,
-          },
-        ],
-      },
+      ...resolvedCommonRoutes,
+      ...authRoutes,
+      ...mypageRoutes,
+      ...guideRoutes,
+      { path: '*', element: <Navigate to="/" replace /> },
     ],
   },
 ])

--- a/frontend/src/routes/authRoutes.jsx
+++ b/frontend/src/routes/authRoutes.jsx
@@ -1,0 +1,8 @@
+import { LoginPage } from '../pages/LoginPage'
+import { SignupPage } from '../pages/SignupPage'
+
+export const authRoutes = [
+  { path: 'auth/login', element: <LoginPage /> },
+  { path: 'auth/signup', element: <SignupPage /> },
+]
+

--- a/frontend/src/routes/commonRoutes.jsx
+++ b/frontend/src/routes/commonRoutes.jsx
@@ -1,0 +1,27 @@
+import { Navigate } from 'react-router-dom'
+
+import { AiQuickSearchPage } from '../pages/AiQuickSearchPage'
+import { GuideDetailPage } from '../pages/GuideDetailPage'
+import { GuideFeedTourPage } from '../pages/GuideFeedTourPage'
+import { GuideListPage } from '../pages/GuideListPage'
+import { GuideMatchedCoursePage } from '../pages/GuideMatchedCoursePage'
+import { GuideMatchOptionsPage } from '../pages/GuideMatchOptionsPage'
+import { GuideProposalPage } from '../pages/GuideProposalPage'
+import { HomePage } from '../pages/HomePage'
+import { MessagesPage } from '../pages/MessagesPage'
+import { PaymentKakaoStubPage } from '../pages/PaymentKakaoStubPage'
+
+export const commonRoutes = [
+  { index: true, element: <HomePage /> },
+  { path: 'messages', element: <MessagesPage /> },
+  { path: 'ai-search', element: <AiQuickSearchPage /> },
+  { path: 'ai-quick', element: <Navigate to="/ai-search" replace /> },
+  { path: 'guides', element: <GuideListPage /> },
+  { path: 'guides/:guideId/proposal', element: <GuideProposalPage /> },
+  { path: 'guides/:guideId/match', element: <GuideMatchOptionsPage /> },
+  { path: 'guides/:guideId/match/complete', element: <GuideMatchedCoursePage /> },
+  { path: 'guides/:guideId/feeds/:feedId', element: <GuideFeedTourPage /> },
+  { path: 'guides/:guideId', element: <GuideDetailPage /> },
+  { path: 'pay/kakao-stub', element: <PaymentKakaoStubPage /> },
+]
+

--- a/frontend/src/routes/guideRoutes.jsx
+++ b/frontend/src/routes/guideRoutes.jsx
@@ -1,0 +1,75 @@
+import { Navigate } from 'react-router-dom'
+
+import { ProtectedRoute } from '../components/ProtectedRoute'
+import { GuideDashboardLayout } from '../layouts/GuideDashboardLayout'
+import { GuideApplyPage } from '../pages/GuideApplyPage'
+import { GuideFeedSchedulePage } from '../pages/GuideFeedSchedulePage'
+import { GuideFeesPage } from '../pages/GuideFeesPage'
+import { GuideInboxPage } from '../pages/GuideInboxPage'
+import { GuideIntroEditPage } from '../pages/GuideIntroEditPage'
+import { GuideProfileEditPage } from '../pages/GuideProfileEditPage'
+import { GuideReviewsManagePage } from '../pages/GuideReviewsManagePage'
+import { GuideSettlementPage } from '../pages/GuideSettlementPage'
+import { GuideSettingsPage } from '../pages/GuideSettingsPage'
+import { GuideTermsPage } from '../pages/GuideTermsPage'
+
+export const guideRoutes = [
+  {
+    path: 'guide/register',
+    element: (
+      <ProtectedRoute>
+        <GuideTermsPage />
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: 'guide/apply',
+    element: (
+      <ProtectedRoute>
+        <GuideApplyPage />
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: 'guide/inbox',
+    element: (
+      <ProtectedRoute>
+        <GuideInboxPage />
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: 'guide/mypage',
+    element: (
+      <ProtectedRoute>
+        <GuideDashboardLayout />
+      </ProtectedRoute>
+    ),
+    children: [
+      { index: true, element: <Navigate to="fees" replace /> },
+      { path: 'fees', element: <GuideFeesPage /> },
+      { path: 'settlement', element: <GuideSettlementPage /> },
+      {
+        path: 'profile',
+        element: <GuideProfileEditPage />,
+      },
+      {
+        path: 'intro',
+        element: <GuideIntroEditPage />,
+      },
+      {
+        path: 'feed-schedule',
+        element: <GuideFeedSchedulePage />,
+      },
+      {
+        path: 'settings',
+        element: <GuideSettingsPage />,
+      },
+      {
+        path: 'reviews',
+        element: <GuideReviewsManagePage />,
+      },
+    ],
+  },
+]
+

--- a/frontend/src/routes/mypageRoutes.jsx
+++ b/frontend/src/routes/mypageRoutes.jsx
@@ -1,0 +1,57 @@
+import { ProtectedRoute } from '../components/ProtectedRoute'
+import { MypageShell } from '../layouts/MypageShell'
+import { MypageItineraryPage } from '../pages/MypageItineraryPage'
+import { MypagePaymentsPage } from '../pages/MypagePaymentsPage'
+import { MypagePlaceholder } from '../pages/MypagePlaceholder'
+import { MypagePrivacyPage } from '../pages/MypagePrivacyPage'
+import { MypageScrapbookPage } from '../pages/MypageScrapbookPage'
+import { MypageTourPage } from '../pages/MypageTourPage'
+import { MyPageOverview } from '../pages/MyPageOverview'
+
+export const mypageRoutes = [
+  {
+    path: 'mypage',
+    element: (
+      <ProtectedRoute>
+        <MypageShell />
+      </ProtectedRoute>
+    ),
+    children: [
+      { index: true, element: <MyPageOverview /> },
+      {
+        path: 'profile',
+        element: (
+          <MypagePlaceholder
+            title="프로필"
+            description="회원 프로필 조회·수정 API가 추가되면 이 화면에서 연동합니다."
+          />
+        ),
+      },
+      {
+        path: 'scrapbook',
+        element: <MypageScrapbookPage />,
+      },
+      {
+        path: 'itinerary',
+        element: <MypageItineraryPage />,
+      },
+      {
+        path: 'payments',
+        element: <MypagePaymentsPage />,
+      },
+      {
+        path: 'privacy',
+        element: <MypagePrivacyPage />,
+      },
+      {
+        path: 'tour',
+        element: <MypageTourPage />,
+      },
+      {
+        path: 'reviews',
+        element: <MypagePlaceholder title="내 리뷰" description="/api/reviews 기반 목록·작성 화면 연동 예정." />,
+      },
+    ],
+  },
+]
+


### PR DESCRIPTION
## 변경 이유
동시 작업 시 App.jsx/공통 라우트 충돌을 줄이고,
팀원별 담당 페이지 진입을 빠르게 하기 위해 구조를 분리했습니다.

## 주요 변경
- 라우트 분리
  - src/routes/commonRoutes.jsx
  - src/routes/authRoutes.jsx
  - src/routes/mypageRoutes.jsx
  - src/routes/guideRoutes.jsx
- App.jsx
  - 도메인 라우트 조합 방식으로 변경
- DEV 시작 경로
  - VITE_DEV_START_PATH 지원 (DEV에서만 index 경로 리다이렉트)
- 문서
  - frontend/docs/FRONTEND_COLLAB_STRUCTURE.md 추가

## 테스트
- [x] npm run build 통과
- [x] 라우트/린트 오류 없음

## 팀원 .env.local 예시
- guide: VITE_DEV_START_PATH=/guide/mypage/profile
- mypage: VITE_DEV_START_PATH=/mypage/payments
- auth: VITE_DEV_START_PATH=/auth/login