### PR TITLE
Feat/be#282 마이페이지 데이터 안내 및 개발용 API 힌트 분리

### DIFF
--- a/frontend/src/components/MypageDevHint.jsx
+++ b/frontend/src/components/MypageDevHint.jsx
@@ -1,0 +1,8 @@
+/**
+ * Vite 개발 서버에서만 API·구현 힌트를 표시한다. 프로덕션 빌드에서는 렌더하지 않음.
+ * @param {{ children: import('react').ReactNode, className?: string }} props
+ */
+export function MypageDevHint({ children, className = '' }) {
+  if (!import.meta.env.DEV) return null
+  return <p className={['mp-dev-hint', className].filter(Boolean).join(' ')}>{children}</p>
+}

--- a/frontend/src/pages/MyPageOverview.jsx
+++ b/frontend/src/pages/MyPageOverview.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 
+import { MypageDevHint } from '../components/MypageDevHint.jsx'
 import { PageEmpty, PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client.js'
 import { useAuth } from '../context/useAuth.js'
@@ -96,7 +97,14 @@ export function MyPageOverview() {
     <div className="mp-member">
       <h1>마이페이지</h1>
       <p className="sub">
-        <code>GET /api/mypage/guest/dashboard</code> 기반 요약입니다. 세부 관리는 아래 바로가기로 이동할 수 있어요.
+        일정·기록·결제를 한곳에서 요약해 보여 드려요. 세부 내용은 왼쪽 메뉴나 아래 바로가기에서 확인할 수 있어요.
+      </p>
+      <MypageDevHint>
+        <code>GET /api/mypage/guest/dashboard</code> 응답 기반 요약입니다.
+      </MypageDevHint>
+      <p className="sub mp-data-note">
+        <strong>데이터 안내:</strong> 아래 「나의 여행 기록」은 서버에 저장된 <strong>스크랩북</strong>이고, 「기록 전체」
+        메뉴는 <strong>완료된 매칭만</strong> 모은 목록이라 건수가 다를 수 있어요.
       </p>
 
       <div className="mp-scrap-hero" style={{ marginBottom: '1rem' }}>

--- a/frontend/src/pages/MypageItineraryPage.jsx
+++ b/frontend/src/pages/MypageItineraryPage.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
+import { MypageDevHint } from '../components/MypageDevHint.jsx'
 import { PageEmpty, PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client.js'
 import { daysUntil, fetchGuestMatchRequests, parseMatchingApiError } from '../lib/matchingGuest.js'
@@ -141,9 +142,11 @@ export function MypageItineraryPage() {
     <div className="mp-member">
       <h1>📆 앞으로의 여행 일정</h1>
       <p className="sub">
-        <code>GET /api/matching/requests/guest/list</code> 중 진행·예정 상태만 표시합니다. 수락/거절/취소는 매칭 API를
-        호출합니다.
+        진행 중이거나 예정된 매칭만 보여 줍니다. 수락·거절·취소는 각 카드에서 진행할 수 있어요.
       </p>
+      <MypageDevHint>
+        <code>GET /api/matching/requests/guest/list</code> 중 진행·예정 상태만 표시 · 수락/거절/취소는 매칭 API 호출
+      </MypageDevHint>
       {toast && <p className="err">{toast}</p>}
       {loading && <PageLoading />}
       {!loading && error && <PageError message={error} onRetry={() => void refetch()} />}

--- a/frontend/src/pages/MypageMemberPages.css
+++ b/frontend/src/pages/MypageMemberPages.css
@@ -20,6 +20,26 @@
   line-height: 1.45;
 }
 
+/* 요약 vs 하위 화면 데이터 기준 안내 */
+.mp-data-note {
+  margin: 0 0 1rem;
+  font-size: 0.82rem;
+  color: #4b5563;
+  line-height: 1.5;
+}
+
+/* 개발 모드 전용 API 힌트 (MypageDevHint) */
+.mp-dev-hint {
+  margin: 0 0 1rem;
+  font-size: 0.78rem;
+  color: #6b7280;
+  line-height: 1.45;
+}
+
+.mp-dev-hint code {
+  font-size: 0.76rem;
+}
+
 .mp-member .err {
   color: #b91c1c;
   font-size: 0.88rem;

--- a/frontend/src/pages/MypagePaymentsPage.jsx
+++ b/frontend/src/pages/MypagePaymentsPage.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useLocation } from 'react-router-dom'
 
+import { MypageDevHint } from '../components/MypageDevHint.jsx'
 import { PageEmpty, PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client.js'
 import { fetchGuestMatchRequests, fetchGuestPayments, parseMatchingApiError } from '../lib/matchingGuest.js'
@@ -98,9 +99,11 @@ export function MypagePaymentsPage() {
   return (
     <div className="mp-member">
       <h1>💳 나의 결제 내역</h1>
-      <p className="sub">
-        <code>GET /api/matching/payments/guest/list</code> · 상세 <code>GET /api/matching/payments/&#123;paymentId&#125;</code>
-      </p>
+      <p className="sub">결제·환불 상태를 확인하고, 영수증 상세를 열어 볼 수 있어요.</p>
+      <MypageDevHint>
+        목록 <code>GET /api/matching/payments/guest/list</code> · 상세{' '}
+        <code>GET /api/matching/payments/&#123;paymentId&#125;</code>
+      </MypageDevHint>
       {routeHint && (
         <p
           className="sub"

--- a/frontend/src/pages/MypagePrivacyPage.css
+++ b/frontend/src/pages/MypagePrivacyPage.css
@@ -26,6 +26,18 @@
   line-height: 1.45;
 }
 
+/* MypageDevHint — 개발 모드 API 힌트 (프로덕션에서는 미렌더) */
+.mp-privacy .mp-dev-hint {
+  margin: 0 0 1rem;
+  font-size: 0.78rem;
+  color: #9aa0a6;
+  line-height: 1.45;
+}
+
+.mp-privacy .mp-dev-hint code {
+  font-size: 0.74rem;
+}
+
 .mp-privacy-section {
   padding: 1rem 0;
   border-top: 1px solid #eef0f3;

--- a/frontend/src/pages/MypagePrivacyPage.jsx
+++ b/frontend/src/pages/MypagePrivacyPage.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 
+import { MypageDevHint } from '../components/MypageDevHint.jsx'
 import { useAuth } from '../context/useAuth.js'
 import { loadGuestPrivacyForm, persistGuestPrivacyForm } from '../lib/guestMypagePrefs.js'
 
@@ -61,9 +62,11 @@ export function MypagePrivacyPage() {
         회원 정보 및 여행 설정 <span aria-hidden>⚙️</span>
       </h1>
       <p className="mp-privacy-hint">
-        회원 닉네임·알림·여행 성향은 아직 전용 API가 없어 이 브라우저에만 저장됩니다. 백엔드에{' '}
-        <code>PATCH /members/me</code> 등이 추가되면 연동할 수 있습니다.
+        회원 닉네임·알림·여행 성향은 전용 서버 연동 전까지 이 브라우저에만 저장됩니다.
       </p>
+      <MypageDevHint className="mp-privacy-hint">
+        백엔드에 <code>PATCH /members/me</code> 등이 추가되면 연동 예정입니다.
+      </MypageDevHint>
       {savedFlash && <p className="mp-privacy-banner">설정이 저장되었습니다.</p>}
 
       <section className="mp-privacy-section">

--- a/frontend/src/pages/MypageProfilePage.jsx
+++ b/frontend/src/pages/MypageProfilePage.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 
+import { MypageDevHint } from '../components/MypageDevHint.jsx'
 import { apiRequest } from '../api/client.js'
 import { useAuth } from '../context/useAuth.js'
 import { getGuestDisplayName, loadGuestPrivacyForm } from '../lib/guestMypagePrefs.js'
@@ -60,9 +61,12 @@ export function MypageProfilePage() {
     <div className="mp-member">
       <h1>👤 프로필</h1>
       <p className="sub">
-        현재 백엔드는 <code>POST /members/join</code>, <code>DELETE /members/me?role=...</code> 중심입니다. 표시 정보는{' '}
-        <strong>JWT + 로컬 설정(/mypage/privacy)</strong> 기반으로 구성합니다.
+        계정 이메일·역할은 로그인 토큰 기준이며, 표시 이름 등은 <strong>개인정보 설정(/mypage/privacy)</strong>에 저장한 값을
+        함께 씁니다.
       </p>
+      <MypageDevHint>
+        회원 API: <code>POST /members/join</code>, <code>DELETE /members/me?role=...</code> · 표시는 JWT + 로컬 prefs
+      </MypageDevHint>
 
       {toast && <p className="err">{toast}</p>}
 

--- a/frontend/src/pages/MypageReviewsPage.jsx
+++ b/frontend/src/pages/MypageReviewsPage.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 
+import { MypageDevHint } from '../components/MypageDevHint.jsx'
 import { PageEmpty, PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client.js'
 
@@ -87,9 +88,12 @@ export function MypageReviewsPage() {
     <div className="mp-member">
       <h1>⭐ 내 리뷰</h1>
       <p className="sub">
-        <code>GET /reviews/me</code>로 내가 작성한 리뷰만 불러옵니다. 팀 정책상 <strong>작성 후 수정은 불가</strong>이며, 잘못 올린 경우{' '}
+        내가 작성한 리뷰만 모아 보여 줍니다. 팀 정책상 <strong>작성 후 수정은 불가</strong>이며, 잘못 올린 경우{' '}
         <strong>삭제</strong>만 가능합니다.
       </p>
+      <MypageDevHint>
+        <code>GET /reviews/me</code> (로그인 필요)
+      </MypageDevHint>
 
       {actionErr && <p className="err">{actionErr}</p>}
       {loading && <PageLoading />}

--- a/frontend/src/pages/MypageScrapbookPage.jsx
+++ b/frontend/src/pages/MypageScrapbookPage.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 
+import { MypageDevHint } from '../components/MypageDevHint.jsx'
 import { PageEmpty, PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client.js'
 import { daysUntil, fetchGuestMatchRequests } from '../lib/matchingGuest.js'
@@ -84,8 +85,15 @@ export function MypageScrapbookPage() {
     <div className="mp-member">
       <h1>📒 나의 여행 기록 (스크랩북)</h1>
       <p className="sub">
-        <code>GET /api/matching/requests/guest/list</code> 중 <strong>COMPLETED</strong> 만 표시합니다. 가이드 닉네임은{' '}
-        <code>GET /api/guides/&#123;guideId&#125;</code> 로 보강합니다.
+        투어가 <strong>완료</strong>된 매칭만 시간 순으로 모아 보여 줍니다. 가이드 이름은 공개 프로필에서 가져옵니다.
+      </p>
+      <MypageDevHint>
+        <code>GET /api/matching/requests/guest/list</code> 중 <strong>COMPLETED</strong> 만 표시 · 가이드 닉네임은{' '}
+        <code>GET /api/guides/&#123;guideId&#125;</code> 로 보강
+      </MypageDevHint>
+      <p className="sub mp-data-note">
+        <strong>데이터 안내:</strong> 요약 화면의 기록 카드는 <strong>스크랩북(서버 저장)</strong> 기준이라, 이 목록과 개수가
+        다를 수 있어요.
       </p>
       {loading && <PageLoading />}
       {!loading && error && <PageError message={error} onRetry={() => void refetch()} />}


### PR DESCRIPTION
🔗 Closes #282

💡 변경 요약
- **제품 카피**: 요약 화면에 스크랩북 vs 「기록 전체」(완료 매칭) **데이터 기준이 다를 수 있음**을 `mp-data-note`로 안내
- **스크랩북**: 동일 안내 + 사용자용 설명을 API 문구에서 분리
- **`MypageDevHint`**: `import.meta.env.DEV`일 때만 API·구현 힌트(`<code>GET …</code>`) 표시 — 프로덕션 빌드에서는 UI에 미노출
- 적용 페이지: Overview, 스크랩북, 일정, 결제, 리뷰, 프로필, 개인정보

✅ 검증: `cd frontend && npm run build`

Made with [Cursor](https://cursor.com)