### PR TITLE
Feat/fe#259 JWT 인증 에러/401 공통 처리

### DIFF
--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -16,6 +16,59 @@ function getStoredToken() {
   return localStorage.getItem('localguest_access_token')
 }
 
+/** @type {null | (() => void)} */
+let unauthorizedHandler = null
+
+/**
+ * Register a global handler invoked when an authenticated request returns 401.
+ * This is intentionally UI-agnostic; AuthProvider wires it to logout UX.
+ * @param {null | (() => void)} handler
+ */
+export function setUnauthorizedHandler(handler) {
+  unauthorizedHandler = typeof handler === 'function' ? handler : null
+}
+
+export class ApiError extends Error {
+  /** @param {string} message @param {{ status?: number, code?: string, raw?: unknown }} [meta] */
+  constructor(message, meta) {
+    super(message)
+    this.name = 'ApiError'
+    this.status = meta?.status
+    this.code = meta?.code
+    this.raw = meta?.raw
+  }
+}
+
+/**
+ * @param {number} status
+ * @param {unknown} payload
+ */
+export function toUserErrorMessage(status, payload) {
+  if (payload && typeof payload === 'object') {
+    // Spring error wrapper often uses { message }, sometimes { errorCode }
+    // eslint-disable-next-line no-unused-vars
+    const p = /** @type {{ message?: unknown }} */ (payload)
+    if (typeof p.message === 'string' && p.message.trim()) return p.message.trim()
+  }
+  if (typeof payload === 'string' && payload.trim()) return payload.trim()
+
+  if (status === 401) return '로그인이 만료됐어요. 다시 로그인해주세요.'
+  if (status === 403) return '권한이 없어요.'
+  if (status >= 500) return '잠시 후 다시 시도해주세요.'
+  return '요청을 처리할 수 없습니다.'
+}
+
+async function readJsonOrText(res) {
+  const text = (await res.text()).trim()
+  if (!text) return { text: '', json: null }
+  if (!text.startsWith('{') && !text.startsWith('[')) return { text, json: null }
+  try {
+    return { text, json: JSON.parse(text) }
+  } catch {
+    return { text, json: null }
+  }
+}
+
 /**
  * @param {string} path
  * @param {RequestInit & { json?: unknown, skipAuth?: boolean }} [options]
@@ -41,7 +94,28 @@ export async function apiRequest(path, options = {}) {
     body: json !== undefined ? JSON.stringify(json) : rest.body,
   })
 
+  if (!skipAuth && res.status === 401 && unauthorizedHandler) {
+    try {
+      unauthorizedHandler()
+    } catch {
+      /* ignore */
+    }
+  }
+
   return res
+}
+
+/**
+ * apiRequest + error normalization (throws ApiError when !ok).
+ * @param {string} path
+ * @param {RequestInit & { json?: unknown, skipAuth?: boolean }} [options]
+ */
+export async function apiRequestOrThrow(path, options = {}) {
+  const res = await apiRequest(path, options)
+  if (res.ok) return res
+  const { text, json } = await readJsonOrText(res)
+  const payload = json ?? text
+  throw new ApiError(toUserErrorMessage(res.status, payload), { status: res.status, raw: payload })
 }
 
 /**

--- a/frontend/src/context/AuthProvider.jsx
+++ b/frontend/src/context/AuthProvider.jsx
@@ -1,12 +1,13 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 
-import { apiLogin, apiRequest } from '../api/client'
+import { apiLogin, apiRequest, setUnauthorizedHandler, toUserErrorMessage } from '../api/client'
 import { clearStoredGuideId } from '../lib/guideId.js'
 import { getEmailFromToken, getRoleFromToken, parseJwtPayload } from '../lib/jwt'
 
 import { AuthContext } from './auth-context.js'
 
 const TOKEN_KEY = 'localguest_access_token'
+const LOGIN_FLASH_KEY = 'login_flash'
 
 export function AuthProvider({ children }) {
   const [token, setTokenState] = useState(() => {
@@ -27,6 +28,15 @@ export function AuthProvider({ children }) {
     }
     setTokenState(next)
   }, [])
+
+  useEffect(() => {
+    setUnauthorizedHandler(() => {
+      sessionStorage.setItem(LOGIN_FLASH_KEY, toUserErrorMessage(401))
+      clearStoredGuideId()
+      setToken(null)
+    })
+    return () => setUnauthorizedHandler(null)
+  }, [setToken])
 
   const claims = useMemo(() => parseJwtPayload(token ?? ''), [token])
   const email = token ? getEmailFromToken(token) : null
@@ -53,18 +63,15 @@ export function AuthProvider({ children }) {
       }
 
       if (!attempt.res.ok) {
-        let message = '로그인에 실패했습니다.'
-        try {
-          const body = JSON.parse(attempt.text)
-          if (body?.message) {
-            message = body.message
-          }
-        } catch {
-          if (attempt.text) {
-            message = attempt.text
+        let payload = attempt.text
+        if (attempt.text?.startsWith('{') || attempt.text?.startsWith('[')) {
+          try {
+            payload = JSON.parse(attempt.text)
+          } catch {
+            payload = attempt.text
           }
         }
-        throw new Error(message)
+        throw new Error(toUserErrorMessage(attempt.res.status, payload))
       }
 
       // 최신 백엔드: TokenResponse(JSON), 레거시: plain JWT 문자열

--- a/frontend/src/pages/SignupPage.jsx
+++ b/frontend/src/pages/SignupPage.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 
-import { apiRequest } from '../api/client'
+import { apiRequest, toUserErrorMessage } from '../api/client'
 
 import './SignupPage.css'
 
@@ -196,12 +196,15 @@ export function SignupPage() {
       })
       const text = await res.text()
       if (!res.ok) {
-        try {
-          const j = JSON.parse(text)
-          setError(j.message ?? '가입에 실패했습니다.')
-        } catch {
-          setError(text || '가입에 실패했습니다.')
+        let payload = text
+        if (text?.trim().startsWith('{') || text?.trim().startsWith('[')) {
+          try {
+            payload = JSON.parse(text)
+          } catch {
+            payload = text
+          }
         }
+        setError(toUserErrorMessage(res.status, payload))
         return
       }
       let memberId = null


### PR DESCRIPTION
## 🔗 이슈 번호
- Closes #259

## 💡 주요 변경 사항
- Bearer JWT 요청에서 401 발생 시 세션 정리(토큰 삭제) + 재로그인 유도 플로우 통일
- 401/403/5xx 사용자 메시지 정규화 및 로그인/회원가입 에러 표시 일관화

## ✅ 체크리스트
- [x] 빌드가 정상적으로 되는가?
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [x] 불필요한 파일 수정이 포함되지 않았는가?

## 🧪 검증 커맨드

```bash
npm -C frontend run build
```