### PR TITLE
UX 공통 로딩·에러·빈 상태 컴포넌트 및 페이지 적용

### DIFF
--- a/frontend/src/components/PageStates.css
+++ b/frontend/src/components/PageStates.css
@@ -1,0 +1,131 @@
+/* 공통 로딩 / 오류 / 빈 상태 — mp-member·gmo 등 레이아웃과 함께 사용 */
+
+.page-state--loading {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  color: #6b7280;
+  font-size: 0.9rem;
+  margin: 0 0 1rem;
+  line-height: 1.45;
+}
+
+.page-state-spinner {
+  flex-shrink: 0;
+  width: 1.1rem;
+  height: 1.1rem;
+  border: 2px solid #e5e7eb;
+  border-top-color: #374151;
+  border-radius: 50%;
+  animation: page-state-spin 0.65s linear infinite;
+}
+
+@keyframes page-state-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.page-state-label {
+  font-weight: 500;
+}
+
+.page-state--error {
+  padding: 0.85rem 1rem;
+  border-radius: 12px;
+  border: 1px solid #fecaca;
+  background: #fff7f7;
+  margin: 0 0 1rem;
+}
+
+.page-state--error .page-state-title {
+  margin: 0 0 0.35rem;
+  font-size: 0.88rem;
+  font-weight: 700;
+  color: #991b1b;
+}
+
+.page-state--error .page-state-msg {
+  margin: 0;
+  font-size: 0.88rem;
+  color: #b91c1c;
+  line-height: 1.45;
+}
+
+.page-state-retry {
+  margin-top: 0.65rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 10px;
+  border: 1px solid #e8eaed;
+  background: #fff;
+  font: inherit;
+  font-weight: 600;
+  font-size: 0.86rem;
+  cursor: pointer;
+  color: #1f2328;
+}
+
+.page-state-retry:hover {
+  background: #f9fafb;
+}
+
+.page-state-retry:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}
+
+.page-state--error .page-state-footer {
+  margin-top: 0.65rem;
+  font-size: 0.88rem;
+}
+
+.page-state--error .page-state-footer a {
+  color: #1f2328;
+  font-weight: 600;
+}
+
+.page-state--empty {
+  padding: 1.15rem 1rem;
+  border-radius: 12px;
+  border: 1px dashed #e5e7eb;
+  background: #f9fafb;
+  margin: 0 0 1rem;
+  color: #4b5563;
+  font-size: 0.9rem;
+  line-height: 1.55;
+}
+
+.page-state-empty-title {
+  margin: 0 0 0.4rem;
+  font-weight: 700;
+  font-size: 0.92rem;
+  color: #1f2328;
+}
+
+.page-state-empty-body {
+  margin: 0;
+}
+
+.page-state--muted {
+  color: #6b7280;
+}
+
+/* 사이드바·좁은 영역 */
+.page-state--tight.page-state--loading {
+  margin-bottom: 0.65rem;
+}
+
+.page-state--tight.page-state--error {
+  margin-bottom: 0.65rem;
+  padding: 0.7rem 0.85rem;
+}
+
+.page-state--tight.page-state--empty {
+  padding: 0.75rem 0.85rem;
+  margin-bottom: 0.65rem;
+  font-size: 0.86rem;
+}
+
+.page-state--tight.page-state--empty .page-state-empty-title {
+  font-size: 0.88rem;
+}

--- a/frontend/src/components/PageStates.jsx
+++ b/frontend/src/components/PageStates.jsx
@@ -1,0 +1,48 @@
+import './PageStates.css'
+
+/**
+ * @param {{ label?: string, className?: string }} props
+ */
+export function PageLoading({ label = '불러오는 중…', className = '' }) {
+  return (
+    <div
+      className={`page-state--loading ${className}`.trim()}
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+    >
+      <span className="page-state-spinner" aria-hidden />
+      <span className="page-state-label">{label}</span>
+    </div>
+  )
+}
+
+/**
+ * @param {{ message: string, title?: string, onRetry?: () => void, retryLabel?: string, children?: import('react').ReactNode, className?: string }} props
+ */
+export function PageError({ message, title, onRetry, retryLabel = '다시 시도', children, className = '' }) {
+  return (
+    <div className={`page-state--error ${className}`.trim()} role="alert">
+      {title ? <p className="page-state-title">{title}</p> : null}
+      <p className="page-state-msg">{message}</p>
+      {onRetry ? (
+        <button type="button" className="page-state-retry" onClick={onRetry}>
+          {retryLabel}
+        </button>
+      ) : null}
+      {children ? <div className="page-state-footer">{children}</div> : null}
+    </div>
+  )
+}
+
+/**
+ * @param {{ title?: string, children: import('react').ReactNode, className?: string }} props
+ */
+export function PageEmpty({ title, children, className = '' }) {
+  return (
+    <div className={`page-state--empty ${className}`.trim()}>
+      {title ? <p className="page-state-empty-title">{title}</p> : null}
+      <div className="page-state-empty-body">{children}</div>
+    </div>
+  )
+}

--- a/frontend/src/pages/GuideDetailPage.jsx
+++ b/frontend/src/pages/GuideDetailPage.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Link, useParams, useLocation, useNavigate } from 'react-router-dom'
 
+import { PageEmpty, PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client'
 import { useAuth } from '../context/useAuth.js'
 
@@ -196,9 +197,27 @@ export function GuideDetailPage() {
     }
   }
 
-  if (loading) return <p>불러오는 중…</p>
-  if (error) return <p style={{ color: '#b71c1c' }}>{error}</p>
-  if (!detail?.profile) return <p>데이터가 없습니다.</p>
+  if (loading) {
+    return (
+      <div style={{ maxWidth: 720, margin: '0 auto', padding: '1rem' }}>
+        <PageLoading />
+      </div>
+    )
+  }
+  if (error) {
+    return (
+      <div style={{ maxWidth: 720, margin: '0 auto', padding: '1rem' }}>
+        <PageError message={error} />
+      </div>
+    )
+  }
+  if (!detail?.profile) {
+    return (
+      <div style={{ maxWidth: 720, margin: '0 auto', padding: '1rem' }}>
+        <PageEmpty title="표시할 프로필이 없습니다">가이드 ID를 확인하거나 목록으로 돌아가 주세요.</PageEmpty>
+      </div>
+    )
+  }
 
   const p = detail.profile
 

--- a/frontend/src/pages/GuideFeedTourPage.jsx
+++ b/frontend/src/pages/GuideFeedTourPage.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 
+import { PageEmpty, PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client'
 import { useAuth } from '../context/useAuth.js'
 
@@ -110,7 +111,7 @@ export function GuideFeedTourPage() {
   if (loading) {
     return (
       <div className="gft">
-        <p className="gft-muted">불러오는 중…</p>
+        <PageLoading />
       </div>
     )
   }
@@ -121,8 +122,9 @@ export function GuideFeedTourPage() {
         <button type="button" className="gft-back" onClick={() => goBack()}>
           ← 뒤로 가기
         </button>
-        <p className="gft-err">{error || '가이드를 찾을 수 없습니다.'}</p>
-        <Link to="/guides">가이드 목록</Link>
+        <PageError message={error || '가이드를 찾을 수 없습니다.'}>
+          <Link to="/guides">가이드 목록</Link>
+        </PageError>
       </div>
     )
   }
@@ -133,8 +135,10 @@ export function GuideFeedTourPage() {
         <button type="button" className="gft-back" onClick={() => goBack()}>
           ← 뒤로 가기
         </button>
-        <p className="gft-err">이 피드는 삭제되었거나 없습니다.</p>
-        <Link to={`/guides/${guideId}`}>가이드 프로필</Link>
+        <PageEmpty title="이 피드를 찾을 수 없습니다">
+          삭제되었거나 주소가 바뀌었을 수 있어요.{' '}
+          <Link to={`/guides/${guideId}`}>가이드 프로필</Link>로 이동
+        </PageEmpty>
       </div>
     )
   }

--- a/frontend/src/pages/GuideListPage.jsx
+++ b/frontend/src/pages/GuideListPage.jsx
@@ -1,6 +1,7 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
 
+import { PageEmpty, PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client'
 
 import './GuideListPage.css'
@@ -19,19 +20,35 @@ export function GuideListPage() {
     return items.filter((g) => (g.region || '').toLowerCase().includes(q))
   }, [items, regionFilter])
 
+  const loadGuides = useCallback(async () => {
+    const res = await apiRequest('/guides', { method: 'GET', skipAuth: true })
+    const text = await res.text()
+    if (!res.ok) {
+      throw new Error(text || '목록을 불러오지 못했습니다.')
+    }
+    const data = text ? JSON.parse(text) : []
+    setItems(Array.isArray(data) ? data : [])
+  }, [])
+
+  const refetch = useCallback(async () => {
+    setLoading(true)
+    setError('')
+    try {
+      await loadGuides()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '오류')
+    } finally {
+      setLoading(false)
+    }
+  }, [loadGuides])
+
   useEffect(() => {
     let cancelled = false
     ;(async () => {
       setLoading(true)
       setError('')
       try {
-        const res = await apiRequest('/guides', { method: 'GET', skipAuth: true })
-        const text = await res.text()
-        if (!res.ok) {
-          throw new Error(text || '목록을 불러오지 못했습니다.')
-        }
-        const data = text ? JSON.parse(text) : []
-        if (!cancelled) setItems(Array.isArray(data) ? data : [])
+        await loadGuides()
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : '오류')
       } finally {
@@ -41,19 +58,23 @@ export function GuideListPage() {
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [loadGuides])
 
   return (
     <div className="guide-list">
       <h1 style={{ marginTop: 0 }}>가이드 목록</h1>
       <p className="guide-list-hint">승인·활성 가이드만 표시됩니다 (`GET /api/guides`).</p>
 
-      {loading && <p>불러오는 중…</p>}
-      {error && <p className="guide-list-error">{error}</p>}
+      {loading && <PageLoading />}
+      {!loading && error && <PageError message={error} onRetry={() => void refetch()} />}
 
-      {!loading && !error && items.length === 0 && <p>표시할 가이드가 없습니다.</p>}
+      {!loading && !error && items.length === 0 && (
+        <PageEmpty title="표시할 가이드가 없습니다">승인된 가이드가 등록되면 여기에 나타납니다.</PageEmpty>
+      )}
       {!loading && !error && items.length > 0 && filtered.length === 0 && regionFilter && (
-        <p>「{regionFilter}」 지역에 해당하는 가이드가 없습니다.</p>
+        <PageEmpty title="검색 결과가 없습니다">
+          「{regionFilter}」 지역에 해당하는 가이드가 없습니다. 필터를 바꿔 보세요.
+        </PageEmpty>
       )}
 
       <ul className="guide-grid">

--- a/frontend/src/pages/GuideMatchOptionsPage.jsx
+++ b/frontend/src/pages/GuideMatchOptionsPage.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Link, useLocation, useNavigate, useParams } from 'react-router-dom'
 
+import { PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client'
 
 import './GuideMatchOptionsPage.css'
@@ -195,13 +196,18 @@ export function GuideMatchOptionsPage() {
   }
 
   if (loading) {
-    return <p className="gmo" style={{ color: '#6b7280' }}>불러오는 중…</p>
+    return (
+      <div className="gmo">
+        <PageLoading />
+      </div>
+    )
   }
   if (error || !profile) {
     return (
       <div className="gmo">
-        <p style={{ color: '#b91c1c' }}>{error || '가이드를 찾을 수 없습니다.'}</p>
-        <Link to="/guides">가이드 목록</Link>
+        <PageError message={error || '가이드를 찾을 수 없습니다.'}>
+          <Link to="/guides">가이드 목록</Link>
+        </PageError>
       </div>
     )
   }

--- a/frontend/src/pages/GuideMatchedCoursePage.jsx
+++ b/frontend/src/pages/GuideMatchedCoursePage.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom'
 
+import { PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client'
 
 import './GuideMatchedCoursePage.css'
@@ -314,13 +315,18 @@ export function GuideMatchedCoursePage() {
   }
 
   if (loading) {
-    return <p className="gmc" style={{ color: '#6b7280' }}>불러오는 중…</p>
+    return (
+      <div className="gmc">
+        <PageLoading />
+      </div>
+    )
   }
   if (error || !profile) {
     return (
       <div className="gmc">
-        <p className="gmc-err">{error || '가이드 정보를 찾을 수 없습니다.'}</p>
-        <Link to="/ai-search">검색으로 돌아가기</Link>
+        <PageError message={error || '가이드 정보를 찾을 수 없습니다.'}>
+          <Link to="/ai-search">검색으로 돌아가기</Link>
+        </PageError>
       </div>
     )
   }

--- a/frontend/src/pages/GuideProposalPage.jsx
+++ b/frontend/src/pages/GuideProposalPage.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 
+import { PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client'
 
 import './GuideProposalPage.css'
@@ -153,12 +154,19 @@ export function GuideProposalPage() {
       : '—'
   const rc = profile?.reviewCount != null ? profile.reviewCount : 0
 
-  if (loading) return <p className="gp" style={{ color: '#6b7280' }}>불러오는 중…</p>
+  if (loading) {
+    return (
+      <div className="gp">
+        <PageLoading />
+      </div>
+    )
+  }
   if (error || !profile) {
     return (
       <div className="gp">
-        <p className="gp-err">{error || '프로필을 찾을 수 없습니다.'}</p>
-        <Link to="/guides">가이드 목록</Link>
+        <PageError message={error || '프로필을 찾을 수 없습니다.'}>
+          <Link to="/guides">가이드 목록</Link>
+        </PageError>
       </div>
     )
   }

--- a/frontend/src/pages/GuideReviewsManagePage.jsx
+++ b/frontend/src/pages/GuideReviewsManagePage.jsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 
+import { PageEmpty, PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client.js'
 import { useResolvedGuideId } from '../hooks/useResolvedGuideId.js'
 
@@ -70,7 +71,7 @@ export function GuideReviewsManagePage() {
   if (idLoading) {
     return (
       <div className="g-panel">
-        <p>불러오는 중…</p>
+        <PageLoading />
       </div>
     )
   }
@@ -78,7 +79,7 @@ export function GuideReviewsManagePage() {
   if (idError) {
     return (
       <div className="g-panel">
-        <p className="g-error">{idError}</p>
+        <PageError message={idError} />
       </div>
     )
   }
@@ -87,8 +88,10 @@ export function GuideReviewsManagePage() {
     <div className="g-panel">
       <h1>⭐ 가이드 리뷰</h1>
 
-      {loadError && <p className="g-error">{loadError}</p>}
-      {listLoading && <p style={{ marginTop: '0.75rem' }}>목록 불러오는 중…</p>}
+      {loadError && (
+        <PageError message={loadError} onRetry={() => guideId != null && void loadPage(guideId, page)} />
+      )}
+      {listLoading && <PageLoading label="목록을 불러오는 중…" />}
 
       <section className="grv-wrap">
         <header className="grv-head">
@@ -105,7 +108,9 @@ export function GuideReviewsManagePage() {
           </article>
         </header>
 
-        {!listLoading && rows.length === 0 && <p className="gm-hint">아직 등록된 리뷰가 없습니다.</p>}
+        {!listLoading && rows.length === 0 && (
+          <PageEmpty title="등록된 리뷰가 없습니다">게스트가 남긴 후기가 있으면 여기에 표시됩니다.</PageEmpty>
+        )}
 
         {rows.length > 0 && (
           <div className="grv-grid">

--- a/frontend/src/pages/GuideSettingsPage.jsx
+++ b/frontend/src/pages/GuideSettingsPage.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 
+import { PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client.js'
 import { useResolvedGuideId } from '../hooks/useResolvedGuideId.js'
 
@@ -74,7 +75,7 @@ export function GuideSettingsPage() {
   if (idLoading) {
     return (
       <div className="g-panel">
-        <p>불러오는 중…</p>
+        <PageLoading />
       </div>
     )
   }
@@ -82,7 +83,7 @@ export function GuideSettingsPage() {
   if (idError) {
     return (
       <div className="g-panel">
-        <p className="g-error">{idError}</p>
+        <PageError message={idError} />
       </div>
     )
   }
@@ -90,7 +91,7 @@ export function GuideSettingsPage() {
   if (loadError) {
     return (
       <div className="g-panel">
-        <p className="g-error">{loadError}</p>
+        <PageError message={loadError} onRetry={() => guideId != null && void load(guideId)} />
       </div>
     )
   }

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 
+import { PageEmpty, PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client'
 import { useAuth } from '../context/useAuth.js'
 
@@ -34,19 +35,35 @@ export function HomePage() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
 
+  const loadGuides = useCallback(async () => {
+    const res = await apiRequest('/guides', { method: 'GET', skipAuth: true })
+    const text = await res.text()
+    if (!res.ok) {
+      throw new Error(text || '가이드 목록을 불러오지 못했습니다.')
+    }
+    const data = text ? JSON.parse(text) : []
+    setGuides(Array.isArray(data) ? data : [])
+  }, [])
+
+  const refetchGuides = useCallback(async () => {
+    setLoading(true)
+    setError('')
+    try {
+      await loadGuides()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '오류')
+    } finally {
+      setLoading(false)
+    }
+  }, [loadGuides])
+
   useEffect(() => {
     let cancelled = false
     ;(async () => {
       setLoading(true)
       setError('')
       try {
-        const res = await apiRequest('/guides', { method: 'GET', skipAuth: true })
-        const text = await res.text()
-        if (!res.ok) {
-          throw new Error(text || '가이드 목록을 불러오지 못했습니다.')
-        }
-        const data = text ? JSON.parse(text) : []
-        if (!cancelled) setGuides(Array.isArray(data) ? data : [])
+        await loadGuides()
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : '오류')
       } finally {
@@ -56,7 +73,7 @@ export function HomePage() {
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [loadGuides])
 
   const experts = guides.slice(0, 3)
 
@@ -129,9 +146,11 @@ export function HomePage() {
         <h2 id="f02-exp-title" className="f02-section-title f02-section-title--solo">
           Local Experts
         </h2>
-        {loading && <p className="f02-muted">가이드를 불러오는 중…</p>}
-        {error && <p className="f02-err">{error}</p>}
-        {!loading && !error && experts.length === 0 && <p className="f02-muted">등록된 가이드가 없습니다. 가이드 신청을 기다리고 있어요.</p>}
+        {loading && <PageLoading label="가이드를 불러오는 중…" />}
+        {!loading && error && <PageError message={error} onRetry={() => void refetchGuides()} />}
+        {!loading && !error && experts.length === 0 && (
+          <PageEmpty title="등록된 가이드가 없습니다">가이드 신청을 기다리고 있어요.</PageEmpty>
+        )}
         {!loading && !error && experts.length > 0 && (
           <div className="f02-expert-grid">
             {experts.map((g) => {

--- a/frontend/src/pages/MessagesPage.jsx
+++ b/frontend/src/pages/MessagesPage.jsx
@@ -3,6 +3,7 @@ import SockJS from 'sockjs-client/dist/sockjs'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
 
+import { PageEmpty, PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client'
 import { useAuth } from '../context/useAuth.js'
 
@@ -209,8 +210,12 @@ export function MessagesPage() {
     <div className="msg">
       <aside className="msg-rooms">
         <h2>대화 목록</h2>
-        {loadingRooms && <p className="msg-muted">불러오는 중…</p>}
-        {!loadingRooms && rooms.length === 0 && <p className="msg-muted">참여 중인 채팅방이 없습니다.</p>}
+        {loadingRooms && <PageLoading className="page-state--tight" />}
+        {!loadingRooms && rooms.length === 0 && (
+          <PageEmpty className="page-state--tight" title="채팅방이 없습니다">
+            매칭 후 대화가 시작되면 여기에 표시됩니다.
+          </PageEmpty>
+        )}
         <ul>
           {rooms.map((room) => (
             <li key={room.roomId}>
@@ -240,10 +245,13 @@ export function MessagesPage() {
         </header>
 
         <div ref={chatBodyRef} className="msg-body">
-          {error && <p className="msg-error">{error}</p>}
+          {error && <PageError message={error} className="page-state--tight" />}
           {!selectedRoomId && <p className="msg-muted">왼쪽 목록에서 채팅방을 선택해 주세요.</p>}
+          {selectedRoomId && loadingMessages && <PageLoading className="page-state--tight" label="메시지를 불러오는 중…" />}
           {selectedRoomId && !loadingMessages && messages.length === 0 && (
-            <p className="msg-muted">아직 메시지가 없습니다. 첫 메시지를 보내보세요.</p>
+            <PageEmpty className="page-state--tight" title="아직 메시지가 없습니다">
+              첫 메시지를 보내보세요.
+            </PageEmpty>
           )}
           {selectedRoomId && messages.length > 0 && (
             <>

--- a/frontend/src/pages/MyPageOverview.jsx
+++ b/frontend/src/pages/MyPageOverview.jsx
@@ -1,6 +1,7 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 
+import { PageEmpty, PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client.js'
 import { useAuth } from '../context/useAuth.js'
 
@@ -28,25 +29,29 @@ export function MyPageOverview() {
   const [error, setError] = useState('')
   const [data, setData] = useState(null)
 
+  const fetchDashboard = useCallback(async () => {
+    const res = await apiRequest('/mypage/guest/dashboard', { method: 'GET' })
+    const text = await res.text()
+    if (!res.ok) {
+      let msg = '대시보드를 불러오지 못했습니다.'
+      try {
+        const j = JSON.parse(text)
+        if (typeof j?.message === 'string' && j.message.trim()) msg = j.message.trim()
+      } catch {
+        if (text) msg = text
+      }
+      throw new Error(msg)
+    }
+    return text ? JSON.parse(text) : null
+  }, [])
+
   useEffect(() => {
     let cancelled = false
     ;(async () => {
       setLoading(true)
       setError('')
       try {
-        const res = await apiRequest('/mypage/guest/dashboard', { method: 'GET' })
-        const text = await res.text()
-        if (!res.ok) {
-          let msg = '대시보드를 불러오지 못했습니다.'
-          try {
-            const j = JSON.parse(text)
-            if (typeof j?.message === 'string' && j.message.trim()) msg = j.message.trim()
-          } catch {
-            if (text) msg = text
-          }
-          throw new Error(msg)
-        }
-        const json = text ? JSON.parse(text) : null
+        const json = await fetchDashboard()
         if (!cancelled) setData(json)
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : '불러오기 실패')
@@ -57,7 +62,22 @@ export function MyPageOverview() {
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [fetchDashboard])
+
+  const onRetry = useCallback(() => {
+    void (async () => {
+      setLoading(true)
+      setError('')
+      try {
+        const json = await fetchDashboard()
+        setData(json)
+      } catch (e) {
+        setError(e instanceof Error ? e.message : '불러오기 실패')
+      } finally {
+        setLoading(false)
+      }
+    })()
+  }, [fetchDashboard])
 
   const upcoming = useMemo(() => (Array.isArray(data?.upcomingMatches) ? data.upcomingMatches : []), [data])
   const scrapbooks = useMemo(() => (Array.isArray(data?.scrapbooks) ? data.scrapbooks : []), [data])
@@ -98,14 +118,14 @@ export function MyPageOverview() {
         </div>
       </div>
 
-      {error && <p className="err">{error}</p>}
-      {loading && <p>불러오는 중…</p>}
+      {loading && <PageLoading />}
+      {!loading && error && <PageError message={error} onRetry={onRetry} />}
 
       {!loading && !error && (
         <>
           <h2 style={{ margin: '0 0 0.75rem', fontSize: '0.95rem', fontWeight: 800 }}>다가오는 여행</h2>
           {upcoming.length === 0 ? (
-            <p className="sub">예정된 여행이 없어요.</p>
+            <PageEmpty title="예정된 여행이 없어요">일정 메뉴에서 매칭을 확인하거나 새 요청을 이어가 보세요.</PageEmpty>
           ) : (
             <div className="mp-cards">
               {upcoming.map((m) => (
@@ -138,7 +158,7 @@ export function MyPageOverview() {
 
           <h2 style={{ margin: '1.5rem 0 0.75rem', fontSize: '0.95rem', fontWeight: 800 }}>나의 여행 기록</h2>
           {scrapbooks.length === 0 ? (
-            <p className="sub">아직 스크랩북이 없어요.</p>
+            <PageEmpty title="아직 스크랩북이 없어요">완료된 투어가 쌓이면 여기에 표시됩니다.</PageEmpty>
           ) : (
             <div className="mp-cards">
               {scrapbooks.slice(0, 3).map((s) => (

--- a/frontend/src/pages/MypageItineraryPage.jsx
+++ b/frontend/src/pages/MypageItineraryPage.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
+import { PageEmpty, PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client.js'
 import { daysUntil, fetchGuestMatchRequests, parseMatchingApiError } from '../lib/matchingGuest.js'
 
@@ -53,6 +54,18 @@ export function MypageItineraryPage() {
     )
     setNames(nm)
   }, [])
+
+  const refetch = useCallback(async () => {
+    setLoading(true)
+    setError('')
+    try {
+      await reload()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '불러오기 실패')
+    } finally {
+      setLoading(false)
+    }
+  }, [reload])
 
   useEffect(() => {
     let cancelled = false
@@ -131,11 +144,13 @@ export function MypageItineraryPage() {
         <code>GET /api/matching/requests/guest/list</code> 중 진행·예정 상태만 표시합니다. 수락/거절/취소는 매칭 API를
         호출합니다.
       </p>
-      {error && <p className="err">{error}</p>}
       {toast && <p className="err">{toast}</p>}
-      {loading && <p>불러오는 중…</p>}
+      {loading && <PageLoading />}
+      {!loading && error && <PageError message={error} onRetry={() => void refetch()} />}
 
-      {!loading && !error && rows.length === 0 && <p className="sub">예정된 여행이 없습니다.</p>}
+      {!loading && !error && rows.length === 0 && (
+        <PageEmpty title="예정된 여행이 없습니다">진행 중이거나 예정된 매칭이 없을 때 표시됩니다.</PageEmpty>
+      )}
 
       {!loading && !error && rows.length > 0 && (
         <div className="mp-cards">

--- a/frontend/src/pages/MypagePaymentsPage.jsx
+++ b/frontend/src/pages/MypagePaymentsPage.jsx
@@ -1,5 +1,6 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 
+import { PageEmpty, PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client.js'
 import { fetchGuestMatchRequests, fetchGuestPayments, parseMatchingApiError } from '../lib/matchingGuest.js'
 
@@ -31,20 +32,35 @@ export function MypagePaymentsPage() {
   const [loading, setLoading] = useState(true)
   const [detail, setDetail] = useState(null)
 
+  const loadPayments = useCallback(async () => {
+    const [pay, req] = await Promise.all([fetchGuestPayments(apiRequest), fetchGuestMatchRequests(apiRequest)])
+    setPayments(Array.isArray(pay) ? pay : [])
+    const map = {}
+    for (const r of Array.isArray(req) ? req : []) {
+      map[r.requestId] = r
+    }
+    setRequestsById(map)
+  }, [])
+
+  const refetch = useCallback(async () => {
+    setLoading(true)
+    setError('')
+    try {
+      await loadPayments()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '불러오기 실패')
+    } finally {
+      setLoading(false)
+    }
+  }, [loadPayments])
+
   useEffect(() => {
     let cancelled = false
     ;(async () => {
       setLoading(true)
       setError('')
       try {
-        const [pay, req] = await Promise.all([fetchGuestPayments(apiRequest), fetchGuestMatchRequests(apiRequest)])
-        if (cancelled) return
-        setPayments(Array.isArray(pay) ? pay : [])
-        const map = {}
-        for (const r of Array.isArray(req) ? req : []) {
-          map[r.requestId] = r
-        }
-        setRequestsById(map)
+        await loadPayments()
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : '불러오기 실패')
       } finally {
@@ -54,7 +70,7 @@ export function MypagePaymentsPage() {
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [loadPayments])
 
   const filtered = useMemo(() => payments.filter((p) => tabFilter(tab, p)), [payments, tab])
 
@@ -75,8 +91,8 @@ export function MypagePaymentsPage() {
       <p className="sub">
         <code>GET /api/matching/payments/guest/list</code> · 상세 <code>GET /api/matching/payments/&#123;paymentId&#125;</code>
       </p>
-      {error && <p className="err">{error}</p>}
-      {loading && <p>불러오는 중…</p>}
+      {loading && <PageLoading />}
+      {!loading && error && <PageError message={error} onRetry={() => void refetch()} />}
 
       {!loading && !error && (
         <>
@@ -92,8 +108,10 @@ export function MypagePaymentsPage() {
             </button>
           </div>
 
-          {filtered.length === 0 && <p className="sub">해당하는 결제 내역이 없습니다.</p>}
-
+          {filtered.length === 0 ? (
+            <PageEmpty title="해당하는 결제 내역이 없습니다">다른 탭을 선택하거나 매칭 결제를 완료해 보세요.</PageEmpty>
+          ) : (
+            <>
           <div className="mp-pay-wrap">
             <table className="mp-pay-table">
               <thead>
@@ -160,6 +178,8 @@ export function MypagePaymentsPage() {
               )
             })}
           </div>
+            </>
+          )}
         </>
       )}
 

--- a/frontend/src/pages/MypageReviewsPage.jsx
+++ b/frontend/src/pages/MypageReviewsPage.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 
+import { PageEmpty, PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client.js'
 
 import './MypageMemberPages.css'
@@ -91,13 +92,14 @@ export function MypageReviewsPage() {
       </p>
 
       {actionErr && <p className="err">{actionErr}</p>}
-      {error && <p className="err">{error}</p>}
+      {loading && <PageLoading />}
+      {!loading && error && <PageError message={error} onRetry={() => void load(page)} />}
 
-      {loading ? (
-        <p className="sub">불러오는 중…</p>
-      ) : rows.length === 0 ? (
-        <p className="sub">아직 작성한 리뷰가 없습니다. 가이드 매칭 화면에서 후기를 남겨 보세요.</p>
-      ) : (
+      {!loading && !error && rows.length === 0 && (
+        <PageEmpty title="작성한 리뷰가 없습니다">가이드 매칭 화면에서 후기를 남기면 여기에 표시됩니다.</PageEmpty>
+      )}
+
+      {!loading && !error && rows.length > 0 ? (
         <div className="mp-cards">
           {rows.map((r) => (
             <article key={r.id} className="mp-trip-card mp-trip-card--past">
@@ -138,16 +140,18 @@ export function MypageReviewsPage() {
             </article>
           ))}
         </div>
-      )}
+      ) : null}
 
-      <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1rem', flexWrap: 'wrap' }}>
-        <button type="button" className="mp-btn mp-btn--line" disabled={first || loading} onClick={() => setPage((p) => Math.max(0, p - 1))}>
-          이전
-        </button>
-        <button type="button" className="mp-btn mp-btn--line" disabled={last || loading} onClick={() => setPage((p) => p + 1)}>
-          다음
-        </button>
-      </div>
+      {!error && (
+        <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1rem', flexWrap: 'wrap' }}>
+          <button type="button" className="mp-btn mp-btn--line" disabled={first || loading} onClick={() => setPage((p) => Math.max(0, p - 1))}>
+            이전
+          </button>
+          <button type="button" className="mp-btn mp-btn--line" disabled={last || loading} onClick={() => setPage((p) => p + 1)}>
+            다음
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/MypageScrapbookPage.jsx
+++ b/frontend/src/pages/MypageScrapbookPage.jsx
@@ -1,6 +1,7 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 
+import { PageEmpty, PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client.js'
 import { daysUntil, fetchGuestMatchRequests } from '../lib/matchingGuest.js'
 
@@ -32,19 +33,35 @@ export function MypageScrapbookPage() {
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(true)
 
+  const loadScrapbook = useCallback(async () => {
+    const all = await fetchGuestMatchRequests(apiRequest)
+    const completed = (Array.isArray(all) ? all : []).filter((r) => r.status === 'COMPLETED')
+    completed.sort((a, b) => String(b.desiredDate).localeCompare(String(a.desiredDate)))
+    setRows(completed)
+    const gids = completed.map((r) => r.guideId)
+    const nm = await loadGuideNicknames(apiRequest, gids)
+    setNames(nm)
+  }, [])
+
+  const refetch = useCallback(async () => {
+    setLoading(true)
+    setError('')
+    try {
+      await loadScrapbook()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '불러오기 실패')
+    } finally {
+      setLoading(false)
+    }
+  }, [loadScrapbook])
+
   useEffect(() => {
     let cancelled = false
     ;(async () => {
       setLoading(true)
       setError('')
       try {
-        const all = await fetchGuestMatchRequests(apiRequest)
-        const completed = (Array.isArray(all) ? all : []).filter((r) => r.status === 'COMPLETED')
-        completed.sort((a, b) => String(b.desiredDate).localeCompare(String(a.desiredDate)))
-        if (!cancelled) setRows(completed)
-        const gids = completed.map((r) => r.guideId)
-        const nm = await loadGuideNicknames(apiRequest, gids)
-        if (!cancelled) setNames(nm)
+        await loadScrapbook()
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : '불러오기 실패')
       } finally {
@@ -54,7 +71,7 @@ export function MypageScrapbookPage() {
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [loadScrapbook])
 
   const count = rows.length
 
@@ -70,8 +87,8 @@ export function MypageScrapbookPage() {
         <code>GET /api/matching/requests/guest/list</code> 중 <strong>COMPLETED</strong> 만 표시합니다. 가이드 닉네임은{' '}
         <code>GET /api/guides/&#123;guideId&#125;</code> 로 보강합니다.
       </p>
-      {error && <p className="err">{error}</p>}
-      {loading && <p>불러오는 중…</p>}
+      {loading && <PageLoading />}
+      {!loading && error && <PageError message={error} onRetry={() => void refetch()} />}
 
       {!loading && !error && (
         <>
@@ -85,7 +102,9 @@ export function MypageScrapbookPage() {
             </Link>
           </div>
 
-          {rows.length === 0 && <p className="sub">완료된 투어가 생기면 여기에 쌓입니다.</p>}
+          {rows.length === 0 && (
+            <PageEmpty title="완료된 투어 기록이 없습니다">투어가 완료되면 여기에 쌓입니다.</PageEmpty>
+          )}
 
           {rows.length > 0 && (
             <div className="mp-cards">

--- a/frontend/src/pages/MypageTourPage.jsx
+++ b/frontend/src/pages/MypageTourPage.jsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 
+import { PageEmpty, PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client.js'
 import { fetchGuestMatchRequests, fetchGuestPayments, parseMatchingApiError } from '../lib/matchingGuest.js'
 
@@ -103,6 +104,18 @@ export function MypageTourPage() {
     setExtMap(m)
   }, [])
 
+  const refetch = useCallback(async () => {
+    setLoading(true)
+    setError('')
+    try {
+      await load()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '불러오기 실패')
+    } finally {
+      setLoading(false)
+    }
+  }, [load])
+
   useEffect(() => {
     let cancelled = false
     ;(async () => {
@@ -176,9 +189,9 @@ export function MypageTourPage() {
     <div className="mp-member">
       <h1>투어 연장 및 환불 관리 🔄</h1>
       <p className="sub">투어 종료 직전/직후의 연장 선택과 환불 처리를 한 번에 관리합니다.</p>
-      {error && <p className="err">{error}</p>}
       {toast && <p className="err">{toast}</p>}
-      {loading && <p>불러오는 중…</p>}
+      {loading && <PageLoading />}
+      {!loading && error && <PageError message={error} onRetry={() => void refetch()} />}
 
       {!loading && !error && (
         <div className="mp-tour-shell">
@@ -186,7 +199,7 @@ export function MypageTourPage() {
             <h2>진행 예정 투어 연장</h2>
             <p className="sub">투어 전날 저녁, 아쉬움이 남는다면 하루 더 로컬과 함께해요.</p>
             {Object.keys(extMap).length === 0 && (
-              <article className="mp-tour-card mp-tour-card--empty">진행 중인 연장 요청이 없습니다.</article>
+              <PageEmpty title="진행 중인 연장 요청이 없습니다">연장 안내가 오면 이 영역에 표시됩니다.</PageEmpty>
             )}
             <div className="mp-cards">
               {Object.entries(extMap).map(([requestId, ex]) => {
@@ -225,7 +238,7 @@ export function MypageTourPage() {
             <h2>투어 취소 및 환불 관리</h2>
             <p className="sub">결제 후 2시간 이내에는 조건에 따라 즉시 환불이 가능합니다.</p>
             {refundable.length === 0 && (
-              <article className="mp-tour-card mp-tour-card--empty">현재 환불 가능한 결제가 없습니다.</article>
+              <PageEmpty title="환불 가능한 결제가 없습니다">조건을 만족하는 결제가 있으면 여기에서 신청할 수 있어요.</PageEmpty>
             )}
             <div className="mp-cards">
               {refundable.map((p) => (


### PR DESCRIPTION
🔗 관련: 화면별로 달랐던 로딩/에러/빈 상태 UX 정리

💡 변경 요약
- `PageLoading` / `PageError` / `PageEmpty` + `PageStates.css` 추가 (스피너·알림 카드·점선 빈 상태)
- 마이페이지: Overview, 일정, 결제, 스크랩북, 투어·환불, 내 리뷰에 적용. 실패 시 **다시 시도** 가능한 곳은 `onRetry` 연결
- 홈·가이드 목록·매칭/피드/완주/제안/상세·가이드 설정·리뷰 관리·메시지 등 주요 데이터 로드 화면에 동일 패턴 적용
- 메시지: 사이드바·본문에 `page-state--tight`로 밀도 조정

✅ 검증: `cd frontend && npm run build`

Made with [Cursor](https://cursor.com)