### PR TITLE
Feat/fe#272: 프론트 백엔드 연결 설정

### DIFF
--- a/frontend/deployment/nginx/fe_blue.inc
+++ b/frontend/deployment/nginx/fe_blue.inc
@@ -1,3 +1,10 @@
 location / {
     proxy_pass http://127.0.0.1:3001; # 프론트 Blue 포트
 }
+location /api/ {
+    proxy_pass http://127.0.0.1:8080;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+}

--- a/frontend/deployment/nginx/fe_green.inc
+++ b/frontend/deployment/nginx/fe_green.inc
@@ -1,3 +1,10 @@
 location / {
     proxy_pass http://127.0.0.1:3002; # 프론트 Green 포트
 }
+location /api/ {
+    proxy_pass http://127.0.0.1:8080;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+}


### PR DESCRIPTION
# 🔗 이슈 번호
- Closes #272 

---

## 💡 주요 변경 사항
1. 배포 환경 API 통신 구조 개선 (Nginx Reverse Proxy)
Nginx 포트 포워딩 설정: 80포트로 들어오는 /api/ 요청을 백엔드 서버(8080포트)로 중계하도록 설정하여 CORS 이슈를 원천 해결하고 통신 구조를 단일화했습니다.

Blue-Green 배포 대응: fe_blue.inc 등 인클루드 파일 내에 API 프록시 설정을 추가하여 무중단 배포 시에도 API 엔드포인트가 유지되도록 구성했습니다.

---

## ⚠️ 주의 사항 / 질문
리뷰어가 중점적으로 봐주었으면 하는 부분이나 고민되는 지점을 적어주세요.

---

## ✅ 체크리스트
- [ ] 빌드가 정상적으로 되는가?
- [ ] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [ ] .gitignore에 설정 파일이 잘 포함되었는가? (application-local.yml 등)