### PR TITLE
feat: CreateGuideScheduleRequest DTO 필드 추가

### DIFF
--- a/backend/module-domain/src/main/java/com/team6/domain/guide/dto/request/CreateGuideProfileRequest.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/dto/request/CreateGuideProfileRequest.java
@@ -33,4 +33,10 @@ public class CreateGuideProfileRequest {
     private Integer residenceYears; // 해당 지역 거주 연수 (선택)
 
     private String localStory;      // 지역 스토리 (선택)
+
+    private String keywords;        // AI 매칭용 키워드 (선택, F06-02)
+
+    private String defaultCourse;   // 디폴트 코스 (선택, F06-02)
+
+    private String guideStyle;      // 가이드 스타일 (선택, F06-02)
 }

--- a/backend/module-domain/src/main/java/com/team6/domain/guide/service/GuideProfileService.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/service/GuideProfileService.java
@@ -69,6 +69,9 @@ public class GuideProfileService {
                 .isApproved(true)
                 .residenceYears(request.getResidenceYears())
                 .localStory(request.getLocalStory())
+                .keywords(request.getKeywords())
+                .defaultCourse(request.getDefaultCourse())
+                .guideStyle(request.getGuideStyle())
                 .build();
 
         GuideProfile saved = guideProfileRepository.save(profile);


### PR DESCRIPTION

# 🔗 이슈 번호
- Closes #266

---

## 💡 주요 변경 사항
- CreateGuideProfileRequest DTO에 필드 추가
  - keywords (AI 매칭 키워드)
  - defaultCourse (기본 코스)
  - guideStyle (가이드 스타일)

- GuideProfileService.createProfile()에서
  위 필드들을 GuideProfile.builder()에 매핑하도록 수정

---

## 🧠 변경 이유
- GuideProfile 엔티티에는 이미 해당 필드가 존재했지만
  Create DTO와 서비스 로직에서 누락되어

  👉 가이드 프로필 생성 시 해당 값들이 저장되지 않고
  항상 null로 들어가는 문제 발생

- Update DTO에는 존재했지만 Create에서만 빠져있던 불일치 상태였음

👉 따라서 생성(create) 시에도 정상적으로 값이 저장되도록 수정

---

## ⚠️ 주의 사항 / 영향 범위
- 가이드 프로필 생성 API 요청 구조 변경됨 (필드 3개 추가)
- 프론트에서 해당 필드 전달 여부 확인 필요

---

## ✅ 체크리스트
- [x] 빌드 정상
- [x] DTO ↔ Entity 필드 정합성 맞춤
- [x] 생성/수정 로직 일관성 확보

## ✅ 체크리스트
- [ ] 빌드가 정상적으로 되는가?
- [ ] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [ ] .gitignore에 설정 파일이 잘 포함되었는가? (application-local.yml 등)