### PR TITLE
Feat/be#284 마이페이지 D: 결제 상세 UI·연장/환불 실패 안내·리뷰 유도·로컬 저장 톤

### DIFF
--- a/frontend/src/components/PaymentDetailPanel.css
+++ b/frontend/src/components/PaymentDetailPanel.css
@@ -1,0 +1,94 @@
+.mp-pay-detail {
+  margin: 0.5rem 0 0;
+}
+
+.mp-pay-detail-empty {
+  margin: 0.5rem 0 0;
+  font-size: 0.88rem;
+  color: #6b7280;
+}
+
+.mp-pay-detail-dl {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.65rem 1rem;
+  margin: 0;
+}
+
+@media (max-width: 640px) {
+  .mp-pay-detail-dl {
+    grid-template-columns: 1fr;
+  }
+}
+
+.mp-pay-detail-dl > div {
+  margin: 0;
+  padding: 0.65rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid #e5e7eb;
+  background: #fafafa;
+}
+
+.mp-pay-detail-dl .mp-pay-detail-span {
+  grid-column: 1 / -1;
+}
+
+.mp-pay-detail-dl dt {
+  margin: 0 0 0.25rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: #6b7280;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.mp-pay-detail-dl dd {
+  margin: 0;
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: #111827;
+  line-height: 1.4;
+}
+
+.mp-pay-detail-mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-size: 0.82rem;
+  font-weight: 500;
+}
+
+.mp-pay-detail-break {
+  word-break: break-all;
+}
+
+.mp-pay-detail-extra {
+  margin-top: 0.85rem;
+  font-size: 0.86rem;
+  color: #374151;
+}
+
+.mp-pay-detail-extra summary {
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.mp-pay-detail-table {
+  width: 100%;
+  margin-top: 0.5rem;
+  border-collapse: collapse;
+  font-size: 0.82rem;
+}
+
+.mp-pay-detail-table th,
+.mp-pay-detail-table td {
+  border: 1px solid #e5e7eb;
+  padding: 0.4rem 0.5rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.mp-pay-detail-table th {
+  width: 38%;
+  background: #f9fafb;
+  font-weight: 600;
+  color: #4b5563;
+}

--- a/frontend/src/components/PaymentDetailPanel.jsx
+++ b/frontend/src/components/PaymentDetailPanel.jsx
@@ -1,0 +1,139 @@
+import './PaymentDetailPanel.css'
+
+const PAYMENT_TYPE_LABEL = {
+  CHAT: '채팅',
+  ACCOMPANY: '동행',
+  EXTENSION: '연장',
+}
+
+const KNOWN_KEYS = new Set([
+  'paymentId',
+  'requestId',
+  'amount',
+  'paymentType',
+  'status',
+  'pgOrderNo',
+  'pgTransactionId',
+  'redirectUrl',
+  'paidAt',
+  'refundDeadline',
+])
+
+function paymentStatusLabel(s) {
+  const m = {
+    PENDING: '결제 대기',
+    COMPLETED: '결제완료',
+    REFUNDED: '환불완료',
+    FAILED: '실패',
+    CANCELLED: '취소',
+  }
+  return m[s] ?? String(s ?? '—')
+}
+
+function formatWhen(iso) {
+  if (!iso) return '—'
+  try {
+    const d = new Date(iso)
+    if (Number.isNaN(d.getTime())) return String(iso)
+    return d.toLocaleString('ko-KR', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  } catch {
+    return String(iso)
+  }
+}
+
+/**
+ * @param {{ detail: Record<string, unknown> }} props
+ */
+export function PaymentDetailPanel({ detail }) {
+  if (!detail || typeof detail !== 'object') {
+    return <p className="mp-pay-detail-empty">표시할 데이터가 없습니다.</p>
+  }
+
+  const d = detail
+  const paymentId = d.paymentId
+  const requestId = d.requestId
+  const amount = d.amount
+  const paymentType = d.paymentType
+  const status = d.status
+  const pgOrderNo = d.pgOrderNo
+  const pgTransactionId = d.pgTransactionId
+  const redirectUrl = d.redirectUrl
+  const paidAt = d.paidAt
+  const refundDeadline = d.refundDeadline
+
+  const typeKey = typeof paymentType === 'string' ? paymentType : ''
+  const typeLabel = PAYMENT_TYPE_LABEL[typeKey] ? `${PAYMENT_TYPE_LABEL[typeKey]} (${typeKey})` : typeKey || '—'
+
+  const extra = Object.entries(d).filter(([k]) => !KNOWN_KEYS.has(k))
+
+  return (
+    <div className="mp-pay-detail">
+      <dl className="mp-pay-detail-dl">
+        <div>
+          <dt>결제 ID</dt>
+          <dd>{paymentId != null ? String(paymentId) : '—'}</dd>
+        </div>
+        <div>
+          <dt>매칭 요청 ID</dt>
+          <dd>{requestId != null ? String(requestId) : '—'}</dd>
+        </div>
+        <div>
+          <dt>금액</dt>
+          <dd>{amount != null && !Number.isNaN(Number(amount)) ? `₩ ${Number(amount).toLocaleString('ko-KR')}` : '—'}</dd>
+        </div>
+        <div>
+          <dt>결제 유형</dt>
+          <dd>{typeLabel}</dd>
+        </div>
+        <div>
+          <dt>상태</dt>
+          <dd>{paymentStatusLabel(status)}</dd>
+        </div>
+        <div>
+          <dt>PG 주문번호</dt>
+          <dd className="mp-pay-detail-mono">{pgOrderNo != null && String(pgOrderNo).trim() ? String(pgOrderNo) : '—'}</dd>
+        </div>
+        <div>
+          <dt>PG 거래 ID</dt>
+          <dd className="mp-pay-detail-mono">{pgTransactionId != null && String(pgTransactionId).trim() ? String(pgTransactionId) : '—'}</dd>
+        </div>
+        <div>
+          <dt>결제 완료 일시</dt>
+          <dd>{formatWhen(paidAt)}</dd>
+        </div>
+        <div>
+          <dt>환불 마감</dt>
+          <dd>{formatWhen(refundDeadline)}</dd>
+        </div>
+        {redirectUrl != null && String(redirectUrl).trim() ? (
+          <div className="mp-pay-detail-span">
+            <dt>결제창 URL (준비)</dt>
+            <dd className="mp-pay-detail-mono mp-pay-detail-break">{String(redirectUrl)}</dd>
+          </div>
+        ) : null}
+      </dl>
+
+      {extra.length > 0 ? (
+        <details className="mp-pay-detail-extra">
+          <summary>추가 필드 ({extra.length})</summary>
+          <table className="mp-pay-detail-table">
+            <tbody>
+              {extra.map(([k, v]) => (
+                <tr key={k}>
+                  <th scope="row">{k}</th>
+                  <td className="mp-pay-detail-mono">{v === null || v === undefined ? '—' : typeof v === 'object' ? JSON.stringify(v) : String(v)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </details>
+      ) : null}
+    </div>
+  )
+}

--- a/frontend/src/layouts/DashboardLayout.css
+++ b/frontend/src/layouts/DashboardLayout.css
@@ -51,6 +51,19 @@
   word-break: break-all;
 }
 
+.dash-local-note {
+  margin: 0.55rem 0 0;
+  padding: 0.45rem 0.5rem;
+  max-width: 100%;
+  font-size: 0.72rem;
+  line-height: 1.45;
+  color: #5c6370;
+  text-align: center;
+  background: #f8fafc;
+  border: 1px solid #e8eaed;
+  border-radius: 10px;
+}
+
 .dash-profile-edit {
   margin-top: 0.65rem;
   padding: 0.35rem 0.75rem;

--- a/frontend/src/layouts/DashboardLayout.jsx
+++ b/frontend/src/layouts/DashboardLayout.jsx
@@ -35,6 +35,9 @@ export function DashboardLayout() {
           <div className="dash-avatar" aria-hidden />
           <strong className="dash-name">{displayName}</strong>
           <span className="dash-email">{email ?? ''}</span>
+          <p className="dash-local-note" role="note">
+            닉네임·알림 등은 서버 프로필이 없을 때 <strong>이 브라우저에만</strong> 저장됩니다.
+          </p>
           <Link to="/mypage/profile" className="dash-profile-edit">
             프로필 수정
           </Link>

--- a/frontend/src/pages/MypagePaymentsPage.jsx
+++ b/frontend/src/pages/MypagePaymentsPage.jsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useLocation } from 'react-router-dom'
 
 import { MypageDevHint } from '../components/MypageDevHint.jsx'
+import { PaymentDetailPanel } from '../components/PaymentDetailPanel.jsx'
 import { PageEmpty, PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client.js'
 import { fetchGuestMatchRequests, fetchGuestPayments, parseMatchingApiError } from '../lib/matchingGuest.js'
@@ -33,7 +34,15 @@ export function MypagePaymentsPage() {
   const [tab, setTab] = useState('all')
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(true)
-  const [detail, setDetail] = useState(null)
+  const [detailModal, setDetailModal] = useState(
+    /** @type {{ open: boolean, paymentId: number | null, data: Record<string, unknown> | null, err: string, loading: boolean }} */ ({
+      open: false,
+      paymentId: null,
+      data: null,
+      err: '',
+      loading: false,
+    }),
+  )
   const [routeHint, setRouteHint] = useState('')
 
   useEffect(() => {
@@ -85,14 +94,22 @@ export function MypagePaymentsPage() {
 
   const filtered = useMemo(() => payments.filter((p) => tabFilter(tab, p)), [payments, tab])
 
+  const closeDetail = () => {
+    setDetailModal({ open: false, paymentId: null, data: null, err: '', loading: false })
+  }
+
   const openDetail = async (paymentId) => {
+    setDetailModal({ open: true, paymentId, data: null, err: '', loading: true })
     try {
       const res = await apiRequest(`/matching/payments/${paymentId}`, { method: 'GET' })
       const text = await res.text()
       if (!res.ok) throw new Error(parseMatchingApiError(text))
-      setDetail(text ? JSON.parse(text) : null)
+      const raw = text ? JSON.parse(text) : null
+      const data = raw && typeof raw === 'object' && !Array.isArray(raw) ? raw : {}
+      setDetailModal({ open: true, paymentId, data, err: '', loading: false })
     } catch (e) {
-      setError(e instanceof Error ? e.message : '상세 조회 실패')
+      const msg = e instanceof Error ? e.message : '상세 조회 실패'
+      setDetailModal({ open: true, paymentId, data: null, err: msg, loading: false })
     }
   }
 
@@ -212,13 +229,29 @@ export function MypagePaymentsPage() {
         </>
       )}
 
-      {detail && (
+      {detailModal.open && (
         <div className="mp-modal-overlay" role="dialog" aria-modal="true">
           <div className="mp-modal">
             <h2 style={{ marginTop: 0 }}>결제 상세</h2>
-            <pre style={{ fontSize: '0.78rem', overflow: 'auto', maxHeight: '14rem' }}>{JSON.stringify(detail, null, 2)}</pre>
+            {detailModal.loading ? (
+              <PageLoading label="상세 불러오는 중…" />
+            ) : detailModal.err ? (
+              <PageError
+                message={detailModal.err}
+                onRetry={
+                  detailModal.paymentId != null
+                    ? () => {
+                        void openDetail(detailModal.paymentId)
+                      }
+                    : undefined
+                }
+                retryLabel="다시 시도"
+              />
+            ) : (
+              <PaymentDetailPanel detail={detailModal.data ?? {}} />
+            )}
             <div className="mp-modal-actions">
-              <button type="button" className="mp-btn mp-btn--line" onClick={() => setDetail(null)}>
+              <button type="button" className="mp-btn mp-btn--line" onClick={closeDetail}>
                 닫기
               </button>
             </div>

--- a/frontend/src/pages/MypageProfilePage.jsx
+++ b/frontend/src/pages/MypageProfilePage.jsx
@@ -62,7 +62,7 @@ export function MypageProfilePage() {
       <h1>👤 프로필</h1>
       <p className="sub">
         계정 이메일·역할은 로그인 토큰 기준이며, 표시 이름 등은 <strong>개인정보 설정(/mypage/privacy)</strong>에 저장한 값을
-        함께 씁니다.
+        함께 씁니다. 서버에 게스트 프로필이 없을 때 닉네임·알림 설정은 <strong>이 브라우저(로컬)에만</strong> 남습니다.
       </p>
       <MypageDevHint>
         회원 API: <code>POST /members/join</code>, <code>DELETE /members/me?role=...</code> · 표시는 JWT + 로컬 prefs

--- a/frontend/src/pages/MypageReviewsPage.jsx
+++ b/frontend/src/pages/MypageReviewsPage.jsx
@@ -89,7 +89,7 @@ export function MypageReviewsPage() {
       <h1>⭐ 내 리뷰</h1>
       <p className="sub">
         내가 작성한 리뷰만 모아 보여 줍니다. 팀 정책상 <strong>작성 후 수정은 불가</strong>이며, 잘못 올린 경우{' '}
-        <strong>삭제</strong>만 가능합니다.
+        <strong>삭제</strong>만 가능합니다. 후기는 <strong>완료된 매칭(COMPLETED)</strong>에서만 작성할 수 있어요.
       </p>
       <MypageDevHint>
         <code>GET /reviews/me</code> (로그인 필요)
@@ -100,7 +100,9 @@ export function MypageReviewsPage() {
       {!loading && error && <PageError message={error} onRetry={() => void load(page)} />}
 
       {!loading && !error && rows.length === 0 && (
-        <PageEmpty title="작성한 리뷰가 없습니다">가이드 매칭 화면에서 후기를 남기면 여기에 표시됩니다.</PageEmpty>
+        <PageEmpty title="작성한 리뷰가 없습니다">
+          가이드 매칭이 <strong>완료(COMPLETED)</strong>된 뒤 매칭·결제 화면에서 후기를 남기면 여기에 표시됩니다.
+        </PageEmpty>
       )}
 
       {!loading && !error && rows.length > 0 ? (

--- a/frontend/src/pages/MypageTourPage.jsx
+++ b/frontend/src/pages/MypageTourPage.jsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
-import { useLocation } from 'react-router-dom'
+import { Link, useLocation } from 'react-router-dom'
 
 import { PageEmpty, PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client.js'
@@ -83,6 +83,7 @@ export function MypageTourPage() {
   const [loading, setLoading] = useState(true)
   const [busy, setBusy] = useState(false)
   const [toast, setToast] = useState('')
+  const [actionApiErr, setActionApiErr] = useState('')
   const [refundPaymentId, setRefundPaymentId] = useState(null)
   const [refundReason, setRefundReason] = useState('')
   const [refundEvidence, setRefundEvidence] = useState('')
@@ -145,6 +146,7 @@ export function MypageTourPage() {
   const selectExtension = async (requestId, extend) => {
     setBusy(true)
     setToast('')
+    setActionApiErr('')
     try {
       const res = await apiRequest(`/matching/extensions/${requestId}/select`, {
         method: 'PATCH',
@@ -154,7 +156,7 @@ export function MypageTourPage() {
       if (!res.ok) throw new Error(parseMatchingApiError(text))
       await load()
     } catch (e) {
-      setToast(e instanceof Error ? e.message : '연장 처리 실패')
+      setActionApiErr(e instanceof Error ? e.message : '연장 처리 실패')
     } finally {
       setBusy(false)
     }
@@ -169,6 +171,7 @@ export function MypageTourPage() {
     }
     setBusy(true)
     setToast('')
+    setActionApiErr('')
     try {
       const res = await apiRequest('/matching/payments/refunds', {
         method: 'POST',
@@ -185,7 +188,7 @@ export function MypageTourPage() {
       setRefundEvidence('')
       await load()
     } catch (e) {
-      setToast(e instanceof Error ? e.message : '환불 실패')
+      setActionApiErr(e instanceof Error ? e.message : '환불 실패')
     } finally {
       setBusy(false)
     }
@@ -214,6 +217,20 @@ export function MypageTourPage() {
         </p>
       )}
       {toast && <p className="err">{toast}</p>}
+      {actionApiErr && (
+        <PageError
+          message={actionApiErr}
+          onRetry={() => {
+            setActionApiErr('')
+            void refetch()
+          }}
+          retryLabel="목록 새로고침"
+        >
+          <Link to="/mypage/payments">결제 내역 보기</Link>
+          {' · '}
+          같은 오류가 반복되면 팀에 공유된 고객 지원 채널로 문의해 주세요.
+        </PageError>
+      )}
       {loading && <PageLoading />}
       {!loading && error && <PageError message={error} onRetry={() => void refetch()} />}
 


### PR DESCRIPTION
## 변경 범위
- **결제 상세**: JSON 원문 대신 `PaymentDetailPanel`로 필드별 카드(그리드)·알 수 없는 키는 접기 테이블. 모달 내 로딩·상세 조회 실패 시 목록을 가리지 않고 모달에서만 `PageError`+재시도.
- **연장·환불**: API 실패는 `PageError`로 통일, 푸터에 결제 내역 링크·고객 지원 문구. 입력 검증(환불 사유)은 기존 `err` 한 줄 유지.
- **리뷰**: 완료 매칭에서만 작성 가능 안내 + 빈 상태 문구 보강.
- **사이드바·프로필**: 서버 프로필 없을 때 닉네임 등이 **이 브라우저에만** 저장된다는 톤 정렬.

## 스키마/API
- 백엔드 변경 없음. 결제 상세 필드는 `PaymentResponseDto`와 동일 키 기준.

## 검증
- `npm run build` (frontend)

Closes #284

Made with [Cursor](https://cursor.com)