### PR TITLE
Feat/be#287 여행 일정→상세 코스(지도)·매칭 리다이렉트·완료 화면 정리

### DIFF
--- a/frontend/src/lib/matchingGuest.js
+++ b/frontend/src/lib/matchingGuest.js
@@ -56,6 +56,24 @@ export async function fetchGuestPayments(apiRequest) {
   ])
 }
 
+/** @param {(path: string, init?: object) => Promise<Response>} apiRequest */
+export async function loadGuideNicknames(apiRequest, guideIds) {
+  const map = {}
+  for (const id of [...new Set(guideIds.filter(Boolean))]) {
+    try {
+      const res = await apiRequest(`/guides/${id}`, { method: 'GET', skipAuth: true })
+      const text = await res.text()
+      if (res.ok && text) {
+        const p = JSON.parse(text)
+        map[id] = p.nickname ?? `가이드 #${id}`
+      }
+    } catch {
+      map[id] = `가이드 #${id}`
+    }
+  }
+  return map
+}
+
 /**
  * @param {string} dateStr `YYYY-MM-DD`
  */
@@ -67,4 +85,24 @@ export function daysUntil(dateStr) {
   today.setHours(0, 0, 0, 0)
   const diff = Math.round((d.getTime() - today.getTime()) / 86400000)
   return diff
+}
+
+/**
+ * 매칭 요청별 완료 결제 ID (여러 건이면 가장 큰 paymentId).
+ * @param {unknown[]} payments
+ * @param {number} requestId
+ * @returns {number | null}
+ */
+export function pickLatestCompletedPaymentIdForRequest(payments, requestId) {
+  const rid = Number(requestId)
+  if (Number.isNaN(rid)) return null
+  let best = null
+  for (const p of Array.isArray(payments) ? payments : []) {
+    if (Number(p.requestId) !== rid) continue
+    if (String(p.status).toUpperCase() !== 'COMPLETED') continue
+    const pid = Number(p.paymentId)
+    if (Number.isNaN(pid)) continue
+    if (best == null || pid > best) best = pid
+  }
+  return best
 }

--- a/frontend/src/pages/GuideMatchOptionsPage.jsx
+++ b/frontend/src/pages/GuideMatchOptionsPage.jsx
@@ -3,6 +3,7 @@ import { Link, useLocation, useNavigate, useParams } from 'react-router-dom'
 
 import { PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client'
+import { fetchGuestPayments, pickLatestCompletedPaymentIdForRequest } from '../lib/matchingGuest.js'
 
 import './GuideMatchOptionsPage.css'
 
@@ -73,21 +74,38 @@ export function GuideMatchOptionsPage() {
       const detail = text ? JSON.parse(text) : null
       setProfile(detail?.profile ?? null)
 
+      const listRes = await apiRequest('/matching/requests/guest/list', { method: 'GET' })
+      const list = listRes.ok ? (await listRes.text().then((t) => (t ? JSON.parse(t) : []))) : []
+      const safeList = Array.isArray(list) ? list : []
+
       let rid = stateRequestId != null ? Number(stateRequestId) : null
       if (rid == null || Number.isNaN(rid)) {
-        const listRes = await apiRequest('/matching/requests/guest/list', { method: 'GET' })
-        if (listRes.ok) {
-          const lt = await listRes.text()
-          const list = lt ? JSON.parse(lt) : []
-          const proposed = findLatestProposal(list, guideId)
-          rid = proposed?.requestId != null ? Number(proposed.requestId) : null
-          if (rid == null) {
-            const anyReq = findLatestRequestForGuide(list, guideId)
-            rid = anyReq?.requestId != null ? Number(anyReq.requestId) : null
-          }
+        const proposed = findLatestProposal(safeList, guideId)
+        rid = proposed?.requestId != null ? Number(proposed.requestId) : null
+        if (rid == null) {
+          const anyReq = findLatestRequestForGuide(safeList, guideId)
+          rid = anyReq?.requestId != null ? Number(anyReq.requestId) : null
         }
       }
-      setRequestId(rid != null && !Number.isNaN(rid) ? rid : null)
+
+      const activeRid = rid != null && !Number.isNaN(rid) ? rid : null
+      const row = activeRid != null ? safeList.find((r) => Number(r.requestId) === Number(activeRid)) : null
+      if (row && (row.status === 'PAID' || row.status === 'IN_PROGRESS')) {
+        let payments = []
+        try {
+          payments = await fetchGuestPayments(apiRequest)
+        } catch {
+          payments = []
+        }
+        const paymentId = pickLatestCompletedPaymentIdForRequest(payments, activeRid)
+        const qs = new URLSearchParams()
+        qs.set('requestId', String(activeRid))
+        if (paymentId != null) qs.set('paymentId', String(paymentId))
+        navigate(`/guides/${guideId}/match/complete?${qs.toString()}`, { replace: true })
+        return
+      }
+
+      setRequestId(activeRid)
 
       const revRes = await apiRequest(`/reviews/guide/${guideId}?size=12&sort=createdAt,desc`, { method: 'GET', skipAuth: true })
       const revText = await revRes.text()
@@ -103,7 +121,7 @@ export function GuideMatchOptionsPage() {
     } finally {
       setLoading(false)
     }
-  }, [guideId, stateRequestId])
+  }, [guideId, stateRequestId, navigate])
 
   useEffect(() => {
     void load()

--- a/frontend/src/pages/GuideMatchedCoursePage.css
+++ b/frontend/src/pages/GuideMatchedCoursePage.css
@@ -27,6 +27,31 @@
   border-radius: 16px;
 }
 
+a.gmc-hero--link {
+  text-decoration: none;
+  color: inherit;
+  box-sizing: border-box;
+  cursor: pointer;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+a.gmc-hero--link:hover {
+  border-color: #c5cad3;
+  box-shadow: 0 2px 14px rgba(31, 35, 40, 0.06);
+}
+
+a.gmc-hero--link:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}
+
+.gmc-hero-cta {
+  margin: 0.5rem 0 0;
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: #2563eb;
+}
+
 .gmc-avatar {
   width: 5rem;
   height: 5rem;
@@ -207,88 +232,6 @@
 
 .gmc-chat-btn:hover {
   background: #111418;
-}
-
-.gmc-reviews {
-  margin-top: 1.5rem;
-}
-
-.gmc-reviews h2 {
-  margin: 0 0 0.75rem;
-  font-size: 1.02rem;
-  font-weight: 800;
-}
-
-.gmc-review-form {
-  display: flex;
-  gap: 0.5rem;
-  margin-bottom: 1rem;
-}
-
-.gmc-review-input {
-  flex: 1;
-  border: 1px solid #e5e7eb;
-  border-radius: 999px;
-  padding: 0.62rem 0.9rem;
-  font: inherit;
-  font-size: 0.84rem;
-  resize: vertical;
-}
-
-.gmc-review-submit {
-  border: none;
-  border-radius: 999px;
-  padding: 0 1rem;
-  background: #1f2328;
-  color: #fff;
-  font-size: 0.8rem;
-  font-weight: 700;
-  cursor: pointer;
-}
-
-.gmc-review-submit:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
-}
-
-.gmc-review-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.65rem;
-}
-
-.gmc-review-item {
-  flex: 1 1 260px;
-  display: flex;
-  gap: 0.6rem;
-  background: #fff;
-  border: 1px solid #e8eaed;
-  border-radius: 12px;
-  padding: 0.7rem 0.75rem;
-}
-
-.gmc-review-av {
-  width: 1.8rem;
-  height: 1.8rem;
-  border-radius: 50%;
-  background: #e5e7eb;
-  flex-shrink: 0;
-}
-
-.gmc-review-name {
-  margin: 0 0 0.2rem;
-  font-size: 0.8rem;
-  font-weight: 700;
-  color: #111827;
-}
-
-.gmc-review-text {
-  margin: 0;
-  font-size: 0.78rem;
-  color: #4b5563;
 }
 
 .gmc-err {

--- a/frontend/src/pages/GuideMatchedCoursePage.jsx
+++ b/frontend/src/pages/GuideMatchedCoursePage.jsx
@@ -159,19 +159,14 @@ export function GuideMatchedCoursePage() {
   const [error, setError] = useState('')
   const [profile, setProfile] = useState(null)
   const [requestData, setRequestData] = useState(null)
-  const [reviews, setReviews] = useState([])
-  const [reviewText, setReviewText] = useState('')
-  const [reviewErr, setReviewErr] = useState('')
-  const [reviewSubmitting, setReviewSubmitting] = useState(false)
   const [mapErr, setMapErr] = useState('')
 
   const load = useCallback(async () => {
     setLoading(true)
     setError('')
     try {
-      const [detailRes, reviewRes, reqRes] = await Promise.all([
+      const [detailRes, reqRes] = await Promise.all([
         apiRequest(`/guides/${guideId}/detail`, { method: 'GET', skipAuth: true }),
-        apiRequest(`/reviews/guide/${guideId}?size=12&sort=createdAt,desc`, { method: 'GET', skipAuth: true }),
         apiRequest('/matching/requests/guest/list', { method: 'GET' }),
       ])
 
@@ -179,15 +174,6 @@ export function GuideMatchedCoursePage() {
       if (!detailRes.ok) throw new Error(detailText || '가이드 정보를 불러오지 못했습니다.')
       const detail = detailText ? JSON.parse(detailText) : null
       setProfile(detail?.profile ?? null)
-
-      const reviewTextPayload = await reviewRes.text()
-      if (reviewRes.ok) {
-        const page = reviewTextPayload ? JSON.parse(reviewTextPayload) : {}
-        const raw = page?.content
-        setReviews(Array.isArray(raw) ? raw : [])
-      } else {
-        setReviews([])
-      }
 
       const reqText = await reqRes.text()
       if (reqRes.ok) {
@@ -280,40 +266,6 @@ export function GuideMatchedCoursePage() {
   const rc = profile?.reviewCount != null ? profile.reviewCount : 0
   const likes = useMemo(() => Math.max(Math.round(rc * 2.8) + 40, 12), [rc])
 
-  const onSubmitReview = async (e) => {
-    e.preventDefault()
-    setReviewErr('')
-    const content = reviewText.trim()
-    if (content.length < 10) {
-      setReviewErr('후기는 10자 이상 입력해 주세요.')
-      return
-    }
-    if (!requestData?.requestId) {
-      setReviewErr('매칭 정보가 없어 리뷰를 등록할 수 없습니다.')
-      return
-    }
-    setReviewSubmitting(true)
-    try {
-      const res = await apiRequest('/reviews', {
-        method: 'POST',
-        json: {
-          guideId: Number(guideId),
-          matchRequestId: requestData.requestId,
-          rating: 5,
-          content,
-        },
-      })
-      const text = await res.text()
-      if (!res.ok) throw new Error(text || '리뷰 등록에 실패했습니다.')
-      setReviewText('')
-      void load()
-    } catch (e) {
-      setReviewErr(e instanceof Error ? e.message : '오류')
-    } finally {
-      setReviewSubmitting(false)
-    }
-  }
-
   if (loading) {
     return (
       <div className="gmc">
@@ -337,7 +289,11 @@ export function GuideMatchedCoursePage() {
         ← Back to Search
       </button>
 
-      <header className="gmc-hero">
+      <Link
+        to={`/guides/${guideId}`}
+        className="gmc-hero gmc-hero--link"
+        aria-label={`${profile.nickname ?? '가이드'} 프로필 및 피드 보기`}
+      >
         <div
           className="gmc-avatar"
           style={profile.profileImage ? { backgroundImage: `url(${profile.profileImage})` } : undefined}
@@ -348,9 +304,10 @@ export function GuideMatchedCoursePage() {
             📍 {profile.region ?? ''} · ⭐ {rating} ({rc} 리뷰)
           </p>
           <p className="gmc-quote">“{profile.bio?.slice(0, 120) || '관광객은 모르는 사진 찍기 좋은 조용한 루트를 안내합니다.'}”</p>
+          <p className="gmc-hero-cta">프로필·피드 보기 →</p>
         </div>
         <div className="gmc-likes">♥ {likes}</div>
-      </header>
+      </Link>
 
       <section className="gmc-course">
         <h2 className="gmc-title">매칭 완료! 상세 코스</h2>
@@ -375,49 +332,6 @@ export function GuideMatchedCoursePage() {
             </Link>
           </aside>
         </div>
-      </section>
-
-      <section className="gmc-reviews">
-        <h2>여행자들의 후기 ({rc})</h2>
-        {reviewErr && <p className="gmc-err">{reviewErr}</p>}
-        <form className="gmc-review-form" onSubmit={(e) => void onSubmitReview(e)}>
-          <textarea
-            className="gmc-review-input"
-            rows={2}
-            placeholder="가이드에게 궁금한 점이나 후기를 남겨주세요..."
-            value={reviewText}
-            onChange={(e) => setReviewText(e.target.value)}
-            disabled={!requestData?.requestId}
-          />
-          <button
-            type="submit"
-            className="gmc-review-submit"
-            disabled={reviewSubmitting || !requestData?.requestId}
-          >
-            등록
-          </button>
-        </form>
-        <ul className="gmc-review-list">
-          {reviews.length === 0 ? (
-            <li className="gmc-review-item">
-              <div className="gmc-review-av" />
-              <div>
-                <p className="gmc-review-name">LocalGuest</p>
-                <p className="gmc-review-text">아직 등록된 후기가 없어요.</p>
-              </div>
-            </li>
-          ) : (
-            reviews.slice(0, 6).map((r) => (
-              <li key={r.id} className="gmc-review-item">
-                <div className="gmc-review-av" />
-                <div>
-                  <p className="gmc-review-name">{r.writeNickname ?? '여행자'}</p>
-                  <p className="gmc-review-text">{r.content}</p>
-                </div>
-              </li>
-            ))
-          )}
-        </ul>
       </section>
     </div>
   )

--- a/frontend/src/pages/MypageItineraryPage.jsx
+++ b/frontend/src/pages/MypageItineraryPage.jsx
@@ -1,31 +1,21 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import { MypageDevHint } from '../components/MypageDevHint.jsx'
 import { PageEmpty, PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client.js'
-import { daysUntil, fetchGuestMatchRequests, parseMatchingApiError } from '../lib/matchingGuest.js'
+import {
+  daysUntil,
+  fetchGuestMatchRequests,
+  fetchGuestPayments,
+  loadGuideNicknames,
+  parseMatchingApiError,
+  pickLatestCompletedPaymentIdForRequest,
+} from '../lib/matchingGuest.js'
 
 import './MypageMemberPages.css'
 
 const UPCOMING = new Set(['PENDING', 'ACCEPTED', 'PAID', 'IN_PROGRESS'])
-
-async function loadGuideNicknames(apiRequest, guideIds) {
-  const map = {}
-  for (const id of [...new Set(guideIds.filter(Boolean))]) {
-    try {
-      const res = await apiRequest(`/guides/${id}`, { method: 'GET', skipAuth: true })
-      const text = await res.text()
-      if (res.ok && text) {
-        const p = JSON.parse(text)
-        map[id] = p.nickname ?? `가이드 #${id}`
-      }
-    } catch {
-      map[id] = `가이드 #${id}`
-    }
-  }
-  return map
-}
 
 export function MypageItineraryPage() {
   const navigate = useNavigate()
@@ -35,12 +25,16 @@ export function MypageItineraryPage() {
   const [loading, setLoading] = useState(true)
   const [busyId, setBusyId] = useState(null)
   const [toast, setToast] = useState('')
-  const [detail, setDetail] = useState(null)
   const [modal, setModal] = useState(null)
   const [reason, setReason] = useState('')
+  const [paymentIdByRequest, setPaymentIdByRequest] = useState(() => ({}))
 
   const reload = useCallback(async () => {
-    const all = await fetchGuestMatchRequests(apiRequest)
+    const [all, paysRaw] = await Promise.all([
+      fetchGuestMatchRequests(apiRequest),
+      fetchGuestPayments(apiRequest).catch(() => []),
+    ])
+    const pays = Array.isArray(paysRaw) ? paysRaw : []
     const list = (Array.isArray(all) ? all : []).filter((r) => UPCOMING.has(r.status))
     list.sort((a, b) => {
       const da = String(a.desiredDate ?? '')
@@ -54,6 +48,12 @@ export function MypageItineraryPage() {
       list.map((r) => r.guideId),
     )
     setNames(nm)
+    const payMap = {}
+    for (const r of list) {
+      const pid = pickLatestCompletedPaymentIdForRequest(pays, r.requestId)
+      if (pid != null) payMap[r.requestId] = pid
+    }
+    setPaymentIdByRequest(payMap)
   }, [])
 
   const refetch = useCallback(async () => {
@@ -86,18 +86,23 @@ export function MypageItineraryPage() {
     }
   }, [reload])
 
-  const goPay = useCallback(
+  /** 결제 전·대기·수락: 매칭(옵션) 화면 / 결제 후·진행: 상세 코스(지도) */
+  const openMatchScreen = useCallback(
     (row) => {
       if (!row?.guideId || !row?.requestId) return
+      const st = String(row.status ?? '')
+      if (st === 'PAID' || st === 'IN_PROGRESS') {
+        const qs = new URLSearchParams()
+        qs.set('requestId', String(row.requestId))
+        const pid = paymentIdByRequest[row.requestId]
+        if (pid != null) qs.set('paymentId', String(pid))
+        navigate(`/guides/${row.guideId}/match/complete?${qs.toString()}`)
+        return
+      }
       navigate(`/guides/${row.guideId}/match`, { state: { requestId: row.requestId } })
     },
-    [navigate],
+    [navigate, paymentIdByRequest],
   )
-
-  const detailGuideName = useMemo(() => {
-    if (!detail) return ''
-    return names[detail.guideId] ?? `가이드 #${detail.guideId}`
-  }, [detail, names])
 
   const openModal = (mode, requestId) => {
     setReason('')
@@ -142,10 +147,13 @@ export function MypageItineraryPage() {
     <div className="mp-member">
       <h1>📆 앞으로의 여행 일정</h1>
       <p className="sub">
-        진행 중이거나 예정된 매칭만 보여 줍니다. 수락·거절·취소는 각 카드에서 진행할 수 있어요.
+        진행 중이거나 예정된 매칭만 보여 줍니다. <strong>일정 제목</strong> 또는 <strong>Preview</strong>를 누르면, 결제가 끝난 일정은{' '}
+        <strong>상세 코스(카카오 지도)</strong> 화면으로, 아직이면 <strong>매칭·결제</strong> 화면으로 이동합니다. 거절·취소는 각 카드 버튼에서
+        진행할 수 있어요.
       </p>
       <MypageDevHint>
-        <code>GET /api/matching/requests/guest/list</code> 중 진행·예정 상태만 표시 · 수락/거절/취소는 매칭 API 호출
+        PAID/IN_PROGRESS → <code>/guides/&#123;id&#125;/match/complete?requestId=…</code> · 그 외 →{' '}
+        <code>/guides/&#123;id&#125;/match</code>
       </MypageDevHint>
       {toast && <p className="err">{toast}</p>}
       {loading && <PageLoading />}
@@ -166,7 +174,7 @@ export function MypageItineraryPage() {
               <article key={r.requestId} className="mp-trip-card">
                 <div className="mp-trip-card__meta">
                   <span className="mp-dday">{dday}</span>
-                  <button type="button" className="mp-trip-title-btn" onClick={() => setDetail(r)}>
+                  <button type="button" className="mp-trip-title-btn" onClick={() => openMatchScreen(r)}>
                     {nick}와(과) 함께하는 {r.destination}
                   </button>
                   <p className="mp-trip-detail">
@@ -176,12 +184,12 @@ export function MypageItineraryPage() {
                   <p className="mp-trip-detail">예산: {r.desiredBudget != null ? `₩${Number(r.desiredBudget).toLocaleString()}` : '—'}</p>
                 </div>
                 <div className="mp-trip-actions">
-                  <span className="mp-thumb" style={{ minHeight: '4.5rem' }}>
+                  <button type="button" className="mp-thumb mp-thumb--match" style={{ minHeight: '4.5rem' }} onClick={() => openMatchScreen(r)}>
                     Preview
-                  </span>
+                  </button>
                   {r.status === 'ACCEPTED' && (
                     <>
-                      <button type="button" className="mp-btn" disabled={busyId != null} onClick={() => goPay(r)}>
+                      <button type="button" className="mp-btn" disabled={busyId != null} onClick={() => openMatchScreen(r)}>
                         결제하고 확정
                       </button>
                       <button type="button" className="mp-btn mp-btn--danger" disabled={busyId != null} onClick={() => openModal('decline', r.requestId)}>
@@ -223,44 +231,6 @@ export function MypageItineraryPage() {
         </div>
       )}
 
-      {detail && (
-        <div className="mp-modal-overlay" role="dialog" aria-modal="true">
-          <div className="mp-modal" style={{ maxWidth: '28rem' }}>
-            <h2 style={{ marginTop: 0 }}>여행 일정 상세</h2>
-            <p className="sub">
-              {detailGuideName} · 요청 #{detail.requestId}
-            </p>
-            <div style={{ display: 'grid', gap: '0.35rem' }}>
-              <p className="mp-trip-detail" style={{ margin: 0 }}>
-                목적지: <strong>{detail.destination ?? '—'}</strong>
-              </p>
-              <p className="mp-trip-detail" style={{ margin: 0 }}>
-                여행일: {detail.desiredDate ?? '—'}
-              </p>
-              <p className="mp-trip-detail" style={{ margin: 0 }}>
-                제시 일정: {detail.proposedSchedule ?? '—'}
-              </p>
-              <p className="mp-trip-detail" style={{ margin: 0 }}>
-                상태: {detail.status}
-              </p>
-              <p className="mp-trip-detail" style={{ margin: 0 }}>
-                예산:{' '}
-                {detail.desiredBudget != null ? `₩${Number(detail.desiredBudget).toLocaleString()}` : '—'}
-              </p>
-            </div>
-            <div className="mp-modal-actions">
-              {detail.status === 'ACCEPTED' && (
-                <button type="button" className="mp-btn" onClick={() => goPay(detail)} disabled={busyId != null}>
-                  결제하고 확정
-                </button>
-              )}
-              <button type="button" className="mp-btn mp-btn--line" onClick={() => setDetail(null)}>
-                닫기
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
     </div>
   )
 }

--- a/frontend/src/pages/MypageMemberPages.css
+++ b/frontend/src/pages/MypageMemberPages.css
@@ -193,6 +193,23 @@
   font-weight: 600;
 }
 
+button.mp-thumb--match {
+  border: 1px solid #e5e7eb;
+  cursor: pointer;
+  font: inherit;
+  color: #6b7280;
+}
+
+button.mp-thumb--match:hover {
+  background: linear-gradient(145deg, #eef0f3, #e2e5e9);
+  border-color: #d1d5db;
+}
+
+button.mp-thumb--match:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}
+
 .mp-scrap-hero {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## 변경 범위
- **마이페이지 여행 일정**: `PAID`/`IN_PROGRESS` → `/guides/:guideId/match/complete`(+ `requestId`, 가능 시 `paymentId`). 그 외 → `/guides/.../match`.
- **GuideMatchOptionsPage**: 동일 상태에서 잠긴 미리보기 대신 `match/complete`로 `replace` 이동.
- **matchingGuest**: `pickLatestCompletedPaymentIdForRequest` 추가.
- **GuideMatchedCoursePage**: 상단 가이드 카드 → `/guides/:guideId` 링크, 하단 후기 섹션·리뷰 API 호출 제거.

## 스키마/API
- 백엔드 변경 없음.

## 검증
- `npm run build` (frontend)

Closes #287

Made with [Cursor](https://cursor.com)