### PR TITLE
Feat/be#261: MatchRequest COMPLETED 상태 자동 전이 반영

### DIFF
--- a/backend/module-domain/src/main/java/com/team6/domain/matching/entity/MatchRequest.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/entity/MatchRequest.java
@@ -168,6 +168,35 @@ public class MatchRequest extends BaseTimeEntity {
     }
 
     /**
+     * 투어 날짜가 오늘이면 진행 상태로 전이한다.
+     * 결제 완료(PAID) 상태에서만 전이한다.
+     */
+    public void markInProgressIfTourDay(LocalDate today) {
+        if (today == null || this.desiredDate == null) {
+            return;
+        }
+        if (this.status == MatchRequestStatus.PAID && this.desiredDate.isEqual(today)) {
+            this.status = MatchRequestStatus.IN_PROGRESS;
+            log.info("[Matching] 투어 진행 시작 — status=IN_PROGRESS, requestId={}", this.id);
+        }
+    }
+
+    /**
+     * 투어 날짜가 지났으면 완료 상태로 전이한다.
+     * PAID/IN_PROGRESS 상태에서만 전이한다.
+     */
+    public void markCompletedIfTourEnded(LocalDate today) {
+        if (today == null || this.desiredDate == null) {
+            return;
+        }
+        if ((this.status == MatchRequestStatus.PAID || this.status == MatchRequestStatus.IN_PROGRESS)
+                && this.desiredDate.isBefore(today)) {
+            this.status = MatchRequestStatus.COMPLETED;
+            log.info("[Matching] 투어 완료 반영 — status=COMPLETED, requestId={}", this.id);
+        }
+    }
+
+    /**
      * 게스트가 가이드 제안(수락 대기)을 거절할 때 — 취소(CANCELLED)와 구분하기 위해 REJECTED로 전이한다.
      */
     public void declineProposalByGuest(String reason) {

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/service/MatchRequestService.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/service/MatchRequestService.java
@@ -16,6 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.text.NumberFormat;
 import java.util.List;
 import java.util.Locale;
@@ -54,17 +55,19 @@ public class MatchRequestService {
     }
 
     /** 게스트 본인 매칭 요청 전체 (마이페이지 일정·스크랩북 등) */
-    @Transactional(readOnly = true)
     public List<MatchRequestCreateResponse> getGuestRequests(Long guestId) {
+        LocalDate today = LocalDate.now();
         return matchRequestRepository.findByGuestId(guestId).stream()
+                .peek(request -> syncTourProgress(request, today))
                 .map(MatchRequestCreateResponse::from)
                 .toList();
     }
 
     // 가이드의 매칭 요청 목록 조회
-    @Transactional(readOnly = true)
     public List<MatchRequestCreateResponse> getGuideRequests(Long guideId) {
+        LocalDate today = LocalDate.now();
         return matchRequestRepository.findByGuideId(guideId).stream()
+                .peek(request -> syncTourProgress(request, today))
                 .map(MatchRequestCreateResponse::from)
                 .toList();
     }
@@ -226,5 +229,10 @@ public class MatchRequestService {
         return guideProfileRepository.findById(guideProfileId)
                 .map(guideProfile -> guideProfile.getMemberId())
                 .orElseThrow(() -> new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED));
+    }
+
+    private void syncTourProgress(MatchRequest request, LocalDate today) {
+        request.markInProgressIfTourDay(today);
+        request.markCompletedIfTourEnded(today);
     }
 }


### PR DESCRIPTION
## 🔗 이슈 번호
- Closes #261 
---

## 💡 주요 변경 사항
- `MatchRequest` 엔티티에 일정 기반 상태 전이 로직을 추가했습니다.
  - `markInProgressIfTourDay(today)`: `PAID -> IN_PROGRESS`
  - `markCompletedIfTourEnded(today)`: `PAID/IN_PROGRESS -> COMPLETED`
- `MatchRequestService` 목록 조회 시점에 상태 동기화를 적용했습니다.
  - `getGuestRequests`
  - `getGuideRequests`
---

## ⚠️ 주의 사항 / 질문
- 현재는 **조회 시점 동기화 방식**입니다.
- 별도 배치/스케줄러 없이도 스크랩북/리뷰 노출에는 충분하지만,
  트래픽/정합성 요구가 커지면 배치 전환 여부를 추후 검토할 수 있습니다.
---

## ✅ 체크리스트
- [x] 빌드(compileJava)가 정상적으로 되는가?
- [x] 프론트 스크랩북의 COMPLETED 필터와 동작 정합성이 맞는가?
- [x] 불필요한 템플릿/문서 변경이 없는가?