### PR TITLE
Fix/be#270 카카오 콜백 pgOrderNo 누락 리다이렉트

### DIFF
--- a/backend/module-domain/src/main/java/com/team6/domain/matching/controller/KakaoPayRedirectController.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/controller/KakaoPayRedirectController.java
@@ -35,8 +35,21 @@ public class KakaoPayRedirectController {
     @GetMapping("/success")
     public ResponseEntity<Void> success(
             @RequestParam("pg_token") String pgToken,
-            @RequestParam("pgOrderNo") String pgOrderNo
+            @RequestParam(value = "pgOrderNo", required = false) String pgOrderNo
     ) {
+        if (pgOrderNo == null || pgOrderNo.isBlank()) {
+            URI redirect = UriComponentsBuilder
+                    .fromHttpUrl(frontendBaseUrl)
+                    .path("/pay/kakao-stub")
+                    .queryParam("result", "success")
+                    .queryParam("error", "missing_pgOrderNo")
+                    .build(true)
+                    .toUri();
+            HttpHeaders headers = new HttpHeaders();
+            headers.setLocation(redirect);
+            return new ResponseEntity<>(headers, HttpStatus.FOUND);
+        }
+
         Payment payment = paymentRepository.findByPgOrderNo(pgOrderNo)
                 .orElseThrow(() -> new MatchingException(MatchingErrorCode.PAYMENT_NOT_FOUND));
 
@@ -47,7 +60,19 @@ public class KakaoPayRedirectController {
     }
 
     @GetMapping("/cancel")
-    public ResponseEntity<Void> cancel(@RequestParam("pgOrderNo") String pgOrderNo) {
+    public ResponseEntity<Void> cancel(@RequestParam(value = "pgOrderNo", required = false) String pgOrderNo) {
+        if (pgOrderNo == null || pgOrderNo.isBlank()) {
+            URI redirect = UriComponentsBuilder
+                    .fromHttpUrl(frontendBaseUrl)
+                    .path("/pay/kakao-stub")
+                    .queryParam("result", "cancel")
+                    .queryParam("error", "missing_pgOrderNo")
+                    .build(true)
+                    .toUri();
+            HttpHeaders headers = new HttpHeaders();
+            headers.setLocation(redirect);
+            return new ResponseEntity<>(headers, HttpStatus.FOUND);
+        }
         Payment payment = paymentRepository.findByPgOrderNo(pgOrderNo)
                 .orElseThrow(() -> new MatchingException(MatchingErrorCode.PAYMENT_NOT_FOUND));
         URI redirect = buildFrontendRedirect(payment, null, "cancel");
@@ -57,7 +82,19 @@ public class KakaoPayRedirectController {
     }
 
     @GetMapping("/fail")
-    public ResponseEntity<Void> fail(@RequestParam("pgOrderNo") String pgOrderNo) {
+    public ResponseEntity<Void> fail(@RequestParam(value = "pgOrderNo", required = false) String pgOrderNo) {
+        if (pgOrderNo == null || pgOrderNo.isBlank()) {
+            URI redirect = UriComponentsBuilder
+                    .fromHttpUrl(frontendBaseUrl)
+                    .path("/pay/kakao-stub")
+                    .queryParam("result", "fail")
+                    .queryParam("error", "missing_pgOrderNo")
+                    .build(true)
+                    .toUri();
+            HttpHeaders headers = new HttpHeaders();
+            headers.setLocation(redirect);
+            return new ResponseEntity<>(headers, HttpStatus.FOUND);
+        }
         Payment payment = paymentRepository.findByPgOrderNo(pgOrderNo)
                 .orElseThrow(() -> new MatchingException(MatchingErrorCode.PAYMENT_NOT_FOUND));
         URI redirect = buildFrontendRedirect(payment, null, "fail");


### PR DESCRIPTION
## 🔗 이슈 번호
- Closes #270

## 💡 주요 변경 사항
- 카카오 success/cancel/fail 콜백에서 pgOrderNo 누락 시 400 오류페이지 대신 프론트 `/pay/kakao-stub`로 리다이렉트

## ✅ 체크리스트
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [x] 불필요한 파일 수정이 포함되지 않았는가?

## 🧪 검증
- 로컬에서 `GET /api/matching/payments/kakao/success?pg_token=test` 호출 시 302로 프론트 리다이렉트 확인

Made with [Cursor](https://cursor.com)