### PR TITLE
Feat/be#273: 마이페이지 대시보드 API 연동

### DIFF
--- a/frontend/src/pages/MyPageOverview.jsx
+++ b/frontend/src/pages/MyPageOverview.jsx
@@ -1,51 +1,194 @@
-import { Link } from 'react-router-dom'
+import { useEffect, useMemo, useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
 
+import { apiRequest } from '../api/client.js'
 import { useAuth } from '../context/useAuth.js'
+
+import './MypageMemberPages.css'
+
+function formatDateKo(v) {
+  if (!v) return '—'
+  const d = new Date(String(v))
+  if (Number.isNaN(d.getTime())) return String(v)
+  return d.toLocaleDateString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit', weekday: 'short' })
+}
+
+function formatDateTimeKo(v) {
+  if (!v) return '—'
+  const d = new Date(String(v))
+  if (Number.isNaN(d.getTime())) return String(v)
+  return d.toLocaleString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' })
+}
 
 export function MyPageOverview() {
   const { email, isGuide } = useAuth()
+  const navigate = useNavigate()
+
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [data, setData] = useState(null)
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      setLoading(true)
+      setError('')
+      try {
+        const res = await apiRequest('/mypage/guest/dashboard', { method: 'GET' })
+        const text = await res.text()
+        if (!res.ok) {
+          let msg = '대시보드를 불러오지 못했습니다.'
+          try {
+            const j = JSON.parse(text)
+            if (typeof j?.message === 'string' && j.message.trim()) msg = j.message.trim()
+          } catch {
+            if (text) msg = text
+          }
+          throw new Error(msg)
+        }
+        const json = text ? JSON.parse(text) : null
+        if (!cancelled) setData(json)
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : '불러오기 실패')
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const upcoming = useMemo(() => (Array.isArray(data?.upcomingMatches) ? data.upcomingMatches : []), [data])
+  const scrapbooks = useMemo(() => (Array.isArray(data?.scrapbooks) ? data.scrapbooks : []), [data])
+
+  const displayName = data?.guestName?.trim() ? String(data.guestName).trim() : email ?? '여행자'
+  const displayEmail = data?.guestEmail?.trim() ? String(data.guestEmail).trim() : email ?? '—'
+
+  const goPay = (m) => {
+    const guideId = m?.guideId
+    const requestId = m?.matchRequestedId ?? m?.requestId
+    if (!guideId || !requestId) return
+    navigate(`/guides/${guideId}/match`, { state: { requestId } })
+  }
 
   return (
-    <div>
-      <h2 style={{ marginTop: 0 }}>대시보드</h2>
-      <p style={{ color: '#555', lineHeight: 1.5 }}>
-        로그인 계정: <strong>{email}</strong>
-        <br />
-        JWT 역할: <strong>{isGuide ? 'GUIDE' : 'GUEST'}</strong> — 가이드 신청 후에는 <strong>재로그인</strong>해서
-        로그인 유형을 GUIDE로 선택하면 가이드 토큰이 발급됩니다.
+    <div className="mp-member">
+      <h1>마이페이지</h1>
+      <p className="sub">
+        <code>GET /api/mypage/guest/dashboard</code> 기반 요약입니다. 세부 관리는 아래 바로가기로 이동할 수 있어요.
       </p>
-      <ul style={{ paddingLeft: '1.2rem', color: '#444', lineHeight: 1.6 }}>
-        <li>
-          <Link to="/mypage/scrapbook">나의 여행 기록</Link> · <code>GET /api/matching/requests/guest/list</code>
-        </li>
-        <li>
-          <Link to="/mypage/itinerary">앞으로의 여행 일정</Link> · 동일 API (진행·예정)
-        </li>
-        <li>
-          <Link to="/mypage/profile">프로필</Link> · 조회/수정 API는 추후 연동
-        </li>
-        <li>
-          <Link to="/mypage/payments">결제 내역</Link> · <code>GET /api/matching/payments/guest/list</code>
-        </li>
-        <li>
-          <Link to="/mypage/tour">연장·환불</Link> · <code>/api/matching/extensions</code>, <code>…/payments/refunds</code>
-        </li>
-        <li>
-          <Link to="/mypage/reviews">내 리뷰</Link> · <code>/api/reviews</code>
-        </li>
-      </ul>
-      {!isGuide && (
-        <p style={{ marginTop: '1.25rem' }}>
-          <Link to="/guide/register" className="button" style={{ display: 'inline-flex' }}>
-            가이드 신청하기 (약관 → <code>POST /api/guides</code>)
+
+      <div className="mp-scrap-hero" style={{ marginBottom: '1rem' }}>
+        <div>
+          <h2 style={{ margin: 0, fontSize: '1rem', fontWeight: 800 }}>{displayName}님, 환영해요</h2>
+          <p style={{ margin: '0.35rem 0 0', color: '#4b5563', lineHeight: 1.55 }}>
+            로그인 계정: <strong>{displayEmail}</strong>
+            <br />
+            JWT 역할: <strong>{isGuide ? 'GUIDE' : 'GUEST'}</strong>
+          </p>
+        </div>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.45rem', justifyContent: 'flex-end' }}>
+          <Link to="/mypage/itinerary" className="mp-btn mp-btn--line" style={{ textDecoration: 'none' }}>
+            일정 전체
           </Link>
-        </p>
-      )}
-      {isGuide && (
-        <p style={{ marginTop: '1.25rem', color: '#0d47a1' }}>
-          가이드 메뉴: 상단 <strong>가이드 예약함</strong>에서 <code>GET /api/matching/requests/guide/list</code> 결과를
-          확인할 수 있습니다.
-        </p>
+          <Link to="/mypage/scrapbook" className="mp-btn mp-btn--line" style={{ textDecoration: 'none' }}>
+            기록 전체
+          </Link>
+        </div>
+      </div>
+
+      {error && <p className="err">{error}</p>}
+      {loading && <p>불러오는 중…</p>}
+
+      {!loading && !error && (
+        <>
+          <h2 style={{ margin: '0 0 0.75rem', fontSize: '0.95rem', fontWeight: 800 }}>다가오는 여행</h2>
+          {upcoming.length === 0 ? (
+            <p className="sub">예정된 여행이 없어요.</p>
+          ) : (
+            <div className="mp-cards">
+              {upcoming.map((m) => (
+                <article key={m.matchRequestedId ?? m.requestId ?? `${m.guideId}-${m.desiredDate}`} className="mp-trip-card">
+                  <div className="mp-trip-card__meta">
+                    <h2 className="mp-trip-title">{m.destination ?? '여행'}</h2>
+                    <p className="mp-trip-detail">
+                      {formatDateKo(m.desiredDate)} · 상태: {m.status ?? '—'}
+                    </p>
+                    <p className="mp-trip-detail">요청 #{m.matchRequestedId ?? m.requestId ?? '—'}</p>
+                    <p className="mp-trip-detail">가이드: #{m.guideId ?? '—'}</p>
+                  </div>
+                  <div className="mp-trip-actions">
+                    <span className="mp-thumb" style={{ minHeight: '4.5rem' }}>
+                      Preview
+                    </span>
+                    {String(m.status).toUpperCase() === 'ACCEPTED' && (
+                      <button type="button" className="mp-btn" onClick={() => goPay(m)}>
+                        결제하고 확정
+                      </button>
+                    )}
+                    <Link to="/mypage/itinerary" className="mp-btn mp-btn--line" style={{ textDecoration: 'none', textAlign: 'center' }}>
+                      일정에서 관리
+                    </Link>
+                  </div>
+                </article>
+              ))}
+            </div>
+          )}
+
+          <h2 style={{ margin: '1.5rem 0 0.75rem', fontSize: '0.95rem', fontWeight: 800 }}>나의 여행 기록</h2>
+          {scrapbooks.length === 0 ? (
+            <p className="sub">아직 스크랩북이 없어요.</p>
+          ) : (
+            <div className="mp-cards">
+              {scrapbooks.slice(0, 3).map((s) => (
+                <article key={s.scrapbookId} className="mp-trip-card mp-trip-card--past">
+                  <div className="mp-trip-card__meta">
+                    <h2 className="mp-trip-title">{s.title ?? '스크랩북'}</h2>
+                    <p className="mp-trip-detail">작성: {formatDateTimeKo(s.createdAt)}</p>
+                    {s.tags ? <p className="mp-trip-detail">태그: {String(s.tags)}</p> : null}
+                    {s.matchRequestId != null ? (
+                      <p className="mp-trip-detail">매칭 요청 #{s.matchRequestId}</p>
+                    ) : null}
+                  </div>
+                  <div
+                    className="mp-thumb"
+                    style={
+                      s.mainImageUrl
+                        ? {
+                            minHeight: '4.5rem',
+                            backgroundImage: `url(${String(s.mainImageUrl)})`,
+                            backgroundSize: 'cover',
+                            backgroundPosition: 'center',
+                          }
+                        : { minHeight: '4.5rem' }
+                    }
+                  >
+                    {!s.mainImageUrl ? 'Cover' : ''}
+                  </div>
+                </article>
+              ))}
+            </div>
+          )}
+
+          <h2 style={{ margin: '1.5rem 0 0.75rem', fontSize: '0.95rem', fontWeight: 800 }}>바로가기</h2>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.45rem' }}>
+            <Link to="/mypage/payments" className="mp-btn mp-btn--line" style={{ textDecoration: 'none' }}>
+              결제 내역
+            </Link>
+            <Link to="/mypage/tour" className="mp-btn mp-btn--line" style={{ textDecoration: 'none' }}>
+              연장·환불
+            </Link>
+            <Link to="/mypage/privacy" className="mp-btn mp-btn--line" style={{ textDecoration: 'none' }}>
+              알림/설정
+            </Link>
+            {!isGuide && (
+              <Link to="/guide/register" className="mp-btn" style={{ textDecoration: 'none' }}>
+                가이드 신청
+              </Link>
+            )}
+          </div>
+        </>
       )}
     </div>
   )


### PR DESCRIPTION
## 🔗 이슈 번호
- Closes #273

## 💡 주요 변경 사항
- `/mypage` Overview(`MyPageOverview`)가 `GET /mypage/guest/dashboard` 응답 기반 요약 대시보드로 동작
- 다가오는 여행(`ACCEPTED`)에서 결제 플로우(`/guides/:guideId/match`)로 이동 가능 (`matchRequestedId` → `requestId` state)
- 스크랩북 요약(최대 3개) 표시 및 마이페이지 하위 화면 바로가기 제공
- 마이페이지 공통 스타일(`MypageMemberPages.css`) import로 UI 톤 정렬

## ⚠️ 주의 사항 / 질문
- `UpcomingMatchResponse`에는 제안 일정 필드가 없어 대시보드 카드에서는 요약 정보만 노출됩니다(상세는 `/mypage/itinerary`에서 확인).
- 런타임 검증은 백엔드 기동 + 로그인(GUEST) 상태에서 `/mypage` 진입으로 확인하는 것을 권장합니다.

## ✅ 체크리스트
- [x] 빌드가 정상적으로 되는가?
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [x] `.gitignore`에 설정 파일이 잘 포함되었는가? (`application-local.yml` 등)

## 🧪 검증 커맨드

```bash
npm -C frontend run build
```