### PR TITLE
Feat/be#275 마이페이지 프로필·내 리뷰 및 리뷰 본인 목록 API

### DIFF
--- a/backend/api-server/src/main/java/com/team6/apiserver/auth/config/SecurityConfig.java
+++ b/backend/api-server/src/main/java/com/team6/apiserver/auth/config/SecurityConfig.java
@@ -71,7 +71,8 @@ public class SecurityConfig {
                                 "/api/swagger-ui.html"
                         ).permitAll()
 
-                        // 2. 리뷰 조회는 비로그인 유저도 가능
+                        // 2. 리뷰 조회는 비로그인 유저도 가능 (단, 본인 목록은 인증 필요 — /reviews/** 보다 먼저 둔다)
+                        .requestMatchers(HttpMethod.GET, "/reviews/me").authenticated()
                         .requestMatchers(HttpMethod.GET, "/reviews/**").permitAll()
                         // 리뷰 등록, 수정, 삭제는 인증 필요
                         .requestMatchers(HttpMethod.POST, "/reviews/**").authenticated()

--- a/backend/module-domain/src/main/java/com/team6/domain/review/controller/ReviewController.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/review/controller/ReviewController.java
@@ -27,6 +27,14 @@ public class ReviewController {
         return ResponseEntity.ok(reviewService.findAll(pageable));
     }
 
+    /** 마이페이지 등: 로그인한 작성자 본인의 리뷰만 조회 */
+    @GetMapping("/me")
+    public ResponseEntity<Page<ReviewResponse>> getMyReviews(
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return ResponseEntity.ok(reviewService.listMyReviews(pageable));
+    }
+
     @PostMapping
     public ResponseEntity<String> create(@Valid @RequestBody ReviewRequest request) {
         reviewService.saveReview(request);

--- a/backend/module-domain/src/main/java/com/team6/domain/review/dto/response/ReviewResponse.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/review/dto/response/ReviewResponse.java
@@ -3,12 +3,13 @@ package com.team6.domain.review.dto.response;
 import com.team6.domain.review.entity.Review;
 import lombok.Getter;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
 public class ReviewResponse {
     private Long id;
+    private Long guideId;
+    private Long matchRequestId;
     private Integer rating;
     private String content;
     private String writeNickname;
@@ -16,6 +17,8 @@ public class ReviewResponse {
 
     public ReviewResponse (Review review) {
         this.id = review.getId();
+        this.guideId = review.getGuideId();
+        this.matchRequestId = review.getMatchRequestId();
         this.rating = review.getRating();
         this.content = review.getContent();
         this.writeNickname = review.getMember().getNickname();

--- a/backend/module-domain/src/main/java/com/team6/domain/review/repository/ReviewRepository.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/review/repository/ReviewRepository.java
@@ -20,6 +20,9 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     @EntityGraph(attributePaths = {"member"})
     Page<Review> findAllByDeletedFalse(Pageable pageable);
 
+    @EntityGraph(attributePaths = {"member"})
+    Page<Review> findAllByMemberAndDeletedFalse(Member member, Pageable pageable);
+
     boolean existsByMatchRequestId(Long matchedRequestedId);
 
     @Query("SELECT AVG(r.rating), COUNT(r) FROM Review r WHERE r.guideId = :guideId")

--- a/backend/module-domain/src/main/java/com/team6/domain/review/service/ReviewService.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/review/service/ReviewService.java
@@ -90,6 +90,14 @@ public class ReviewService {
                 .map(ReviewResponse::new);
     }
 
+    /** 현재 로그인한 회원이 작성한 리뷰(삭제 제외) */
+    @Transactional(readOnly = true)
+    public Page<ReviewResponse> listMyReviews(Pageable pageable) {
+        Member member = getCurrentMember();
+        return reviewRepository.findAllByMemberAndDeletedFalse(member, pageable)
+                .map(ReviewResponse::new);
+    }
+
     // 리뷰 삭제
     @Transactional
     public void deleteReview(Long reviewId) {

--- a/frontend/src/pages/MypageProfilePage.jsx
+++ b/frontend/src/pages/MypageProfilePage.jsx
@@ -1,0 +1,114 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+
+import { apiRequest } from '../api/client.js'
+import { useAuth } from '../context/useAuth.js'
+import { getGuestDisplayName, loadGuestPrivacyForm } from '../lib/guestMypagePrefs.js'
+import { getEmailFromToken, getRoleFromToken, parseJwtPayload } from '../lib/jwt.js'
+
+import './MypageMemberPages.css'
+
+function parseApiErrorMessage(text) {
+  if (!text) return '요청 실패'
+  try {
+    const j = JSON.parse(text)
+    return (j.message ?? text) || '요청 실패'
+  } catch {
+    return text || '요청 실패'
+  }
+}
+
+export function MypageProfilePage() {
+  const { email, token, logout } = useAuth()
+  const navigate = useNavigate()
+
+  const claims = useMemo(() => parseJwtPayload(token ?? ''), [token])
+  const jwtEmail = useMemo(() => (token ? getEmailFromToken(token) : null), [token])
+  const jwtRole = useMemo(() => (token ? getRoleFromToken(token) : null), [token])
+
+  const [nickname, setNickname] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [toast, setToast] = useState('')
+
+  useEffect(() => {
+    const f = loadGuestPrivacyForm(email)
+    setNickname(f.nickname ?? '')
+  }, [email])
+
+  const displayName = useMemo(() => getGuestDisplayName(email), [email, nickname])
+
+  const onWithdraw = async () => {
+    const ok = window.confirm('정말 탈퇴할까요? 탈퇴 후에는 복구가 어려울 수 있어요.')
+    if (!ok) return
+
+    setBusy(true)
+    setToast('')
+    try {
+      const res = await apiRequest('/members/me?role=GUEST', { method: 'DELETE' })
+      const text = await res.text()
+      if (!res.ok) throw new Error(parseApiErrorMessage(text))
+      await logout()
+      navigate('/', { replace: true, state: { hint: '회원 탈퇴가 완료되었습니다.' } })
+    } catch (e) {
+      setToast(e instanceof Error ? e.message : '탈퇴 처리 실패')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="mp-member">
+      <h1>👤 프로필</h1>
+      <p className="sub">
+        현재 백엔드는 <code>POST /members/join</code>, <code>DELETE /members/me?role=...</code> 중심입니다. 표시 정보는{' '}
+        <strong>JWT + 로컬 설정(/mypage/privacy)</strong> 기반으로 구성합니다.
+      </p>
+
+      {toast && <p className="err">{toast}</p>}
+
+      <div className="mp-scrap-hero" style={{ marginBottom: '1rem' }}>
+        <div>
+          <h2 style={{ margin: 0, fontSize: '1rem', fontWeight: 800 }}>{displayName}</h2>
+          <p style={{ margin: '0.35rem 0 0', color: '#4b5563', lineHeight: 1.55 }}>
+            이메일: <strong>{email ?? '—'}</strong>
+            <br />
+            표시 닉네임(로컬): <strong>{nickname?.trim() ? nickname.trim() : '—'}</strong>
+          </p>
+        </div>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.45rem', justifyContent: 'flex-end' }}>
+          <Link to="/mypage/privacy" className="mp-btn" style={{ textDecoration: 'none' }}>
+            개인정보/알림 설정
+          </Link>
+        </div>
+      </div>
+
+      <h2 style={{ margin: '0 0 0.75rem', fontSize: '0.95rem', fontWeight: 800 }}>계정/토큰 정보</h2>
+      <div className="mp-cards">
+        <article className="mp-trip-card mp-trip-card--past">
+          <div className="mp-trip-card__meta">
+            <p className="mp-trip-detail">JWT 이메일(sub): {jwtEmail ?? '—'}</p>
+            <p className="mp-trip-detail">JWT 역할: {jwtRole ?? '—'}</p>
+            <p className="mp-trip-detail">jti: {claims?.jti ? String(claims.jti) : '—'}</p>
+            <p className="mp-trip-detail">exp: {claims?.exp ? String(claims.exp) : '—'}</p>
+          </div>
+          <div className="mp-trip-actions">
+            <span className="mp-thumb" style={{ minHeight: '4.5rem' }}>
+              Account
+            </span>
+            <Link to="/auth/login" className="mp-btn mp-btn--line" style={{ textDecoration: 'none', textAlign: 'center' }}>
+              다른 계정으로 로그인
+            </Link>
+          </div>
+        </article>
+      </div>
+
+      <h2 style={{ margin: '1.5rem 0 0.75rem', fontSize: '0.95rem', fontWeight: 800 }}>위험 구역</h2>
+      <p className="sub">탈퇴는 되돌리기 어려운 동작입니다. 로컬 개발 계정에서만 테스트해 주세요.</p>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.45rem' }}>
+        <button type="button" className="mp-btn mp-btn--danger" disabled={busy} onClick={() => void onWithdraw()}>
+          {busy ? '처리 중…' : '회원 탈퇴(DELETE /members/me?role=GUEST)'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/MypageReviewsPage.jsx
+++ b/frontend/src/pages/MypageReviewsPage.jsx
@@ -1,0 +1,277 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+
+import { apiRequest } from '../api/client.js'
+
+import './MypageMemberPages.css'
+
+function formatDt(iso) {
+  if (!iso) return '—'
+  try {
+    return new Date(iso).toLocaleString('ko-KR')
+  } catch {
+    return String(iso)
+  }
+}
+
+function stars(rating) {
+  const n = Math.max(1, Math.min(5, Math.round(Number(rating ?? 0))))
+  return '★'.repeat(n)
+}
+
+function parseApiErrorMessage(text) {
+  if (!text) return '요청 실패'
+  try {
+    const j = JSON.parse(text)
+    return (j.message ?? text) || '요청 실패'
+  } catch {
+    return text || '요청 실패'
+  }
+}
+
+function within24Hours(createdAtIso) {
+  if (!createdAtIso) return false
+  const t = new Date(createdAtIso).getTime()
+  if (Number.isNaN(t)) return false
+  return Date.now() - t < 24 * 60 * 60 * 1000
+}
+
+export function MypageReviewsPage() {
+  const [page, setPage] = useState(0)
+  const [rows, setRows] = useState([])
+  const [first, setFirst] = useState(true)
+  const [last, setLast] = useState(true)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [busyId, setBusyId] = useState(/** @type {number | null} */ (null))
+  const [editId, setEditId] = useState(/** @type {number | null} */ (null))
+  const [editRating, setEditRating] = useState(5)
+  const [editContent, setEditContent] = useState('')
+  const [formErr, setFormErr] = useState('')
+
+  const load = useCallback(async (p) => {
+    setLoading(true)
+    setError('')
+    try {
+      const res = await apiRequest(`/reviews/me?page=${p}&size=10`, { method: 'GET' })
+      const text = await res.text()
+      if (!res.ok) throw new Error(parseApiErrorMessage(text))
+      const data = text ? JSON.parse(text) : {}
+      const content = Array.isArray(data.content) ? data.content : []
+      setRows(content)
+      setFirst(data.first === true)
+      setLast(data.last === true)
+    } catch (e) {
+      setRows([])
+      setError(e instanceof Error ? e.message : '목록을 불러오지 못했습니다.')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void load(page)
+  }, [load, page])
+
+  const onDelete = async (id) => {
+    const ok = window.confirm('이 리뷰를 삭제할까요?')
+    if (!ok) return
+    setBusyId(id)
+    setFormErr('')
+    try {
+      const res = await apiRequest(`/reviews/${id}`, { method: 'DELETE' })
+      if (!res.ok) {
+        const text = await res.text()
+        throw new Error(parseApiErrorMessage(text))
+      }
+      void load(page)
+    } catch (e) {
+      setFormErr(e instanceof Error ? e.message : '삭제 실패')
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  const openEdit = (r) => {
+    setFormErr('')
+    setEditId(r.id)
+    setEditRating(Number(r.rating ?? 5))
+    setEditContent(String(r.content ?? ''))
+  }
+
+  const onSaveEdit = async (e) => {
+    e.preventDefault()
+    if (editId == null) return
+    const content = editContent.trim()
+    if (content.length < 10) {
+      setFormErr('리뷰는 10자 이상 입력해 주세요.')
+      return
+    }
+    setBusyId(editId)
+    setFormErr('')
+    try {
+      const res = await apiRequest(`/reviews/${editId}/update`, {
+        method: 'POST',
+        json: { rating: editRating, content },
+      })
+      const text = await res.text()
+      if (!res.ok) throw new Error(parseApiErrorMessage(text))
+      setEditId(null)
+      void load(page)
+    } catch (e) {
+      setFormErr(e instanceof Error ? e.message : '수정 실패')
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  return (
+    <div className="mp-member">
+      <h1>⭐ 내 리뷰</h1>
+      <p className="sub">
+        <code>GET /reviews/me</code>로 내가 작성한 리뷰만 불러옵니다. 수정은 작성 후 24시간 이내, 삭제는 언제든 가능합니다(백엔드 정책과 동일).
+      </p>
+
+      {formErr && <p className="err">{formErr}</p>}
+      {error && <p className="err">{error}</p>}
+
+      {loading ? (
+        <p className="sub">불러오는 중…</p>
+      ) : rows.length === 0 ? (
+        <p className="sub">아직 작성한 리뷰가 없습니다. 가이드 매칭 화면에서 후기를 남겨 보세요.</p>
+      ) : (
+        <div className="mp-cards">
+          {rows.map((r) => (
+            <article key={r.id} className="mp-trip-card mp-trip-card--past">
+              <div className="mp-trip-card__meta">
+                <p className="mp-trip-detail" style={{ fontWeight: 700 }}>
+                  {stars(r.rating)} <span style={{ color: '#6b7280', fontWeight: 600 }}>({r.rating}/5)</span>
+                </p>
+                <p className="mp-trip-detail" style={{ whiteSpace: 'pre-wrap' }}>
+                  {r.content}
+                </p>
+                <p className="mp-trip-detail" style={{ fontSize: '0.8rem', color: '#6b7280' }}>
+                  작성: {formatDt(r.createdAt)}
+                  {r.guideId != null ? (
+                    <>
+                      {' · '}
+                      <Link to={`/guides/${r.guideId}`}>가이드 프로필</Link>
+                      {' · '}
+                      <Link
+                        to={`/guides/${r.guideId}/match`}
+                        state={r.matchRequestId != null ? { requestId: r.matchRequestId } : undefined}
+                      >
+                        매칭·결제
+                      </Link>
+                    </>
+                  ) : null}
+                </p>
+              </div>
+              <div className="mp-trip-actions" style={{ alignSelf: 'stretch' }}>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '0.45rem', width: '100%' }}>
+                  {within24Hours(r.createdAt) ? (
+                    <button type="button" className="mp-btn mp-btn--line" disabled={busyId != null} onClick={() => openEdit(r)}>
+                      수정
+                    </button>
+                  ) : null}
+                  <button
+                    type="button"
+                    className="mp-btn mp-btn--danger"
+                    disabled={busyId != null}
+                    onClick={() => void onDelete(r.id)}
+                  >
+                    {busyId === r.id ? '처리 중…' : '삭제'}
+                  </button>
+                </div>
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
+
+      <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1rem', flexWrap: 'wrap' }}>
+        <button type="button" className="mp-btn mp-btn--line" disabled={first || loading} onClick={() => setPage((p) => Math.max(0, p - 1))}>
+          이전
+        </button>
+        <button type="button" className="mp-btn mp-btn--line" disabled={last || loading} onClick={() => setPage((p) => p + 1)}>
+          다음
+        </button>
+      </div>
+
+      {editId != null && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="mp-rev-edit-title"
+          style={{
+            position: 'fixed',
+            inset: 0,
+            background: 'rgba(15,23,42,0.45)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 50,
+            padding: '1rem',
+          }}
+        >
+          <form
+            onSubmit={(e) => void onSaveEdit(e)}
+            style={{
+              width: '100%',
+              maxWidth: 420,
+              background: '#fff',
+              borderRadius: 14,
+              padding: '1.1rem',
+              border: '1px solid #e8eaed',
+              boxShadow: '0 12px 40px rgba(15,23,42,0.12)',
+            }}
+          >
+            <h2 id="mp-rev-edit-title" style={{ margin: '0 0 0.75rem', fontSize: '1rem', fontWeight: 800 }}>
+              리뷰 수정
+            </h2>
+            <label className="sub" style={{ display: 'block', marginBottom: '0.35rem' }}>
+              별점
+            </label>
+            <select
+              className="mp-btn mp-btn--line"
+              style={{ width: '100%', marginBottom: '0.75rem', padding: '0.5rem' }}
+              value={editRating}
+              onChange={(e) => setEditRating(Number(e.target.value))}
+            >
+              {[1, 2, 3, 4, 5].map((n) => (
+                <option key={n} value={n}>
+                  {n}점
+                </option>
+              ))}
+            </select>
+            <label className="sub" style={{ display: 'block', marginBottom: '0.35rem' }}>
+              내용 (10~500자)
+            </label>
+            <textarea
+              value={editContent}
+              onChange={(e) => setEditContent(e.target.value)}
+              rows={5}
+              style={{
+                width: '100%',
+                boxSizing: 'border-box',
+                borderRadius: 10,
+                border: '1px solid #e8eaed',
+                padding: '0.6rem',
+                font: 'inherit',
+                resize: 'vertical',
+              }}
+            />
+            <div style={{ display: 'flex', gap: '0.5rem', marginTop: '0.85rem', justifyContent: 'flex-end' }}>
+              <button type="button" className="mp-btn mp-btn--line" disabled={busyId != null} onClick={() => setEditId(null)}>
+                취소
+              </button>
+              <button type="submit" className="mp-btn" disabled={busyId != null}>
+                {busyId != null ? '저장 중…' : '저장'}
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/routes/mypageRoutes.jsx
+++ b/frontend/src/routes/mypageRoutes.jsx
@@ -2,8 +2,9 @@ import { ProtectedRoute } from '../components/ProtectedRoute'
 import { MypageShell } from '../layouts/MypageShell'
 import { MypageItineraryPage } from '../pages/MypageItineraryPage'
 import { MypagePaymentsPage } from '../pages/MypagePaymentsPage'
-import { MypagePlaceholder } from '../pages/MypagePlaceholder'
 import { MypagePrivacyPage } from '../pages/MypagePrivacyPage'
+import { MypageProfilePage } from '../pages/MypageProfilePage'
+import { MypageReviewsPage } from '../pages/MypageReviewsPage'
 import { MypageScrapbookPage } from '../pages/MypageScrapbookPage'
 import { MypageTourPage } from '../pages/MypageTourPage'
 import { MyPageOverview } from '../pages/MyPageOverview'
@@ -18,15 +19,7 @@ export const mypageRoutes = [
     ),
     children: [
       { index: true, element: <MyPageOverview /> },
-      {
-        path: 'profile',
-        element: (
-          <MypagePlaceholder
-            title="프로필"
-            description="회원 프로필 조회·수정 API가 추가되면 이 화면에서 연동합니다."
-          />
-        ),
-      },
+      { path: 'profile', element: <MypageProfilePage /> },
       {
         path: 'scrapbook',
         element: <MypageScrapbookPage />,
@@ -47,10 +40,7 @@ export const mypageRoutes = [
         path: 'tour',
         element: <MypageTourPage />,
       },
-      {
-        path: 'reviews',
-        element: <MypagePlaceholder title="내 리뷰" description="/api/reviews 기반 목록·작성 화면 연동 예정." />,
-      },
+      { path: 'reviews', element: <MypageReviewsPage /> },
     ],
   },
 ]


### PR DESCRIPTION
🔗 관련 이슈: Closes #275

💡 변경 요약
- 마이페이지 `/mypage/profile`: JWT·로컬 닉네임(`/mypage/privacy`) 요약, 개인정보 설정 링크, `DELETE /members/me?role=GUEST` 탈퇴 흐름.
- 마이페이지 `/mypage/reviews`: `GET /reviews/me` 목록, 24시간 이내 `POST /reviews/{id}/update`, `DELETE /reviews/{id}`.
- 백엔드: `GET /reviews/me`(인증), `ReviewResponse`에 `guideId`·`matchRequestId` 포함. `SecurityConfig`에서 `/reviews/me`만 `GET` 인증 필요로 `/reviews/**` 공개 규칙보다 앞에 배치.

⚠️ 주의/한계
- `ReviewResponse` 필드 추가로 기존 리뷰 JSON에 필드가 늘어납니다(하위 호환).
- 프로필 상세 조회 전용 `GET /members/me`는 없어 JWT·로컬 설정 기반 UI입니다.

✅ 검증
- `./gradlew :module-domain:compileJava :api-server:compileJava`
- `cd frontend && npm run build`

Made with [Cursor](https://cursor.com)