### PR TITLE
Feat/be#296 채팅방 목록 상대 닉네임 표시

### DIFF
--- a/backend/module-domain/src/main/java/com/team6/domain/chat/controller/ChatOrchestrationController.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/chat/controller/ChatOrchestrationController.java
@@ -1,6 +1,7 @@
 package com.team6.domain.chat.controller;
 
 import com.team6.domain.guide.repository.GuideProfileRepository;
+import com.team6.domain.member.entity.Role;
 import com.team6.domain.member.repository.MemberRepository;
 import com.team6.module.common.global.util.SecurityUtil;
 import jakarta.servlet.http.HttpServletRequest;
@@ -13,6 +14,8 @@ import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * 채팅 모듈은 채팅만 담당하고, 도메인 식별자(guideId 등) → 채팅 생성 입력값(email 등) 해석은 domain에서 오케스트레이션한다.
@@ -27,6 +30,47 @@ public class ChatOrchestrationController {
     private final GuideProfileRepository guideProfileRepository;
     private final MemberRepository memberRepository;
     private final RestTemplate restTemplate = new RestTemplate();
+
+    private static final Pattern DM_GUIDE_TITLE = Pattern.compile("^LG-DM-GUIDE-(\\d+)$");
+
+    /**
+     * 채팅방 목록 조회(표시용): title을 카톡처럼 상대 닉네임으로 가공한다.
+     */
+    @GetMapping
+    public ResponseEntity<Map<String, Object>> getRoomListView(HttpServletRequest request) {
+        String auth = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (auth == null || auth.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Authorization 헤더가 없습니다.");
+        }
+
+        String base = ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString();
+        Map<String, Object> raw = fetchRooms(base, auth);
+        Object roomsObj = raw.get("rooms");
+        if (!(roomsObj instanceof List<?> rooms)) {
+            return ResponseEntity.ok(raw);
+        }
+
+        String role = SecurityUtil.getCurrentUserRoleString();
+        List<Object> mapped = new ArrayList<>(rooms.size());
+        for (Object o : rooms) {
+            if (!(o instanceof Map<?, ?> m)) {
+                mapped.add(o);
+                continue;
+            }
+            //noinspection unchecked
+            Map<String, Object> room = new LinkedHashMap<>((Map<String, Object>) m);
+            String title = asString(room.get("title"));
+            String display = resolveDisplayTitle(role, title, room);
+            if (display != null && !display.isBlank()) {
+                room.put("title", display);
+            }
+            mapped.add(room);
+        }
+
+        Map<String, Object> out = new LinkedHashMap<>(raw);
+        out.put("rooms", mapped);
+        return ResponseEntity.ok(out);
+    }
 
     /**
      * 게스트가 특정 가이드(guide_profiles PK)와 1:1 DM 방을 조회/생성한다.
@@ -63,7 +107,7 @@ public class ChatOrchestrationController {
         return ResponseEntity.status(HttpStatus.CREATED).body(created);
     }
 
-    private Map<String, Object> findRoomByTitle(String base, String auth, String title) {
+    private Map<String, Object> fetchRooms(String base, String auth) {
         ResponseEntity<Map<String, Object>> res = restTemplate.exchange(
                 base + "/chat/rooms",
                 HttpMethod.GET,
@@ -71,7 +115,12 @@ public class ChatOrchestrationController {
                 new ParameterizedTypeReference<>() {
                 }
         );
-        Object roomsObj = res.getBody() != null ? res.getBody().get("rooms") : null;
+        return res.getBody() != null ? res.getBody() : Map.of("rooms", List.of(), "totalCount", 0);
+    }
+
+    private Map<String, Object> findRoomByTitle(String base, String auth, String title) {
+        Map<String, Object> raw = fetchRooms(base, auth);
+        Object roomsObj = raw.get("rooms");
         if (!(roomsObj instanceof List<?> rooms)) return null;
         for (Object o : rooms) {
             if (o instanceof Map<?, ?> m) {
@@ -118,6 +167,30 @@ public class ChatOrchestrationController {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "가이드 계정을 찾을 수 없습니다."))
                 .getEmail();
+    }
+
+    private String resolveDisplayTitle(String role, String rawTitle, Map<String, Object> room) {
+        if (rawTitle == null) return null;
+
+        Matcher dm = DM_GUIDE_TITLE.matcher(rawTitle);
+        if (dm.matches()) {
+            Long guideId = Long.valueOf(dm.group(1));
+            if ("ROLE_GUEST".equals(role)) {
+                return guideProfileRepository.findById(guideId).map(g -> g.getNickname()).orElse(rawTitle);
+            }
+            if ("ROLE_GUIDE".equals(role)) {
+                String ownerEmail = asString(room.get("ownerEmail"));
+                if (ownerEmail == null || ownerEmail.isBlank()) return rawTitle;
+                return memberRepository.findByEmailAndRole(ownerEmail, Role.GUEST)
+                        .map(m -> m.getNickname() != null && !m.getNickname().isBlank() ? m.getNickname() : ownerEmail.split("@")[0])
+                        .orElse(ownerEmail.split("@")[0]);
+            }
+        }
+        return rawTitle;
+    }
+
+    private static String asString(Object v) {
+        return v == null ? null : String.valueOf(v);
     }
 
     private static String dmTitleForGuide(Long guideId) {

--- a/frontend/src/api/chat.js
+++ b/frontend/src/api/chat.js
@@ -1,7 +1,9 @@
 import { apiRequest } from './client.js'
 
 /**
- * module-chat REST — 읽지 않은 개수·목록은 GET /chat/rooms, 방 생성은 POST /chat/rooms.
+ * Chat 목록/생성:
+ * - 목록: GET /matching/chat/rooms (domain에서 상대 닉네임으로 title 가공)
+ * - 생성: POST /chat/rooms (module-chat)
  * @typedef {{ roomId: string, title: string, ownerEmail: string, participantCount: number, lastMessage: string | null, lastMessageAt: string | null, unreadCount: number, createdAt?: string }} ChatRoomListItem
  */
 
@@ -9,7 +11,7 @@ import { apiRequest } from './client.js'
  * @returns {Promise<ChatRoomListItem[]>}
  */
 export async function fetchChatRooms() {
-  const res = await apiRequest('/chat/rooms', { method: 'GET' })
+  const res = await apiRequest('/matching/chat/rooms', { method: 'GET' })
   const text = await res.text()
   if (!res.ok) throw new Error(text || '채팅방 목록을 불러오지 못했습니다.')
   const data = text ? JSON.parse(text) : {}

--- a/frontend/src/pages/MessagesPage.jsx
+++ b/frontend/src/pages/MessagesPage.jsx
@@ -63,6 +63,12 @@ export function MessagesPage() {
     [rooms, selectedRoomId],
   )
 
+  // 선택된 방은 목록에서 unreadCount를 0으로 유지한다(현재 보고 있으면 '안 읽음' 표시 X).
+  useEffect(() => {
+    if (!selectedRoomId) return
+    setRooms((prev) => prev.map((r) => (r.roomId === selectedRoomId ? { ...r, unreadCount: 0 } : r)))
+  }, [selectedRoomId])
+
   useEffect(() => {
     if (!isAuthenticated || !token) return
 
@@ -80,7 +86,7 @@ export function MessagesPage() {
       refreshTimer = setTimeout(async () => {
         try {
           const list = await fetchChatRooms()
-          setRooms(list)
+          setRooms(list.map((r) => (selectedRoomId && r.roomId === selectedRoomId ? { ...r, unreadCount: 0 } : r)))
         } catch {
           /* ignore */
         }
@@ -90,6 +96,10 @@ export function MessagesPage() {
     es.addEventListener('chat-event', (evt) => {
       try {
         const payload = JSON.parse(String(/** @type {MessageEvent} */ (evt).data || '{}'))
+        // 현재 보고 있는 방에서의 NEW_MESSAGE는 unreadCount 갱신 대상이 아니다(0 유지).
+        if (payload?.type === 'NEW_MESSAGE' && payload?.roomId && payload.roomId === selectedRoomId) {
+          return
+        }
         if (payload?.type === 'NEW_MESSAGE' || payload?.type === 'NEW_ROOM') {
           scheduleRefreshRooms()
         }
@@ -123,6 +133,7 @@ export function MessagesPage() {
               ...r,
               lastMessage: message ?? r.lastMessage,
               lastMessageAt: createdAt ?? r.lastMessageAt,
+              unreadCount: r.roomId === selectedRoomId ? 0 : r.unreadCount,
             }
           : r,
       )

--- a/frontend/src/pages/MessagesPage.jsx
+++ b/frontend/src/pages/MessagesPage.jsx
@@ -51,6 +51,7 @@ export function MessagesPage() {
   const [error, setError] = useState('')
   const [sending, setSending] = useState(false)
   const readUpdateTimerRef = useRef(/** @type {ReturnType<typeof setTimeout> | null} */ (null))
+  const autoReadTimerRef = useRef(/** @type {ReturnType<typeof setTimeout> | null} */ (null))
 
   const myNickname = useMemo(() => {
     const fromClaims =
@@ -187,6 +188,15 @@ export function MessagesPage() {
     if (!isAuthenticated || !selectedRoomId || !email) return
     let cancelled = false
 
+    const markReadNow = async () => {
+      const q = encodeURIComponent(email)
+      try {
+        await apiRequest(`/chat/rooms/${selectedRoomId}/read?email=${q}`, { method: 'POST' })
+      } catch {
+        /* ignore */
+      }
+    }
+
     const loadMessages = async () => {
       setLoadingMessages(true)
       try {
@@ -205,12 +215,7 @@ export function MessagesPage() {
     }
 
     const markRead = async () => {
-      const q = encodeURIComponent(email)
-      try {
-        await apiRequest(`/chat/rooms/${selectedRoomId}/read?email=${q}`, { method: 'POST' })
-      } catch {
-        /* ignore */
-      }
+      await markReadNow()
     }
 
     void loadMessages()
@@ -257,6 +262,24 @@ export function MessagesPage() {
         // 실시간 메시지 수신 시, 방 목록 프리뷰도 같이 갱신한다.
         if (payload?.roomId && payload?.message) {
           bumpRoomPreview(payload.roomId, payload.message, payload.createdAt)
+        }
+        // 내가 보고 있는 방에서 상대가 보낸 메시지는 즉시 읽음 처리(서버 unreadCount/READ_UPDATE 갱신).
+        if (
+          payload?.roomId === selectedRoomId &&
+          payload?.senderEmail &&
+          payload.senderEmail !== email
+        ) {
+          if (autoReadTimerRef.current) clearTimeout(autoReadTimerRef.current)
+          autoReadTimerRef.current = setTimeout(async () => {
+            try {
+              const q = encodeURIComponent(email)
+              await apiRequest(`/chat/rooms/${selectedRoomId}/read?email=${q}`, { method: 'POST' })
+              // UI도 즉시 0으로 맞춘다.
+              setRooms((prev) => prev.map((r) => (r.roomId === selectedRoomId ? { ...r, unreadCount: 0 } : r)))
+            } catch {
+              /* ignore */
+            }
+          }, 120)
         }
         setMessages((prev) => [...prev, payload])
       })


### PR DESCRIPTION
## Summary
- 채팅방 목록에서 기술적 title(LG-DM-GUIDE-xxxx)를 카톡처럼 **상대방 닉네임**으로 표시합니다.
- module-chat은 변경하지 않고, module-domain이 `GET /chat/rooms`를 호출해 title만 가공한 `GET /matching/chat/rooms`를 제공합니다.

## Changes
- **backend/module-domain**
  - `GET /matching/chat/rooms`: DM 방(`LG-DM-GUIDE-{guideId}`)의 title을 role에 따라 상대 닉네임으로 변환
    - GUEST: guide_profiles.nickname
    - GUIDE: 방의 ownerEmail → member(email, role=GUEST) → nickname
- **frontend**
  - 채팅방 목록 조회를 `GET /chat/rooms` → `GET /matching/chat/rooms`로 변경

## Test plan
- `./gradlew :module-domain:compileJava :api-server:compileJava`
- `npm run build` (frontend)

Closes #296

Made with [Cursor](https://cursor.com)