### PR TITLE
Fix/be#298 MAIL_* 없어도 서버 부팅

### DIFF
--- a/backend/api-server/src/main/resources/application.yml
+++ b/backend/api-server/src/main/resources/application.yml
@@ -30,8 +30,9 @@ spring:
   mail:
     host: ${MAIL_HOST:smtp.gmail.com}           # 환경변수 MAIL_HOST 값 사용
     port: ${MAIL_PORT:587}       # 환경변수 없으면 기본값 587
-    username: ${MAIL_USERNAME}
-    password: ${MAIL_PASSWORD}
+    # 로컬에서 MAIL_* 미설정이어도 부팅은 되어야 한다. (메일 기능은 미동작 가능)
+    username: ${MAIL_USERNAME:}
+    password: ${MAIL_PASSWORD:}
     properties:
       mail:
         smtp:


### PR DESCRIPTION
## Summary
MAIL_USERNAME/MAIL_PASSWORD 환경변수가 없을 때도 서버가 부팅되도록 `application.yml`의 placeholder 기본값을 추가했습니다.

## Changes
- `spring.mail.username`: `${MAIL_USERNAME}` → `${MAIL_USERNAME:}`
- `spring.mail.password`: `${MAIL_PASSWORD}` → `${MAIL_PASSWORD:}`

## Test plan
- `./gradlew :api-server:compileJava`
- 로컬에서 MAIL_* 미설정 상태로 api-server 실행 시 부팅 확인

Closes #298

Made with [Cursor](https://cursor.com)