### PR TITLE
Feat/be#257 추천 관측(Micrometer) 보강 + 회귀 세트 확대

### DIFF
--- a/backend/module-ai/src/main/java/com/team6/module/ai/controller/AiController.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/controller/AiController.java
@@ -235,6 +235,7 @@ public class AiController {
             int clicks = clickStore.recentClickCount(c.getGuideId());
             int debiasedClicks = clickStore.debiasedClickScore(c.getGuideId());
             int exposures = exposureStore.recentExposureCount(sessionId, c.getGuideId());
+            recommendationMetrics.recordDebiasedClickUsed(debiasedClicks > 0, AiRecommendationTuning.POLICY_VERSION);
             out.add(GuideRecommendRequest.GuideCandidateDto.builder()
                     .guideId(c.getGuideId())
                     .guideName(c.getGuideName())
@@ -270,6 +271,7 @@ public class AiController {
             }
             exposureStore.recordExposure(sessionId, item.getGuideId());
             clickStore.recordExposure(item.getGuideId(), rank);
+            recommendationMetrics.recordRecommendationExposure(rank, AiRecommendationTuning.POLICY_VERSION);
             rank++;
         }
     }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/engine/MatchingEngine.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/engine/MatchingEngine.java
@@ -121,7 +121,7 @@ public class MatchingEngine {
                 .build();
     }
 
-    private static List<GuideAiProfile> applyNegativeFilters(TravelerPreference pref, List<GuideAiProfile> guides) {
+    private List<GuideAiProfile> applyNegativeFilters(TravelerPreference pref, List<GuideAiProfile> guides) {
         if (guides == null || guides.isEmpty() || pref == null) {
             return guides == null ? List.of() : guides;
         }
@@ -137,9 +137,63 @@ public class MatchingEngine {
         if (exRegions.isEmpty() && exStyles.isEmpty() && exLangs.isEmpty()) {
             return guides;
         }
-        return guides.stream()
-                .filter(g -> !isExcludedGuide(g, exRegions, exStyles, exLangs))
+        int before = guides.size();
+        int removedRegion = 0;
+        int removedStyle = 0;
+        int removedLang = 0;
+
+        List<GuideAiProfile> out = new ArrayList<>(guides.size());
+        for (GuideAiProfile g : guides) {
+            if (g == null) {
+                out.add(null);
+                continue;
+            }
+            boolean r = isExcludedByRegion(g, exRegions);
+            boolean s = isExcludedByStyle(g, exStyles);
+            boolean l = isExcludedByLanguageOnly(g, exLangs);
+            if (r || s || l) {
+                if (r) removedRegion++;
+                if (s) removedStyle++;
+                if (l) removedLang++;
+                continue;
+            }
+            out.add(g);
+        }
+        recommendationMetrics.recordNegativeFilter("region", removedRegion, AiRecommendationTuning.POLICY_VERSION);
+        recommendationMetrics.recordNegativeFilter("style", removedStyle, AiRecommendationTuning.POLICY_VERSION);
+        recommendationMetrics.recordNegativeFilter("language", removedLang, AiRecommendationTuning.POLICY_VERSION);
+        return out;
+    }
+
+    private static boolean isExcludedByRegion(GuideAiProfile g, Set<String> exRegions) {
+        if (exRegions.isEmpty()) {
+            return false;
+        }
+        String r = g.getRegion();
+        return r != null && exRegions.contains(r.toLowerCase());
+    }
+
+    private static boolean isExcludedByStyle(GuideAiProfile g, Set<String> exStyles) {
+        if (exStyles.isEmpty()) {
+            return false;
+        }
+        String s = g.getGuideStyle();
+        return s != null && exStyles.contains(s.toLowerCase());
+    }
+
+    private static boolean isExcludedByLanguageOnly(GuideAiProfile g, Set<String> exLangs) {
+        if (exLangs.isEmpty()) {
+            return false;
+        }
+        List<String> langs = g.getLanguages();
+        if (langs == null || langs.isEmpty()) {
+            return false;
+        }
+        List<String> normalized = langs.stream()
+                .map(KeywordNormalizer::normalizeLanguage)
+                .filter(x -> x != null && !x.isBlank())
                 .toList();
+        return !normalized.isEmpty() && normalized.stream().allMatch(l -> exLangs.contains(l.toLowerCase()));
     }
 
     private static boolean isExcludedGuide(
@@ -151,32 +205,9 @@ public class MatchingEngine {
         if (g == null) {
             return false;
         }
-        if (!exRegions.isEmpty()) {
-            String r = g.getRegion();
-            if (r != null && exRegions.contains(r.toLowerCase())) {
-                return true;
-            }
-        }
-        if (!exStyles.isEmpty()) {
-            String s = g.getGuideStyle();
-            if (s != null && exStyles.contains(s.toLowerCase())) {
-                return true;
-            }
-        }
-        if (!exLangs.isEmpty()) {
-            List<String> langs = g.getLanguages();
-            if (langs != null && !langs.isEmpty()) {
-                List<String> normalized = langs.stream()
-                        .map(KeywordNormalizer::normalizeLanguage)
-                        .filter(x -> x != null && !x.isBlank())
-                        .toList();
-                // 보수적으로: 가이드가 "오직" 제외 언어만 가능한 경우만 제외한다.
-                if (!normalized.isEmpty() && normalized.stream().allMatch(l -> exLangs.contains(l.toLowerCase()))) {
-                    return true;
-                }
-            }
-        }
-        return false;
+        return isExcludedByRegion(g, exRegions)
+                || isExcludedByStyle(g, exStyles)
+                || isExcludedByLanguageOnly(g, exLangs);
     }
 
     private static Set<String> normalizeLowerSet(List<String> raw) {

--- a/backend/module-ai/src/main/java/com/team6/module/ai/engine/ScoreCalculator.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/engine/ScoreCalculator.java
@@ -31,6 +31,17 @@ public class ScoreCalculator {
         int score = 0;
         score += regionMatchPolicy.score(pref, guide);
         score += styleMatchPolicy.score(pref, guide);
+
+        // 범위 예산 매칭 분기는 운영 관측에 남긴다(정책 점수 의미는 BudgetMatchPolicy에 위임).
+        boolean rangeComparable =
+                pref.getBudgetMinWon() != null && pref.getBudgetMaxWon() != null
+                        && guide.getPriceMinWon() != null && guide.getPriceMaxWon() != null;
+        if (rangeComparable) {
+            boolean overlap = Math.max(pref.getBudgetMinWon(), guide.getPriceMinWon())
+                    <= Math.min(pref.getBudgetMaxWon(), guide.getPriceMaxWon());
+            recommendationMetrics.recordBudgetRangeMatch(overlap, AiRecommendationTuning.POLICY_VERSION);
+        }
+
         score += budgetMatchPolicy.score(pref, guide);
         score += activityMatchPolicy.score(pref, guide);
         score += languageMatchPolicy.score(pref, guide);

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationMetrics.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationMetrics.java
@@ -20,6 +20,10 @@ import java.util.concurrent.TimeUnit;
  *   <li>{@code .outcome(type=no_region|empty|success)} — 최종 건수 결과</li>
  *   <li>{@code .feedback_penalty_hits(policy_version=...)} — 후보 1명 스코어링 시
  *       {@link com.team6.module.ai.policy.FeedbackMatchPolicy} 감점이 적용된 횟수(0보다 작은 기여)</li>
+ *   <li>{@code .exposure(policy_version=...,rank=...)} — 추천 카드 노출(랭크별)</li>
+ *   <li>{@code .debiased_click_used(policy_version=...,used=true|false)} — 디바이어스 클릭 신호 사용 여부(가이드별)</li>
+ *   <li>{@code .negative_filter(reason=region|style|language,policy_version=...)} — 부정 의도로 제외된 후보 수</li>
+ *   <li>{@code .budget_range_match(result=match|miss,policy_version=...)} — 범위 예산 매칭 분기(비교 가능 후보에 한함)</li>
  * </ul>
  * <b>Timer / Summary</b> (태그 {@code policy_version} 권장)
  * <ul>
@@ -161,5 +165,46 @@ public class AiRecommendationMetrics {
         String pv = policyVersion == null ? "unknown" : policyVersion;
         String r = (rank == null || rank <= 0) ? "unknown" : String.valueOf(rank);
         registry.counter(PREFIX + ".click", Tags.of("policy_version", pv, "rank", r)).increment();
+    }
+
+    /**
+     * 추천 카드 노출(랭크별).
+     */
+    public void recordRecommendationExposure(Integer rank, String policyVersion) {
+        String pv = policyVersion == null ? "unknown" : policyVersion;
+        String r = (rank == null || rank <= 0) ? "unknown" : String.valueOf(rank);
+        registry.counter(PREFIX + ".exposure", Tags.of("policy_version", pv, "rank", r)).increment();
+    }
+
+    /**
+     * 디바이어스 클릭 신호(포지션 바이어스 보정)가 사용됐는지.
+     */
+    public void recordDebiasedClickUsed(boolean used, String policyVersion) {
+        String pv = policyVersion == null ? "unknown" : policyVersion;
+        registry.counter(PREFIX + ".debiased_click_used", Tags.of("policy_version", pv, "used", String.valueOf(used)))
+                .increment();
+    }
+
+    /**
+     * 부정 의도로 필터링된 후보 수(상세 원인 태그).
+     */
+    public void recordNegativeFilter(String reason, int removedCount, String policyVersion) {
+        if (removedCount <= 0) {
+            return;
+        }
+        String pv = policyVersion == null ? "unknown" : policyVersion;
+        String r = reason == null || reason.isBlank() ? "unknown" : reason;
+        registry.counter(PREFIX + ".negative_filter", Tags.of("policy_version", pv, "reason", r))
+                .increment(removedCount);
+    }
+
+    /**
+     * 범위 예산 매칭 분기(후보/선호 모두 범위를 가진 경우).
+     */
+    public void recordBudgetRangeMatch(boolean matched, String policyVersion) {
+        String pv = policyVersion == null ? "unknown" : policyVersion;
+        String result = matched ? "match" : "miss";
+        registry.counter(PREFIX + ".budget_range_match", Tags.of("policy_version", pv, "result", result))
+                .increment();
     }
 }

--- a/backend/module-ai/src/test/java/com/team6/module/ai/regression/AiRecommendationRegressionTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/regression/AiRecommendationRegressionTest.java
@@ -232,6 +232,64 @@ class AiRecommendationRegressionTest {
     }
 
     @Test
+    void regression_negative_region_should_choose_positive_region_over_negated_one() {
+        List<GuideRecommendRequest.GuideCandidateDto> pool = List.of(
+                GuideRecommendRequest.GuideCandidateDto.builder()
+                        .guideId(2001L).guideName("제주가이드").region("제주").guideStyle("힐링").priceLevel("중간")
+                        .specialtyTags(List.of("맛집")).languages(List.of("한국어"))
+                        .build(),
+                GuideRecommendRequest.GuideCandidateDto.builder()
+                        .guideId(2002L).guideName("부산가이드").region("부산").guideStyle("힐링").priceLevel("중간")
+                        .specialtyTags(List.of("맛집")).languages(List.of("한국어"))
+                        .build()
+        );
+        GuideRecommendRequest parsed = promptParser.parse("제주 말고 부산 맛집", 1, pool);
+        GuideRecommendResponse response = aiRecommendationService.recommend(parsed);
+        assertThat(response.getRecommendations()).isNotEmpty();
+        assertThat(response.getRecommendations().get(0).getGuideId()).isEqualTo(2002L);
+    }
+
+    @Test
+    void regression_budget_range_overlap_should_outweigh_tier_only_when_available() {
+        List<GuideRecommendRequest.GuideCandidateDto> pool = List.of(
+                GuideRecommendRequest.GuideCandidateDto.builder()
+                        .guideId(2101L).guideName("A").region("제주").guideStyle("힐링").priceLevel("중간")
+                        .priceMinWon(350_000).priceMaxWon(450_000).priceScope("per_day")
+                        .specialtyTags(List.of("카페")).languages(List.of("한국어"))
+                        .build(),
+                GuideRecommendRequest.GuideCandidateDto.builder()
+                        .guideId(2102L).guideName("B").region("제주").guideStyle("힐링").priceLevel("중간")
+                        .priceMinWon(180_000).priceMaxWon(260_000).priceScope("per_day")
+                        .specialtyTags(List.of("카페")).languages(List.of("한국어"))
+                        .build()
+        );
+        GuideRecommendRequest parsed = promptParser.parse("제주 총 20만원~30만원 예산 카페", 1, pool);
+        GuideRecommendResponse response = aiRecommendationService.recommend(parsed);
+        assertThat(response.getRecommendations()).isNotEmpty();
+        assertThat(response.getRecommendations().get(0).getGuideId()).isEqualTo(2102L);
+    }
+
+    @Test
+    void regression_comparison_hint_should_be_present_on_top1_when_two_or_more_recommendations() {
+        List<GuideRecommendRequest.GuideCandidateDto> pool = List.of(
+                GuideRecommendRequest.GuideCandidateDto.builder()
+                        .guideId(2201L).guideName("A").region("제주").guideStyle("힐링").priceLevel("중간")
+                        .specialtyTags(List.of("카페", "바다")).languages(List.of("한국어"))
+                        .build(),
+                GuideRecommendRequest.GuideCandidateDto.builder()
+                        .guideId(2202L).guideName("B").region("제주").guideStyle("로컬").priceLevel("중간")
+                        .specialtyTags(List.of("카페")).languages(List.of("한국어"))
+                        .build()
+        );
+        GuideRecommendRequest parsed = promptParser.parse("제주 힐링 카페 바다", 2, pool);
+        GuideRecommendResponse response = createService(ScoringPolicySnapshot.defaults()).recommend(parsed);
+        assertThat(response.getRecommendations()).hasSize(2);
+        assertThat(response.getRecommendations().get(0).getComparisonHint())
+                .isNotBlank()
+                .contains("1위");
+    }
+
+    @Test
     void regression_combo_rule_bonus_can_promote_local_market_guide() {
         ScoringPolicySettings settings = new ScoringPolicySettings();
         ScoringPolicySettings.ComboRuleSetting rule = new ScoringPolicySettings.ComboRuleSetting();


### PR DESCRIPTION
## Summary
- 추천 파이프라인 관측을 위해 Micrometer 지표를 보강했습니다.
  - 노출(exposure) 집계(랭크별)
  - 디바이어스 클릭 신호 사용 여부 집계
  - negative intent 필터로 제외된 후보 수(원인별: region/style/language)
  - 범위 예산 매칭 분기(매칭/미스)
- 회귀/평가 세트를 확장해, 다음 케이스의 퇴보를 빠르게 감지합니다.
  - 지역 부정("제주 말고 부산") 처리
  - 범위 예산 겹침 기반 Top1 선택
  - Top1 comparisonHint 존재/형식(1위/2위 비교)

## Version
- 정책 의미 변경은 없어서 POLICY_VERSION은 유지했습니다.

## Test
- `./gradlew :module-ai:test`
- `./gradlew :api-server:compileJava`

Closes #257

Made with [Cursor](https://cursor.com)