### PR TITLE
Feat/be#280 PG 복귀 후 결제 흐름 정리

### DIFF
--- a/frontend/src/pages/MypagePaymentsPage.jsx
+++ b/frontend/src/pages/MypagePaymentsPage.jsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useLocation } from 'react-router-dom'
 
 import { PageEmpty, PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client.js'
@@ -25,12 +26,21 @@ function tabFilter(tab, p) {
 }
 
 export function MypagePaymentsPage() {
+  const location = useLocation()
   const [payments, setPayments] = useState([])
   const [requestsById, setRequestsById] = useState({})
   const [tab, setTab] = useState('all')
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(true)
   const [detail, setDetail] = useState(null)
+  const [routeHint, setRouteHint] = useState('')
+
+  useEffect(() => {
+    const h = location.state?.hint
+    if (typeof h === 'string' && h.trim()) {
+      setRouteHint(h.trim())
+    }
+  }, [location.state])
 
   const loadPayments = useCallback(async () => {
     const [pay, req] = await Promise.all([fetchGuestPayments(apiRequest), fetchGuestMatchRequests(apiRequest)])
@@ -91,6 +101,22 @@ export function MypagePaymentsPage() {
       <p className="sub">
         <code>GET /api/matching/payments/guest/list</code> · 상세 <code>GET /api/matching/payments/&#123;paymentId&#125;</code>
       </p>
+      {routeHint && (
+        <p
+          className="sub"
+          role="status"
+          style={{
+            padding: '0.75rem 0.95rem',
+            borderRadius: 12,
+            background: '#ecfdf5',
+            border: '1px solid #a7f3d0',
+            color: '#065f46',
+            fontWeight: 600,
+          }}
+        >
+          {routeHint}
+        </p>
+      )}
       {loading && <PageLoading />}
       {!loading && error && <PageError message={error} onRetry={() => void refetch()} />}
 

--- a/frontend/src/pages/MypageTourPage.jsx
+++ b/frontend/src/pages/MypageTourPage.jsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
+import { useLocation } from 'react-router-dom'
 
 import { PageEmpty, PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client.js'
@@ -74,6 +75,7 @@ function dday(v) {
 }
 
 export function MypageTourPage() {
+  const location = useLocation()
   const [requests, setRequests] = useState([])
   const [payments, setPayments] = useState([])
   const [extMap, setExtMap] = useState({})
@@ -84,6 +86,12 @@ export function MypageTourPage() {
   const [refundPaymentId, setRefundPaymentId] = useState(null)
   const [refundReason, setRefundReason] = useState('')
   const [refundEvidence, setRefundEvidence] = useState('')
+  const [routeHint, setRouteHint] = useState('')
+
+  useEffect(() => {
+    const h = location.state?.hint
+    if (typeof h === 'string' && h.trim()) setRouteHint(h.trim())
+  }, [location.state])
 
   const load = useCallback(async () => {
     const [req, pay] = await Promise.all([fetchGuestMatchRequests(apiRequest), fetchGuestPayments(apiRequest)])
@@ -189,6 +197,22 @@ export function MypageTourPage() {
     <div className="mp-member">
       <h1>투어 연장 및 환불 관리 🔄</h1>
       <p className="sub">투어 종료 직전/직후의 연장 선택과 환불 처리를 한 번에 관리합니다.</p>
+      {routeHint && (
+        <p
+          className="sub"
+          role="status"
+          style={{
+            padding: '0.75rem 0.95rem',
+            borderRadius: 12,
+            background: '#eff6ff',
+            border: '1px solid #bfdbfe',
+            color: '#1e3a8a',
+            fontWeight: 600,
+          }}
+        >
+          {routeHint}
+        </p>
+      )}
       {toast && <p className="err">{toast}</p>}
       {loading && <PageLoading />}
       {!loading && error && <PageError message={error} onRetry={() => void refetch()} />}

--- a/frontend/src/pages/PaymentKakaoStubPage.css
+++ b/frontend/src/pages/PaymentKakaoStubPage.css
@@ -149,3 +149,61 @@
   font-size: 0.8rem;
   color: #991b1b;
 }
+
+.pks-banner {
+  margin: 0 0 1rem;
+  padding: 0.85rem 0.95rem;
+  border-radius: 12px;
+  font-size: 0.82rem;
+  line-height: 1.5;
+  color: #374151;
+}
+
+.pks-banner strong {
+  display: block;
+  margin-bottom: 0.35rem;
+  font-size: 0.88rem;
+  color: #111827;
+}
+
+.pks-banner p {
+  margin: 0 0 0.65rem;
+}
+
+.pks-banner--info {
+  background: #eff6ff;
+  border: 1px solid #bfdbfe;
+  color: #1e40af;
+}
+
+.pks-banner--warn {
+  background: #fffbeb;
+  border: 1px solid #fde68a;
+  color: #92400e;
+}
+
+.pks-banner--muted {
+  background: #f9fafb;
+  border: 1px dashed #d1d5db;
+  color: #4b5563;
+}
+
+.pks-inline-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem 1rem;
+}
+
+.pks-inline-links a {
+  font-weight: 700;
+  color: #1d4ed8;
+  text-decoration: underline;
+}
+
+.pks-btn--block {
+  display: block;
+  margin-top: 0.65rem;
+  text-align: center;
+  text-decoration: none;
+  box-sizing: border-box;
+}

--- a/frontend/src/pages/PaymentKakaoStubPage.jsx
+++ b/frontend/src/pages/PaymentKakaoStubPage.jsx
@@ -1,5 +1,5 @@
-import { useMemo, useState } from 'react'
-import { useNavigate, useSearchParams, useLocation } from 'react-router-dom'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Link, useNavigate, useSearchParams, useLocation } from 'react-router-dom'
 
 import { apiRequest } from '../api/client'
 
@@ -9,6 +9,16 @@ function formatWon(n) {
   const v = Number(n)
   if (Number.isNaN(v)) return '—'
   return `${v.toLocaleString('ko-KR')}원`
+}
+
+function parseApiError(text) {
+  if (!text) return '요청 실패'
+  try {
+    const j = JSON.parse(text)
+    return (j.message ?? text) || '요청 실패'
+  } catch {
+    return text || '요청 실패'
+  }
 }
 
 export function PaymentKakaoStubPage() {
@@ -24,9 +34,15 @@ export function PaymentKakaoStubPage() {
   const paymentType = searchParams.get('paymentType') ?? ''
   const requestId = searchParams.get('requestId') ?? ''
   const guideId = searchParams.get('guideId') ?? ''
+  const result = searchParams.get('result') ?? ''
+  const qpError = searchParams.get('error') ?? ''
 
   const [busy, setBusy] = useState(false)
   const [err, setErr] = useState('')
+  /** @type {'idle' | 'need_login'} */
+  const [authGate, setAuthGate] = useState('idle')
+
+  const autoConfirmStarted = useRef(false)
 
   const itemLabel = useMemo(() => {
     const t = String(paymentType).toUpperCase()
@@ -37,13 +53,30 @@ export function PaymentKakaoStubPage() {
 
   const valid = pgOrderNo.trim() !== '' && amount !== '' && !Number.isNaN(Number(amount))
 
-  const goExternal = () => {
-    if (externalRedirect) {
-      window.location.href = String(externalRedirect)
-    }
-  }
+  const loginReturnState = useMemo(
+    () => ({
+      returnTo: `${location.pathname}${location.search || ''}`,
+      hint: '결제를 마치려면 로그인이 필요합니다. 로그인하면 이 화면으로 다시 돌아옵니다.',
+      preferredRole: 'GUEST',
+    }),
+    [location.pathname, location.search],
+  )
 
-  const onStubPay = async () => {
+  const navigateAfterPaid = useCallback(() => {
+    if (guideId) {
+      const qs = new URLSearchParams()
+      if (requestId) qs.set('requestId', requestId)
+      if (paymentId) qs.set('paymentId', paymentId)
+      navigate(`/guides/${guideId}/match/complete?${qs.toString()}`, { replace: true })
+      return
+    }
+    navigate('/mypage/payments', {
+      replace: true,
+      state: { hint: '결제가 완료되었습니다. 아래에서 영수증·상태를 확인할 수 있어요.' },
+    })
+  }, [guideId, requestId, paymentId, navigate])
+
+  const runConfirm = useCallback(async () => {
     setErr('')
     if (!valid) {
       setErr('결제 정보가 없습니다. 매칭 화면에서 다시 결제를 시도해 주세요.')
@@ -60,21 +93,49 @@ export function PaymentKakaoStubPage() {
         },
       })
       const t = await res.text()
-      if (!res.ok) throw new Error(t || '결제 승인에 실패했습니다.')
-      if (guideId) {
-        const qs = new URLSearchParams()
-        if (requestId) qs.set('requestId', requestId)
-        if (paymentId) qs.set('paymentId', paymentId)
-        navigate(`/guides/${guideId}/match/complete?${qs.toString()}`)
+      if (res.status === 401) {
+        setAuthGate('need_login')
         return
       }
-      navigate('/mypage/payments', { state: { hint: 'Stub 결제가 완료되었습니다.' } })
+      if (!res.ok) {
+        const msg = parseApiError(t)
+        if (msg.includes('이미 완료') || msg.includes('PAYMENT_ALREADY_COMPLETED')) {
+          navigateAfterPaid()
+          return
+        }
+        throw new Error(msg)
+      }
+      navigateAfterPaid()
     } catch (e) {
       setErr(e instanceof Error ? e.message : '오류')
     } finally {
       setBusy(false)
     }
+  }, [valid, pgOrderNo, amount, pgToken, navigateAfterPaid])
+
+  /** 카카오·백엔드 리다이렉트로 ?result=success 복귀 시 자동 승인 (전체 페이지 이동으로 state 소실 대비) */
+  useEffect(() => {
+    if (result !== 'success') return
+    if (!valid) return
+    if (autoConfirmStarted.current) return
+    autoConfirmStarted.current = true
+    void runConfirm()
+  }, [result, valid, runConfirm])
+
+  const goExternal = () => {
+    if (externalRedirect) {
+      window.location.href = String(externalRedirect)
+    }
   }
+
+  const onStubPay = async () => {
+    await runConfirm()
+  }
+
+  const cameFromKakao = Boolean(pgToken) || result === 'success' || result === 'cancel' || result === 'fail'
+
+  const showStubActions =
+    authGate !== 'need_login' && result !== 'cancel' && result !== 'fail' && qpError !== 'missing_pgOrderNo'
 
   return (
     <div className="pks">
@@ -83,53 +144,133 @@ export function PaymentKakaoStubPage() {
           <p className="pks-brand">
             kakao<span>pay</span>
           </p>
-          <p className="pks-sub">테스트 · Stub 결제 화면 (로컬 PG)</p>
+          <p className="pks-sub">
+            {result === 'success' && busy
+              ? '결제 승인 처리 중…'
+              : externalRedirect
+                ? '카카오페이로 이동해 결제를 완료해 주세요'
+                : '테스트 · Stub 결제 화면 (로컬 PG)'}
+          </p>
         </header>
         <div className="pks-body">
-          <p className="pks-merchant">LocalGuest</p>
-          <p className="pks-item">{itemLabel}</p>
-          <p className="pks-amount-label">결제금액</p>
-          <p className="pks-amount">{formatWon(amount)}</p>
-          {paymentId && (
-            <p className="pks-meta">
-              paymentId: {paymentId}
-              <br />
-              주문번호: {pgOrderNo}
-            </p>
+          {qpError === 'missing_pgOrderNo' && (
+            <div className="pks-banner pks-banner--warn" role="status">
+              <strong>주문 정보가 누락됐습니다.</strong>
+              <p>카카오페이 복귀 URL에 주문번호가 없습니다. 매칭 화면에서 결제를 다시 시도하거나, 결제 내역을 확인해 주세요.</p>
+              <div className="pks-inline-links">
+                <Link to="/mypage/payments">결제 내역</Link>
+                <Link to="/mypage/tour">연장·환불</Link>
+              </div>
+            </div>
           )}
-          {err && <p className="pks-err">{err}</p>}
-          <div className="pks-actions">
-            {externalRedirect ? (
-              <button type="button" className="pks-btn pks-btn--pay" onClick={() => goExternal()}>
-                카카오페이 결제창으로 이동
-              </button>
-            ) : (
-              <button type="button" className="pks-btn pks-btn--pay" disabled={busy || !valid} onClick={() => void onStubPay()}>
-                {busy ? '처리 중…' : '결제하기'}
-              </button>
-            )}
-            <button
-              type="button"
-              className="pks-btn pks-btn--ghost"
-              onClick={() => {
-                if (guideId) {
-                  navigate(`/guides/${guideId}/match`, { replace: true, state: { requestId: requestId || undefined } })
-                  return
-                }
-                navigate('/mypage/payments', { replace: true })
-              }}
-            >
-              취소하고 나가기
-            </button>
-          </div>
-          {!externalRedirect && (
-            <p className="pks-note">
-              실제 카카오페이가 아닙니다. 서버가 <code>matching.payment.provider=fake</code> 일 때 Stub 승인 API로
-              결제를 완료합니다.
-            </p>
+
+          {result === 'cancel' && (
+            <div className="pks-banner pks-banner--muted" role="status">
+              <strong>결제를 취소했습니다.</strong>
+              <p>카카오페이 창에서 취소한 경우입니다. 필요하면 매칭 화면에서 다시 시도할 수 있어요.</p>
+              <div className="pks-inline-links">
+                {guideId ? (
+                  <Link to={`/guides/${guideId}/match`} state={requestId ? { requestId: Number(requestId) } : undefined}>
+                    매칭·결제로 돌아가기
+                  </Link>
+                ) : null}
+                <Link to="/mypage/payments">결제 내역</Link>
+              </div>
+            </div>
           )}
-          {externalRedirect && (
-            <p className="pks-note">서버가 카카오 결제창 URL을 내려준 경우, 위 버튼으로 이동합니다.</p>
+
+          {result === 'fail' && (
+            <div className="pks-banner pks-banner--warn" role="status">
+              <strong>결제에 실패했습니다.</strong>
+              <p>카드 한도·앱 설정 등을 확인한 뒤 다시 시도해 주세요.</p>
+              <div className="pks-inline-links">
+                {guideId ? (
+                  <Link to={`/guides/${guideId}/match`} state={requestId ? { requestId: Number(requestId) } : undefined}>
+                    다시 결제하기
+                  </Link>
+                ) : null}
+                <Link to="/mypage/payments">결제 내역</Link>
+              </div>
+            </div>
+          )}
+
+          {authGate === 'need_login' && (
+            <div className="pks-banner pks-banner--warn" role="alert">
+              <strong>로그인이 필요합니다.</strong>
+              <p>외부 결제 창에서 돌아온 뒤에는 브라우저가 새로고침되어 로그인 상태가 끊길 수 있어요. 다시 로그인하면 이 결제 화면으로 돌아옵니다.</p>
+              <Link className="pks-btn pks-btn--pay pks-btn--block" to="/auth/login" state={loginReturnState}>
+                로그인하고 계속
+              </Link>
+            </div>
+          )}
+
+          {showStubActions && (
+            <>
+              <p className="pks-merchant">LocalGuest</p>
+              <p className="pks-item">{itemLabel}</p>
+              <p className="pks-amount-label">결제금액</p>
+              <p className="pks-amount">{formatWon(amount)}</p>
+              {paymentId && (
+                <p className="pks-meta">
+                  paymentId: {paymentId}
+                  <br />
+                  주문번호: {pgOrderNo}
+                  {pgToken ? (
+                    <>
+                      <br />
+                      pg_token: 수신됨
+                    </>
+                  ) : null}
+                </p>
+              )}
+              {result === 'success' && busy && (
+                <p className="pks-banner pks-banner--info">PG에서 돌아온 뒤 서버에 결제를 확정하고 있습니다. 잠시만 기다려 주세요.</p>
+              )}
+              {err && <p className="pks-err">{err}</p>}
+              <div className="pks-actions">
+                {externalRedirect ? (
+                  <button type="button" className="pks-btn pks-btn--pay" onClick={() => goExternal()}>
+                    카카오페이 결제창으로 이동
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    className="pks-btn pks-btn--pay"
+                    disabled={busy || !valid || result === 'success'}
+                    onClick={() => void onStubPay()}
+                  >
+                    {busy ? '처리 중…' : '결제 확정하기'}
+                  </button>
+                )}
+                <button
+                  type="button"
+                  className="pks-btn pks-btn--ghost"
+                  disabled={busy}
+                  onClick={() => {
+                    if (guideId) {
+                      navigate(`/guides/${guideId}/match`, { replace: true, state: { requestId: requestId || undefined } })
+                      return
+                    }
+                    navigate('/mypage/payments', { replace: true })
+                  }}
+                >
+                  취소하고 나가기
+                </button>
+              </div>
+              {cameFromKakao && (
+                <p className="pks-note">
+                  카카오페이에서 돌아온 요청입니다. <code>result=success</code> 인 경우 서버 승인(<code>POST /matching/payments/confirm</code>)까지 자동으로 진행합니다.
+                </p>
+              )}
+              {!cameFromKakao && externalRedirect && (
+                <p className="pks-note">아래 버튼으로 카카오 결제창을 연 뒤 결제를 완료하면 이 화면으로 돌아옵니다.</p>
+              )}
+              {!cameFromKakao && !externalRedirect && (
+                <p className="pks-note">
+                  로컬 fake PG: 서버가 <code>matching.payment.provider=fake</code> 일 때 Stub 승인 API로 결제를 완료합니다.
+                </p>
+              )}
+            </>
           )}
         </div>
       </div>


### PR DESCRIPTION
🔗 Closes #280

💡 변경 요약
- `PaymentKakaoStubPage`: `result=success` + 유효 주문이면 **자동 `POST /matching/payments/confirm`** (PG 복귀 후 전체 새로고침으로 `location.state`가 없어도 동작)
- 취소/실패/주문번호 누락(`missing_pgOrderNo`)별 **안내 배너** + 매칭·결제 내역 링크
- `401` 시 **로그인 후 동일 URL 복귀** (`/auth/login` state: `returnTo`, `hint`, `preferredRole: GUEST`)
- 서버 메시지에 **이미 완료** 포함 시 완료 화면/마이페이지로 이동(중복 승인 완화)
- `MypagePaymentsPage` / `MypageTourPage`: `location.state.hint` **성공·안내 배너** 표시 (결제 완료 Stub → 결제 내역 문구 강화)

✅ 검증: `cd frontend && npm run build`

Made with [Cursor](https://cursor.com)