### PR TITLE
[Feat/be#267] 카카오 결제 콜백 401 해소

### DIFF
--- a/backend/api-server/src/main/java/com/team6/apiserver/auth/config/SecurityConfig.java
+++ b/backend/api-server/src/main/java/com/team6/apiserver/auth/config/SecurityConfig.java
@@ -78,6 +78,10 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.PUT, "/reviews/**").authenticated()
                         .requestMatchers(HttpMethod.DELETE, "/reviews/**").authenticated()
 
+                        // 2.5 카카오페이 리다이렉트 콜백 (브라우저 리다이렉트로 Authorization 헤더가 없음)
+                        // context-path가 /api 인 환경도 있어 둘 다 허용한다.
+                        .requestMatchers("/matching/payments/kakao/**", "/api/matching/payments/kakao/**").permitAll()
+
                         // 3. 그 외 (리뷰 등록, 채팅, 마이페이지 등)는 무조건 로그인 필요
                         .anyRequest().authenticated()
                 )

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/client/HttpKakaoPayClient.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/client/HttpKakaoPayClient.java
@@ -39,6 +39,11 @@ public class HttpKakaoPayClient implements KakaoPayClient {
     public ReadyResult ready(String partnerOrderId, String partnerUserId, String itemName, int totalAmount) {
         validateSecretKey();
 
+        // KakaoPay redirect includes pg_token only; we must embed our order identifier so the callback can resolve Payment.
+        String okUrl = approvalUrl + "?pgOrderNo=" + partnerOrderId;
+        String noUrl = cancelUrl + "?pgOrderNo=" + partnerOrderId;
+        String fail = failUrl + "?pgOrderNo=" + partnerOrderId;
+
         Map<String, Object> body = Map.of(
                 "cid", cid,
                 "partner_order_id", partnerOrderId,
@@ -47,9 +52,9 @@ public class HttpKakaoPayClient implements KakaoPayClient {
                 "quantity", 1,
                 "total_amount", totalAmount,
                 "tax_free_amount", 0,
-                "approval_url", approvalUrl,
-                "cancel_url", cancelUrl,
-                "fail_url", failUrl
+                "approval_url", okUrl,
+                "cancel_url", noUrl,
+                "fail_url", fail
         );
 
         try {

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/controller/KakaoPayRedirectController.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/controller/KakaoPayRedirectController.java
@@ -1,0 +1,86 @@
+package com.team6.domain.matching.controller;
+
+import com.team6.domain.matching.entity.Payment;
+import com.team6.domain.matching.exception.MatchingErrorCode;
+import com.team6.domain.matching.exception.MatchingException;
+import com.team6.domain.matching.repository.PaymentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
+/**
+ * KakaoPay redirects the browser to our approval/cancel/fail URLs.
+ * Those redirects do not include Authorization headers, so this controller must be publicly accessible.
+ * It redirects back to the frontend with enough context to continue the confirm step.
+ */
+@RestController
+@RequestMapping("/matching/payments/kakao")
+@RequiredArgsConstructor
+public class KakaoPayRedirectController {
+
+    private final PaymentRepository paymentRepository;
+
+    @Value("${frontend.base-url:http://localhost:5173}")
+    private String frontendBaseUrl;
+
+    @GetMapping("/success")
+    public ResponseEntity<Void> success(
+            @RequestParam("pg_token") String pgToken,
+            @RequestParam("pgOrderNo") String pgOrderNo
+    ) {
+        Payment payment = paymentRepository.findByPgOrderNo(pgOrderNo)
+                .orElseThrow(() -> new MatchingException(MatchingErrorCode.PAYMENT_NOT_FOUND));
+
+        URI redirect = buildFrontendRedirect(payment, pgToken, "success");
+        HttpHeaders headers = new HttpHeaders();
+        headers.setLocation(redirect);
+        return new ResponseEntity<>(headers, HttpStatus.FOUND);
+    }
+
+    @GetMapping("/cancel")
+    public ResponseEntity<Void> cancel(@RequestParam("pgOrderNo") String pgOrderNo) {
+        Payment payment = paymentRepository.findByPgOrderNo(pgOrderNo)
+                .orElseThrow(() -> new MatchingException(MatchingErrorCode.PAYMENT_NOT_FOUND));
+        URI redirect = buildFrontendRedirect(payment, null, "cancel");
+        HttpHeaders headers = new HttpHeaders();
+        headers.setLocation(redirect);
+        return new ResponseEntity<>(headers, HttpStatus.FOUND);
+    }
+
+    @GetMapping("/fail")
+    public ResponseEntity<Void> fail(@RequestParam("pgOrderNo") String pgOrderNo) {
+        Payment payment = paymentRepository.findByPgOrderNo(pgOrderNo)
+                .orElseThrow(() -> new MatchingException(MatchingErrorCode.PAYMENT_NOT_FOUND));
+        URI redirect = buildFrontendRedirect(payment, null, "fail");
+        HttpHeaders headers = new HttpHeaders();
+        headers.setLocation(redirect);
+        return new ResponseEntity<>(headers, HttpStatus.FOUND);
+    }
+
+    private URI buildFrontendRedirect(Payment payment, String pgToken, String result) {
+        UriComponentsBuilder b = UriComponentsBuilder
+                .fromHttpUrl(frontendBaseUrl)
+                .path("/pay/kakao-stub")
+                .queryParam("paymentId", payment.getId())
+                .queryParam("amount", payment.getAmount())
+                .queryParam("pgOrderNo", payment.getPgOrderNo())
+                .queryParam("paymentType", payment.getPaymentType())
+                .queryParam("requestId", payment.getMatchRequest().getId())
+                .queryParam("guideId", payment.getMatchRequest().getGuideId())
+                .queryParam("result", result);
+        if (pgToken != null && !pgToken.isBlank()) {
+            b.queryParam("pgToken", pgToken);
+        }
+        return b.build(true).toUri();
+    }
+}
+

--- a/frontend/src/pages/PaymentKakaoStubPage.jsx
+++ b/frontend/src/pages/PaymentKakaoStubPage.jsx
@@ -20,6 +20,7 @@ export function PaymentKakaoStubPage() {
   const paymentId = searchParams.get('paymentId') ?? ''
   const amount = searchParams.get('amount') ?? ''
   const pgOrderNo = searchParams.get('pgOrderNo') ?? ''
+  const pgToken = searchParams.get('pgToken') ?? ''
   const paymentType = searchParams.get('paymentType') ?? ''
   const requestId = searchParams.get('requestId') ?? ''
   const guideId = searchParams.get('guideId') ?? ''
@@ -55,6 +56,7 @@ export function PaymentKakaoStubPage() {
         json: {
           pgOrderNo,
           amount: Number(amount),
+          ...(pgToken ? { pgToken } : {}),
         },
       })
       const t = await res.text()


### PR DESCRIPTION
## 🔗 이슈 번호
- Closes #267

## 💡 주요 변경 사항
- 카카오페이 success/cancel/fail 콜백 경로를 permitAll로 열어 401 차단 해소
- 콜백 컨트롤러 추가: pgOrderNo로 결제건을 조회해 프론트 `/pay/kakao-stub`로 리다이렉트 (pgToken 포함)
- 프론트 결제 confirm 요청에 pgToken 전달 지원

## ✅ 체크리스트
- [x] 빌드/컴파일이 정상적으로 되는가?
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [x] 불필요한 파일 수정이 포함되지 않았는가?

## 🧪 검증 커맨드

```bash
# backend
cd backend
./gradlew :api-server:compileJava

# frontend
npm -C frontend run build
```

Made with [Cursor](https://cursor.com)