### PR TITLE
Feat/be#301 가이드 스케줄 백엔드 기능 추가 및 프론트 페이지 수정" 

### DIFF
--- a/backend/module-domain/src/main/java/com/team6/domain/guide/controller/GuideScheduleController.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/controller/GuideScheduleController.java
@@ -1,5 +1,6 @@
 package com.team6.domain.guide.controller;
 
+import com.team6.domain.guide.dto.request.BlockDateRequest;
 import com.team6.domain.guide.dto.request.CreateGuideScheduleRequest;
 import com.team6.domain.guide.dto.request.SubmitGuideScheduleFormRequest;
 import com.team6.domain.guide.dto.request.UpdateGuideScheduleRequest;
@@ -171,5 +172,34 @@ public class GuideScheduleController {
     ) {
         Long userId = guideAuthenticationSupport.getCurrentGuideMemberId();
         return ResponseEntity.ok(guideScheduleService.changeStatus(scheduleId, guideId, status, userId));
+    }
+
+    // BLOCKED 날짜 목록 조회 — 게스트 달력용, 인증 불필요
+    @GetMapping("/blocked")
+    public ResponseEntity<List<GuideScheduleResponse>> getBlockedDates(
+            @PathVariable Long guideId
+    ) {
+        return ResponseEntity.ok(guideScheduleService.getBlockedDates(guideId));
+    }
+
+    // 날짜 단위 BLOCKED 등록 — 가이드 본인만
+    @PostMapping("/block")
+    public ResponseEntity<GuideScheduleResponse> blockDate(
+            @PathVariable Long guideId,
+            @RequestBody @Valid BlockDateRequest request
+    ) {
+        Long userId = guideAuthenticationSupport.getCurrentGuideMemberId();
+        return ResponseEntity.ok(guideScheduleService.blockDate(guideId, request.getDate(), userId));
+    }
+
+    // 날짜 단위 BLOCKED 해제 — 가이드 본인만
+    @DeleteMapping("/block")
+    public ResponseEntity<Void> unblockDate(
+            @PathVariable Long guideId,
+            @RequestBody @Valid BlockDateRequest request
+    ) {
+        Long userId = guideAuthenticationSupport.getCurrentGuideMemberId();
+        guideScheduleService.unblockDate(guideId, request.getDate(), userId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/module-domain/src/main/java/com/team6/domain/guide/dto/request/BlockDateRequest.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/dto/request/BlockDateRequest.java
@@ -1,0 +1,18 @@
+package com.team6.domain.guide.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+/**
+ * 날짜 단위 BLOCKED 등록/해제 요청 DTO
+ */
+@Getter
+@NoArgsConstructor
+public class BlockDateRequest {
+
+    @NotNull
+    private LocalDate date;
+}

--- a/backend/module-domain/src/main/java/com/team6/domain/guide/entity/GuideFeed.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/entity/GuideFeed.java
@@ -18,30 +18,31 @@ public class GuideFeed extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")
-    private Long id; // 피드 고유 ID (PK)
+    private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "guide_id", nullable = false)
-    private GuideProfile guideProfile; // 가이드 프로필 (guide_profiles FK)
+    private GuideProfile guideProfile;
 
     @Column(columnDefinition = "TEXT", nullable = false)
-    private String content; // 피드 본문 내용
+    private String content;
 
-    // 로컬 이미지 업로드(data URL) Stub 저장을 위해 길이 제한을 완화한다.
     @Column(name = "image_url", columnDefinition = "LONGTEXT")
-    private String imageUrl; // 피드 이미지 URL (선택)
+    private String imageUrl;
 
     @Column(name = "is_deleted", nullable = false)
     @Builder.Default
-    private Boolean isDeleted = false; // 소프트 삭제 여부 (true = 삭제됨)
+    private Boolean isDeleted = false;
 
     // 피드 내용 수정
     public void update(String content, String imageUrl) {
         this.content = content;
-        this.imageUrl = imageUrl;
+        if (imageUrl != null) {        // null이면 기존 이미지 유지
+            this.imageUrl = imageUrl;
+        }
     }
 
-    // 피드 소프트 삭제 (실제 DB 삭제 없이 플래그만 변경)
+    // 피드 소프트 삭제
     public void delete() {
         this.isDeleted = true;
     }

--- a/backend/module-domain/src/main/java/com/team6/domain/guide/repository/GuideScheduleRepository.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/repository/GuideScheduleRepository.java
@@ -21,6 +21,9 @@ public interface GuideScheduleRepository extends JpaRepository<GuideSchedule, Lo
     // 상태별 스케줄 조회 — 대기 스케줄 확인 (F06-04)
     List<GuideSchedule> findByGuideProfile_IdAndStatus(Long guideId, GuideScheduleStatus status);
 
+    // 특정 날짜의 스케줄 목록 조회 — blockDate/unblockDate 에서 날짜 단위 조회에 사용
+    List<GuideSchedule> findByGuideProfile_IdAndAvailableDate(Long guideId, LocalDate date);
+
     // 시간대 겹침 체크 — UniqueConstraint (guide_id, available_date, start_time, end_time) 기준
     // 같은 날짜에 기존 스케줄과 시간이 겹치면 true (startTime < 기존종료 AND endTime > 기존시작)
     @Query("SELECT COUNT(s) > 0 FROM GuideSchedule s " +

--- a/backend/module-domain/src/main/java/com/team6/domain/guide/service/GuideScheduleService.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/service/GuideScheduleService.java
@@ -17,6 +17,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 
 /**
@@ -285,6 +287,64 @@ public class GuideScheduleService {
         log.info("[F05-01][F05-02] 스케줄 AVAILABLE 복구 동기화 — guideId={}, scheduleId={}, actorId={}",
                 guideId, scheduleId, actorMemberId);
         return GuideScheduleResponse.from(schedule);
+    }
+
+    // BLOCKED 상태 스케줄 목록 조회 — 게스트 달력 조회용 (인증 불필요)
+    @Transactional(readOnly = true)
+    public List<GuideScheduleResponse> getBlockedDates(Long guideId) {
+        return guideScheduleRepository.findByGuideProfile_IdAndStatus(guideId, GuideScheduleStatus.BLOCKED).stream()
+                .map(GuideScheduleResponse::from)
+                .toList();
+    }
+
+    // 날짜 단위 BLOCKED 등록 — 이미 BLOCKED면 스킵, AVAILABLE이면 상태 변경, 없으면 신규 생성
+    @Transactional
+    public GuideScheduleResponse blockDate(Long guideId, LocalDate date, Long userId) {
+        GuideProfile profile = getVerifiedProfile(guideId, userId);
+
+        List<GuideSchedule> existing = guideScheduleRepository.findByGuideProfile_IdAndAvailableDate(guideId, date);
+
+        // 이미 BLOCKED인 날짜면 스킵 (멱등)
+        boolean alreadyBlocked = existing.stream()
+                .anyMatch(s -> s.getStatus() == GuideScheduleStatus.BLOCKED);
+        if (alreadyBlocked) {
+            GuideSchedule blocked = existing.stream()
+                    .filter(s -> s.getStatus() == GuideScheduleStatus.BLOCKED)
+                    .findFirst()
+                    .orElseThrow();
+            return GuideScheduleResponse.from(blocked);
+        }
+
+        // AVAILABLE 스케줄이 있으면 상태 변경
+        if (!existing.isEmpty()) {
+            GuideSchedule target = existing.get(0);
+            target.changeStatus(GuideScheduleStatus.BLOCKED);
+            return GuideScheduleResponse.from(target);
+        }
+
+        // 등록된 스케줄 없음 → 종일 BLOCKED 레코드 신규 생성 (00:00 – 23:59 sentinel)
+        GuideSchedule block = GuideSchedule.builder()
+                .guideProfile(profile)
+                .availableDate(date)
+                .startTime(LocalTime.of(0, 0))
+                .endTime(LocalTime.of(23, 59))
+                .status(GuideScheduleStatus.BLOCKED)
+                .build();
+        return GuideScheduleResponse.from(guideScheduleRepository.save(block));
+    }
+
+    // 날짜 단위 BLOCKED 해제 — BLOCKED → AVAILABLE, 없으면 무시
+    @Transactional
+    public void unblockDate(Long guideId, LocalDate date, Long userId) {
+        getVerifiedProfile(guideId, userId);
+
+        List<GuideSchedule> blocked = guideScheduleRepository
+                .findByGuideProfile_IdAndAvailableDate(guideId, date)
+                .stream()
+                .filter(s -> s.getStatus() == GuideScheduleStatus.BLOCKED)
+                .toList();
+
+        blocked.forEach(s -> s.changeStatus(GuideScheduleStatus.AVAILABLE));
     }
 
     // 시작 시간 < 종료 시간 검증 공통 메서드 — DB의 CHECK 제약과 이중 보호

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -57,6 +57,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -264,29 +265,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -889,6 +867,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -935,6 +914,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1043,6 +1023,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1245,6 +1226,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2224,6 +2206,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2291,6 +2274,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2300,6 +2284,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -2626,6 +2611,7 @@
       "integrity": "sha512-P1PbweD+2/udplnThz3btF4cf6AgPky7kk23RtHUkJIU5BIxwPprhRGmOAHs6FTI7UiGbTNrgNP6jSYD6JaRnw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -2773,6 +2759,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/layouts/GuideDashboardLayout.css
+++ b/frontend/src/layouts/GuideDashboardLayout.css
@@ -279,3 +279,9 @@
   font-size: 0.85rem;
   margin: 0 0 0.75rem;
 }
+
+.g-success {
+  color: #15803d;
+  font-size: 0.85rem;
+  margin: 0 0 0.75rem;
+}

--- a/frontend/src/pages/GuideApplyPage.jsx
+++ b/frontend/src/pages/GuideApplyPage.jsx
@@ -3,12 +3,10 @@ import { Link, useLocation, useNavigate } from 'react-router-dom'
 
 import { apiRequest, fetchNicknameAvailable } from '../api/client'
 import { setStoredGuideId } from '../lib/guideId.js'
-import { useAuth } from '../context/useAuth.js'
 
 import './FormPage.css'
 
 export function GuideApplyPage() {
-  const { email, logout } = useAuth()
   const navigate = useNavigate()
   const location = useLocation()
   const fromTerms = Boolean(location.state?.fromTerms)
@@ -93,16 +91,7 @@ export function GuideApplyPage() {
       if (profile?.guideId != null) {
         setStoredGuideId(profile.guideId)
       }
-      const approved = profile?.isApproved === true
-      sessionStorage.setItem(
-        'login_flash',
-        `가이드 프로필이 등록되었습니다. 관리자 승인: ${approved ? '완료' : '대기'} · JWT 역할 반영을 위해 다시 로그인해 주세요.`,
-      )
-      if (email) {
-        sessionStorage.setItem('prefill_login_email', email)
-      }
-      await logout()
-      navigate('/auth/login', { replace: true })
+      navigate('/guide/mypage', { replace: true })
     } catch {
       setError('네트워크 오류가 발생했습니다.')
     } finally {

--- a/frontend/src/pages/GuideDetailPage.jsx
+++ b/frontend/src/pages/GuideDetailPage.jsx
@@ -34,6 +34,19 @@ function toScheduleList(raw) {
 }
 
 /**
+ * @param {unknown} t
+ * @returns {string}
+ */
+function formatLocalTime(t) {
+  if (t == null) return ''
+  if (typeof t === 'string') return t.slice(0, 5)
+  if (typeof t === 'object' && t.hour != null) {
+    return `${String(t.hour).padStart(2, '0')}:${String(t.minute).padStart(2, '0')}`
+  }
+  return String(t)
+}
+
+/**
  * status 가 비어 있어도(구버전/임시 응답) 일단 예약 후보로 본다.
  * @param {any} schedule
  * @returns {boolean}
@@ -283,7 +296,7 @@ export function GuideDetailPage() {
                 >
                   {schedules.map((s) => (
                     <option key={s.scheduleId} value={s.scheduleId}>
-                      {formatScheduleDate(s.availableDate)} {s.startTime ?? ''} ~ {s.endTime ?? ''}
+                      {formatScheduleDate(s.availableDate)} {formatLocalTime(s.startTime)} ~ {formatLocalTime(s.endTime)}
                     </option>
                   ))}
                 </select>

--- a/frontend/src/pages/GuideFeedSchedulePage.jsx
+++ b/frontend/src/pages/GuideFeedSchedulePage.jsx
@@ -38,6 +38,29 @@ function nextStatus(s) {
   return 'plain'
 }
 
+function useToast() {
+  const [toasts, setToasts] = useState([])
+  const addToast = useCallback((message, type = 'success') => {
+    const id = Date.now() + Math.random()
+    setToasts((prev) => [...prev, { id, message, type }])
+    setTimeout(() => setToasts((prev) => prev.filter((t) => t.id !== id)), 2000)
+  }, [])
+  return { toasts, addToast }
+}
+
+function Toast({ toasts }) {
+  if (toasts.length === 0) return null
+  return (
+    <div style={{ position: 'fixed', bottom: '1.5rem', right: '1.5rem', zIndex: 9999, display: 'flex', flexDirection: 'column', gap: '0.5rem', pointerEvents: 'none' }}>
+      {toasts.map((t) => (
+        <div key={t.id} style={{ padding: '0.7rem 1.2rem', borderRadius: 10, background: t.type === 'success' ? '#15803d' : '#b91c1c', color: '#fff', fontSize: '0.88rem', fontWeight: 600, boxShadow: '0 4px 16px rgba(0,0,0,0.18)', minWidth: 180, maxWidth: 320 }}>
+          {t.message}
+        </div>
+      ))}
+    </div>
+  )
+}
+
 async function readJsonError(res, text) {
   try {
     const j = JSON.parse(text)
@@ -71,11 +94,9 @@ export function GuideFeedSchedulePage() {
   const [feedExtraImageUrl, setFeedExtraImageUrl] = useState('')
   const [feedMainFileName, setFeedMainFileName] = useState('')
   const [feedExtraFileName, setFeedExtraFileName] = useState('')
-  const [schDate, setSchDate] = useState('')
-  const [schStart, setSchStart] = useState('')
-  const [schEnd, setSchEnd] = useState('')
+  const { toasts, addToast } = useToast()
+  const [blockedDates, setBlockedDates] = useState(() => new Set())
   const [busy, setBusy] = useState(false)
-  const [msg, setMsg] = useState('')
   const mainFileInputRef = useRef(null)
   const extraFileInputRef = useRef(null)
   const currentTab = searchParams.get('tab') === 'schedule' ? 'schedule' : 'feed'
@@ -86,17 +107,18 @@ export function GuideFeedSchedulePage() {
 
   const loadAll = useCallback(async (id) => {
     setLoadError('')
-    setMsg('')
     try {
-      const [fr, sr, pr, guideReq] = await Promise.all([
+      const [fr, sr, pr, br, guideReq] = await Promise.all([
         apiRequest(`/guides/${id}/feeds`, { method: 'GET', skipAuth: true }),
         apiRequest(`/guides/${id}/schedules`, { method: 'GET', skipAuth: true }),
         apiRequest(`/guides/${id}/schedules/pending`, { method: 'GET' }),
+        apiRequest(`/guides/${id}/schedules/blocked`, { method: 'GET', skipAuth: true }),
         fetchGuideMatchRequests(apiRequest),
       ])
       const ft = await fr.text()
       const st = await sr.text()
       const pt = await pr.text()
+      const bt = await br.text()
       if (!fr.ok) {
         throw new Error(await readJsonError(fr, ft))
       }
@@ -109,6 +131,10 @@ export function GuideFeedSchedulePage() {
         setPendingSchedules(pt ? JSON.parse(pt) : [])
       } else {
         setPendingSchedules([])
+      }
+      if (br.ok) {
+        const blockedList = bt ? JSON.parse(bt) : []
+        setBlockedDates(new Set(blockedList.map((s) => s.availableDate)))
       }
       setGuideRequests(Array.isArray(guideReq) ? guideReq : [])
     } catch (e) {
@@ -195,7 +221,6 @@ export function GuideFeedSchedulePage() {
   const addFeed = async () => {
     if (!guideId || !feedContent.trim()) return
     setBusy(true)
-    setMsg('')
     try {
       const res = await apiRequest(`/guides/${guideId}/feeds`, {
         method: 'POST',
@@ -206,7 +231,7 @@ export function GuideFeedSchedulePage() {
       })
       const text = await res.text()
       if (!res.ok) {
-        setMsg(await readJsonError(res, text))
+        addToast(await readJsonError(res, text), 'error')
         return
       }
       setFeedContent('')
@@ -214,9 +239,10 @@ export function GuideFeedSchedulePage() {
       setFeedExtraImageUrl('')
       setFeedMainFileName('')
       setFeedExtraFileName('')
+      addToast('등록되었습니다.')
       await loadAll(guideId)
     } catch {
-      setMsg('피드 등록 실패')
+      addToast('피드 등록 실패', 'error')
     } finally {
       setBusy(false)
     }
@@ -225,49 +251,44 @@ export function GuideFeedSchedulePage() {
   const removeFeed = async (feedId) => {
     if (!guideId || !window.confirm('이 피드를 삭제할까요?')) return
     setBusy(true)
-    setMsg('')
     try {
       const res = await apiRequest(`/guides/${guideId}/feeds/${feedId}`, { method: 'DELETE' })
       if (!res.ok) {
         const text = await res.text()
-        setMsg(await readJsonError(res, text))
+        addToast(await readJsonError(res, text), 'error')
         return
       }
       await loadAll(guideId)
     } catch {
-      setMsg('삭제 실패')
+      addToast('삭제 실패', 'error')
     } finally {
       setBusy(false)
     }
   }
 
-  const addSchedule = async () => {
-    if (!guideId || !schDate || !schStart || !schEnd) {
-      setMsg('날짜·시작·종료 시간을 모두 입력해 주세요.')
-      return
-    }
+  const toggleBlock = async (dateStr) => {
+    if (!guideId || busy) return
     setBusy(true)
-    setMsg('')
     try {
-      const res = await apiRequest(`/guides/${guideId}/schedules`, {
-        method: 'POST',
-        json: {
-          availableDate: schDate,
-          startTime: schStart.length === 5 ? `${schStart}:00` : schStart,
-          endTime: schEnd.length === 5 ? `${schEnd}:00` : schEnd,
-        },
+      const isBlocked = blockedDates.has(dateStr)
+      const res = await apiRequest(`/guides/${guideId}/schedules/block`, {
+        method: isBlocked ? 'DELETE' : 'POST',
+        json: { date: dateStr },
       })
       const text = await res.text()
       if (!res.ok) {
-        setMsg(await readJsonError(res, text))
+        addToast(await readJsonError(res, text), 'error')
         return
       }
-      setSchDate('')
-      setSchStart('')
-      setSchEnd('')
+      setBlockedDates((prev) => {
+        const next = new Set(prev)
+        if (isBlocked) next.delete(dateStr)
+        else next.add(dateStr)
+        return next
+      })
       await loadAll(guideId)
     } catch {
-      setMsg('스케줄 등록 실패')
+      addToast('날짜 설정 실패', 'error')
     } finally {
       setBusy(false)
     }
@@ -276,17 +297,16 @@ export function GuideFeedSchedulePage() {
   const acceptPendingSchedule = async (scheduleId) => {
     if (!guideId) return
     setBusy(true)
-    setMsg('')
     try {
       const res = await apiRequest(`/guides/${guideId}/schedules/${scheduleId}/accept`, { method: 'POST' })
       const text = await res.text()
       if (!res.ok) {
-        setMsg(await readJsonError(res, text))
+        addToast(await readJsonError(res, text), 'error')
         return
       }
       await loadAll(guideId)
     } catch {
-      setMsg('스케줄 수락 실패')
+      addToast('스케줄 수락 실패', 'error')
     } finally {
       setBusy(false)
     }
@@ -295,17 +315,16 @@ export function GuideFeedSchedulePage() {
   const rejectPendingSchedule = async (scheduleId) => {
     if (!guideId || !window.confirm('이 예약 대기 스케줄을 거절할까요?')) return
     setBusy(true)
-    setMsg('')
     try {
       const res = await apiRequest(`/guides/${guideId}/schedules/${scheduleId}/reject`, { method: 'POST' })
       const text = await res.text()
       if (!res.ok) {
-        setMsg(await readJsonError(res, text))
+        addToast(await readJsonError(res, text), 'error')
         return
       }
       await loadAll(guideId)
     } catch {
-      setMsg('스케줄 거절 실패')
+      addToast('스케줄 거절 실패', 'error')
     } finally {
       setBusy(false)
     }
@@ -314,17 +333,16 @@ export function GuideFeedSchedulePage() {
   const removeSchedule = async (scheduleId) => {
     if (!guideId || !window.confirm('이 스케줄을 삭제할까요?')) return
     setBusy(true)
-    setMsg('')
     try {
       const res = await apiRequest(`/guides/${guideId}/schedules/${scheduleId}`, { method: 'DELETE' })
       if (!res.ok) {
         const text = await res.text()
-        setMsg(await readJsonError(res, text))
+        addToast(await readJsonError(res, text), 'error')
         return
       }
       await loadAll(guideId)
     } catch {
-      setMsg('스케줄 삭제 실패')
+      addToast('스케줄 삭제 실패', 'error')
     } finally {
       setBusy(false)
     }
@@ -334,7 +352,7 @@ export function GuideFeedSchedulePage() {
     const file = e.target.files?.[0]
     if (!file) return
     if (file.size > MAX_LOCAL_IMAGE_BYTES) {
-      setMsg('이미지 용량이 너무 큽니다. 2MB 이하 파일을 선택해 주세요.')
+      addToast('이미지 용량이 너무 큽니다. 2MB 이하 파일을 선택해 주세요.', 'error')
       e.target.value = ''
       return
     }
@@ -342,9 +360,8 @@ export function GuideFeedSchedulePage() {
       const dataUrl = await readFileAsDataUrl(file)
       setFeedImageUrl(dataUrl)
       setFeedMainFileName(file.name)
-      setMsg('')
     } catch {
-      setMsg('메인 사진을 읽지 못했습니다.')
+      addToast('메인 사진을 읽지 못했습니다.', 'error')
     } finally {
       e.target.value = ''
     }
@@ -354,7 +371,7 @@ export function GuideFeedSchedulePage() {
     const file = e.target.files?.[0]
     if (!file) return
     if (file.size > MAX_LOCAL_IMAGE_BYTES) {
-      setMsg('이미지 용량이 너무 큽니다. 2MB 이하 파일을 선택해 주세요.')
+      addToast('이미지 용량이 너무 큽니다. 2MB 이하 파일을 선택해 주세요.', 'error')
       e.target.value = ''
       return
     }
@@ -362,9 +379,8 @@ export function GuideFeedSchedulePage() {
       const dataUrl = await readFileAsDataUrl(file)
       setFeedExtraImageUrl(dataUrl)
       setFeedExtraFileName(file.name)
-      setMsg('')
     } catch {
-      setMsg('추가 사진을 읽지 못했습니다.')
+      addToast('추가 사진을 읽지 못했습니다.', 'error')
     } finally {
       e.target.value = ''
     }
@@ -409,7 +425,7 @@ export function GuideFeedSchedulePage() {
         </button>
       </div>
       {loadError && <p className="g-error">{loadError}</p>}
-      {msg && <p className="g-error">{msg}</p>}
+      <Toast toasts={toasts} />
       {currentTab === 'feed' ? (
         <section className="gfs-feed">
           <div className="gfs-badge">📸 피드 등록</div>
@@ -547,18 +563,27 @@ export function GuideFeedSchedulePage() {
                 {calendarCells.map((cell) => {
                   const dayKey = ymd(cell.date)
                   const daySchedules = scheduleByDate.get(dayKey) ?? []
-                  const primary = daySchedules[0]
-                  const kind = primary ? nextStatus(primary.status) : 'plain'
+                  const isBlocked = blockedDates.has(dayKey)
+                  const hasBooked = daySchedules.some((s) => s.status === 'BOOKED')
+                  const hasPending = daySchedules.some((s) => s.status === 'PENDING')
+                  let kind = 'plain'
+                  if (isBlocked) kind = 'blocked'
+                  else if (hasBooked) kind = 'booked'
+                  else if (hasPending) kind = 'pending'
                   const today = ymd(new Date()) === dayKey
+                  const canToggle = cell.inMonth && !hasBooked && !hasPending
                   return (
                     <button
                       key={cell.key}
                       type="button"
                       className={`gss-day ${cell.inMonth ? '' : 'is-out'} ${kind !== 'plain' ? `is-${kind}` : ''} ${today ? 'is-today' : ''}`}
-                      title={daySchedules.length ? `${dayKey} · ${daySchedules.length}건` : dayKey}
+                      title={isBlocked ? `${dayKey} · 예약 불가 (클릭 시 해제)` : canToggle ? `${dayKey} · 클릭 시 예약 불가 설정` : dayKey}
+                      onClick={canToggle ? () => void toggleBlock(dayKey) : undefined}
+                      disabled={!cell.inMonth || busy}
                     >
                       <span>{cell.date.getDate()}</span>
-                      {daySchedules.length > 0 && <small>{daySchedules.length}</small>}
+                      {isBlocked && <small>✕</small>}
+                      {!isBlocked && daySchedules.length > 0 && <small>{daySchedules.length}</small>}
                     </button>
                   )
                 })}
@@ -630,25 +655,9 @@ export function GuideFeedSchedulePage() {
               </ul>
             </div>
           )}
-          <div className="gm-grid" style={{ maxWidth: 'none' }}>
-            <div className="gm-field">
-              <label htmlFor="sc-date">가능 날짜</label>
-              <input id="sc-date" type="date" value={schDate} onChange={(e) => setSchDate(e.target.value)} />
-            </div>
-            <div className="gm-field">
-              <label htmlFor="sc-start">시작</label>
-              <input id="sc-start" type="time" value={schStart} onChange={(e) => setSchStart(e.target.value)} />
-            </div>
-            <div className="gm-field">
-              <label htmlFor="sc-end">종료</label>
-              <input id="sc-end" type="time" value={schEnd} onChange={(e) => setSchEnd(e.target.value)} />
-            </div>
-          </div>
-          <div className="gm-actions">
-            <button type="button" className="gm-btn" onClick={() => void addSchedule()} disabled={busy}>
-              스케줄 추가
-            </button>
-          </div>
+          <p className="gm-hint" style={{ marginBottom: '0.5rem' }}>
+            캘린더에서 날짜를 클릭해 예약 불가 설정/해제할 수 있습니다. (BOOKED·PENDING 날짜는 변경 불가)
+          </p>
           <ul className="gm-list" style={{ marginTop: '0.85rem' }}>
             {schedules.length === 0 && <li>등록된 스케줄이 없습니다.</li>}
             {schedules.map((s) => (

--- a/frontend/src/pages/GuideFeesPage.jsx
+++ b/frontend/src/pages/GuideFeesPage.jsx
@@ -5,6 +5,38 @@ import { resolveGuideId } from '../lib/guideId.js'
 
 import '../layouts/GuideDashboardLayout.css'
 
+function useToast() {
+  const [toasts, setToasts] = useState([])
+  const addToast = useCallback((message, type = 'success') => {
+    const id = Date.now() + Math.random()
+    setToasts((prev) => [...prev, { id, message, type }])
+    setTimeout(() => setToasts((prev) => prev.filter((t) => t.id !== id)), 2000)
+  }, [])
+  return { toasts, addToast }
+}
+
+function Toast({ toasts }) {
+  if (toasts.length === 0) return null
+  return (
+    <div style={{ position: 'fixed', bottom: '1.5rem', right: '1.5rem', zIndex: 9999, display: 'flex', flexDirection: 'column', gap: '0.5rem', pointerEvents: 'none' }}>
+      {toasts.map((t) => (
+        <div key={t.id} style={{ padding: '0.7rem 1.2rem', borderRadius: 10, background: t.type === 'success' ? '#15803d' : '#b91c1c', color: '#fff', fontSize: '0.88rem', fontWeight: 600, boxShadow: '0 4px 16px rgba(0,0,0,0.18)', minWidth: 180, maxWidth: 320 }}>
+          {t.message}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+async function readJsonError(res, text) {
+  try {
+    const j = JSON.parse(text)
+    return (j.message ?? text) || '요청 실패'
+  } catch {
+    return text || '요청 실패'
+  }
+}
+
 const HOURS = 8
 const LS_PUSH = 'guide_pref_push_notif'
 const LS_EMAIL = 'guide_pref_email_notif'
@@ -19,9 +51,10 @@ function loadBool(key, fallback) {
 export function GuideFeesPage() {
   const [guideId, setGuideId] = useState(null)
   const [profile, setProfile] = useState(null)
+  const { toasts, addToast } = useToast()
   const [loadError, setLoadError] = useState('')
-  const [error, setError] = useState('')
   const [saving, setSaving] = useState(false)
+  const [toggling, setToggling] = useState(false)
 
   const [pushOn, setPushOn] = useState(() => loadBool(LS_PUSH, true))
   const [emailOn, setEmailOn] = useState(() => loadBool(LS_EMAIL, false))
@@ -65,6 +98,28 @@ export function GuideFeesPage() {
     }
   }, [loadProfile])
 
+  const handleToggleActive = async () => {
+    if (!guideId || toggling) return
+    setToggling(true)
+    try {
+      const res = await apiRequest(`/guides/${guideId}/active`, { method: 'PATCH' })
+      const text = await res.text()
+      if (!res.ok) {
+        addToast(await readJsonError(res, text), 'error')
+        return
+      }
+      const updated = text ? JSON.parse(text) : null
+      const newActive = updated?.isActive !== false
+      if (updated) setProfile(updated)
+      setProfileVisible(newActive)
+      addToast(newActive ? '활성화되었습니다.' : '비활성화되었습니다.')
+    } catch {
+      addToast('요청 실패', 'error')
+    } finally {
+      setToggling(false)
+    }
+  }
+
   const savePrefs = () => {
     localStorage.setItem(LS_PUSH, pushOn ? '1' : '0')
     localStorage.setItem(LS_EMAIL, emailOn ? '1' : '0')
@@ -72,13 +127,12 @@ export function GuideFeesPage() {
 
   const handleSave = async () => {
     if (!guideId || !profile) return
-    setError('')
     setSaving(true)
     savePrefs()
     try {
       const pkg = Number(packageWon.replace(/[^\d]/g, ''))
       if (!Number.isFinite(pkg) || pkg <= 0) {
-        setError('종일 패키지 금액을 올바르게 입력해 주세요.')
+        addToast('종일 패키지 금액을 올바르게 입력해 주세요.', 'error')
         setSaving(false)
         return
       }
@@ -90,7 +144,7 @@ export function GuideFeesPage() {
         region: profile.region,
         language: profile.language,
         pricePerHour: hourly,
-        isActive: profileVisible,
+        isActive: profile?.isActive ?? profileVisible,
         residenceYears: profile.residenceYears ?? undefined,
         localStory: profile.localStory ?? undefined,
         keywords: profile.keywords ?? undefined,
@@ -100,18 +154,14 @@ export function GuideFeesPage() {
       const res = await apiRequest(`/guides/${guideId}`, { method: 'PUT', json: body })
       const text = await res.text()
       if (!res.ok) {
-        try {
-          const j = JSON.parse(text)
-          setError(j.message ?? '저장에 실패했습니다.')
-        } catch {
-          setError(text || '저장에 실패했습니다.')
-        }
+        addToast(await readJsonError(res, text), 'error')
         return
       }
       const updated = text ? JSON.parse(text) : null
       setProfile(updated)
+      addToast('저장되었습니다.')
     } catch {
-      setError('네트워크 오류가 발생했습니다.')
+      addToast('네트워크 오류가 발생했습니다.', 'error')
     } finally {
       setSaving(false)
     }
@@ -138,7 +188,7 @@ export function GuideFeesPage() {
     <div className="g-panel">
       <h1>⚙️ 가이드 비용</h1>
 
-      {error && <p className="g-error">{error}</p>}
+      <Toast toasts={toasts} />
 
       <section className="g-section">
         <h2>알림 설정</h2>
@@ -172,7 +222,7 @@ export function GuideFeesPage() {
             <p>서버 필드 <code>isActive</code> 와 연동됩니다.</p>
           </div>
           <label className="g-toggle">
-            <input type="checkbox" checked={profileVisible} onChange={(e) => setProfileVisible(e.target.checked)} />
+            <input type="checkbox" checked={profileVisible} onChange={() => void handleToggleActive()} disabled={toggling} />
             <span className="g-toggle-ui" />
           </label>
         </div>

--- a/frontend/src/pages/GuideIntroEditPage.jsx
+++ b/frontend/src/pages/GuideIntroEditPage.jsx
@@ -22,8 +22,10 @@ export function GuideIntroEditPage() {
   const [profile, setProfile] = useState(null)
   const [bio, setBio] = useState('')
   const [localStory, setLocalStory] = useState('')
+  const [residenceYears, setResidenceYears] = useState('')
   const [loadError, setLoadError] = useState('')
   const [saveError, setSaveError] = useState('')
+  const [saveSuccess, setSaveSuccess] = useState(false)
   const [saving, setSaving] = useState(false)
 
   const load = useCallback(async (id) => {
@@ -38,6 +40,7 @@ export function GuideIntroEditPage() {
       setProfile(p)
       setBio(p?.bio ?? '')
       setLocalStory(p?.localStory ?? '')
+      setResidenceYears(p?.residenceYears != null ? String(p.residenceYears) : '')
     } catch (e) {
       setLoadError(e instanceof Error ? e.message : '불러오기 실패')
     }
@@ -51,9 +54,10 @@ export function GuideIntroEditPage() {
   const handleSave = async () => {
     if (!guideId || !profile) return
     setSaveError('')
+    setSaveSuccess(false)
     setSaving(true)
     try {
-      const merged = { ...profile, bio, localStory }
+      const merged = { ...profile, bio, localStory, residenceYears: residenceYears ? Number(residenceYears) : undefined }
       const body = buildGuidePutBody(merged)
       const res = await apiRequest(`/guides/${guideId}`, { method: 'PUT', json: body })
       const text = await res.text()
@@ -65,6 +69,8 @@ export function GuideIntroEditPage() {
       setProfile(p)
       setBio(p?.bio ?? '')
       setLocalStory(p?.localStory ?? '')
+      setResidenceYears(p?.residenceYears != null ? String(p.residenceYears) : '')
+      setSaveSuccess(true)
     } catch {
       setSaveError('네트워크 오류')
     } finally {
@@ -104,6 +110,7 @@ export function GuideIntroEditPage() {
         지역 등은 <Link to="/guide/mypage/profile">프로필 등록</Link>에서 수정합니다.
       </p>
       {saveError && <p className="g-error">{saveError}</p>}
+      {saveSuccess && <p className="g-success">저장되었습니다.</p>}
 
       <div className="gm-stack" style={{ marginTop: '0.75rem', maxWidth: '40rem' }}>
         <div className="gm-field">
@@ -118,6 +125,17 @@ export function GuideIntroEditPage() {
             onChange={(e) => setLocalStory(e.target.value)}
             rows={8}
             maxLength={4000}
+          />
+        </div>
+        <div className="gm-field">
+          <label htmlFor="gi-years">거주 연수 (residenceYears)</label>
+          <input
+            id="gi-years"
+            type="number"
+            min={0}
+            value={residenceYears}
+            onChange={(e) => setResidenceYears(e.target.value.replace(/[^\d]/g, ''))}
+            placeholder="예: 15"
           />
         </div>
         <div className="gm-actions">

--- a/frontend/src/pages/GuideMypagePages.css
+++ b/frontend/src/pages/GuideMypagePages.css
@@ -89,6 +89,11 @@
   border: 1px solid #d1d5db;
 }
 
+.gm-btn--danger {
+  background: #b91c1c;
+  color: #fff;
+}
+
 .gm-split {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/frontend/src/pages/GuideProfileEditPage.jsx
+++ b/frontend/src/pages/GuideProfileEditPage.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { apiRequest } from '../api/client.js'
 import { useResolvedGuideId } from '../hooks/useResolvedGuideId.js'
@@ -6,6 +6,29 @@ import { buildGuidePutBody } from '../lib/guideProfilePayload.js'
 
 import '../layouts/GuideDashboardLayout.css'
 import './GuideMypagePages.css'
+
+function useToast() {
+  const [toasts, setToasts] = useState([])
+  const addToast = useCallback((message, type = 'success') => {
+    const id = Date.now() + Math.random()
+    setToasts((prev) => [...prev, { id, message, type }])
+    setTimeout(() => setToasts((prev) => prev.filter((t) => t.id !== id)), 2000)
+  }, [])
+  return { toasts, addToast }
+}
+
+function Toast({ toasts }) {
+  if (toasts.length === 0) return null
+  return (
+    <div style={{ position: 'fixed', bottom: '1.5rem', right: '1.5rem', zIndex: 9999, display: 'flex', flexDirection: 'column', gap: '0.5rem', pointerEvents: 'none' }}>
+      {toasts.map((t) => (
+        <div key={t.id} style={{ padding: '0.7rem 1.2rem', borderRadius: 10, background: t.type === 'success' ? '#15803d' : '#b91c1c', color: '#fff', fontSize: '0.88rem', fontWeight: 600, boxShadow: '0 4px 16px rgba(0,0,0,0.18)', minWidth: 180, maxWidth: 320 }}>
+          {t.message}
+        </div>
+      ))}
+    </div>
+  )
+}
 
 async function readJsonError(res, text) {
   try {
@@ -20,8 +43,9 @@ export function GuideProfileEditPage() {
   const { guideId, loading: idLoading, error: idError } = useResolvedGuideId()
   const [profile, setProfile] = useState(null)
   const [tagInput, setTagInput] = useState('')
+  const { toasts, addToast } = useToast()
+  const photoInputRef = useRef(null)
   const [loadError, setLoadError] = useState('')
-  const [saveError, setSaveError] = useState('')
   const [saving, setSaving] = useState(false)
 
   const load = useCallback(async (id) => {
@@ -73,29 +97,29 @@ export function GuideProfileEditPage() {
 
   const handleSave = async () => {
     if (!guideId || !profile) return
-    setSaveError('')
     setSaving(true)
     try {
       const body = buildGuidePutBody(profile)
       if (!body.nickname || !body.region || !body.language) {
-        setSaveError('닉네임, 활동 지역, 언어는 필수입니다.')
+        addToast('닉네임, 활동 지역, 언어는 필수입니다.', 'error')
         setSaving(false)
         return
       }
       if (!body.pricePerHour || body.pricePerHour <= 0) {
-        setSaveError('시간당 가격은 0보다 커야 합니다. (비용 메뉴에서 종일 패키지로 설정할 수 있습니다.)')
+        addToast('시간당 가격은 0보다 커야 합니다. (비용 메뉴에서 종일 패키지로 설정할 수 있습니다.)', 'error')
         setSaving(false)
         return
       }
       const res = await apiRequest(`/guides/${guideId}`, { method: 'PUT', json: body })
       const text = await res.text()
       if (!res.ok) {
-        setSaveError(await readJsonError(res, text))
+        addToast(await readJsonError(res, text), 'error')
         return
       }
       setProfile(text ? JSON.parse(text) : profile)
+      addToast('저장되었습니다.')
     } catch {
-      setSaveError('네트워크 오류')
+      addToast('네트워크 오류', 'error')
     } finally {
       setSaving(false)
     }
@@ -139,17 +163,27 @@ export function GuideProfileEditPage() {
         <h1>가이드 프로필 등록 📸</h1>
         <p>여행자들에게 보일 기본 정보를 입력해주세요.</p>
       </section>
-      {saveError && <p className="g-error">{saveError}</p>}
-
       <div className="gpv-profile-row">
         <div
           className="gpv-photo"
           style={profile.profileImage ? { backgroundImage: `url(${profile.profileImage})` } : undefined}
         />
         <div className="gpv-photo-actions">
-          <button type="button" className="gpv-photo-btn">
+          <button type="button" className="gpv-photo-btn" onClick={() => photoInputRef.current?.click()}>
             사진 변경
           </button>
+          <input
+            ref={photoInputRef}
+            type="file"
+            accept="image/*"
+            style={{ display: 'none' }}
+            onChange={(e) => {
+              const file = e.target.files?.[0]
+              if (!file) return
+              setField('profileImage', URL.createObjectURL(file))
+              e.target.value = ''
+            }}
+          />
           <details className="gpv-photo-url-box">
             <summary>이미지 URL 직접 입력</summary>
             <input
@@ -228,12 +262,33 @@ export function GuideProfileEditPage() {
           </div>
         </div>
 
+        <div className="gpv-field">
+          <label htmlFor="gp-course">기본 코스</label>
+          <input
+            id="gp-course"
+            value={profile.defaultCourse ?? ''}
+            onChange={(e) => setField('defaultCourse', e.target.value)}
+            placeholder="예: 골목 투어 → 전통 시장 → 야경"
+          />
+        </div>
+
+        <div className="gpv-field">
+          <label htmlFor="gp-style">가이드 스타일</label>
+          <input
+            id="gp-style"
+            value={profile.guideStyle ?? ''}
+            onChange={(e) => setField('guideStyle', e.target.value)}
+            placeholder="예: 편안하고 친근한 동네 산책형"
+          />
+        </div>
+
         <div className="gpv-save-row">
           <button type="button" className="gpv-save" onClick={() => void handleSave()} disabled={saving}>
             {saving ? '저장 중…' : '저장하기'}
           </button>
         </div>
       </div>
+      <Toast toasts={toasts} />
     </div>
   )
 }

--- a/frontend/src/pages/GuideSettingsPage.jsx
+++ b/frontend/src/pages/GuideSettingsPage.jsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 
 import { PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client.js'
@@ -7,6 +7,29 @@ import { useResolvedGuideId } from '../hooks/useResolvedGuideId.js'
 
 import '../layouts/GuideDashboardLayout.css'
 import './GuideMypagePages.css'
+
+function useToast() {
+  const [toasts, setToasts] = useState([])
+  const addToast = useCallback((message, type = 'success') => {
+    const id = Date.now() + Math.random()
+    setToasts((prev) => [...prev, { id, message, type }])
+    setTimeout(() => setToasts((prev) => prev.filter((t) => t.id !== id)), 2000)
+  }, [])
+  return { toasts, addToast }
+}
+
+function Toast({ toasts }) {
+  if (toasts.length === 0) return null
+  return (
+      <div style={{ position: 'fixed', bottom: '1.5rem', right: '1.5rem', zIndex: 9999, display: 'flex', flexDirection: 'column', gap: '0.5rem', pointerEvents: 'none' }}>
+        {toasts.map((t) => (
+            <div key={t.id} style={{ padding: '0.7rem 1.2rem', borderRadius: 10, background: t.type === 'success' ? '#15803d' : '#b91c1c', color: '#fff', fontSize: '0.88rem', fontWeight: 600, boxShadow: '0 4px 16px rgba(0,0,0,0.18)', minWidth: 180, maxWidth: 320 }}>
+              {t.message}
+            </div>
+        ))}
+      </div>
+  )
+}
 
 async function readJsonError(res, text) {
   try {
@@ -19,15 +42,16 @@ async function readJsonError(res, text) {
 
 export function GuideSettingsPage() {
   const { guideId, loading: idLoading, error: idError } = useResolvedGuideId()
+  const navigate = useNavigate()
+  const { toasts, addToast } = useToast()
   const [profile, setProfile] = useState(null)
   const [summary, setSummary] = useState(null)
   const [loadError, setLoadError] = useState('')
-  const [actionError, setActionError] = useState('')
   const [busy, setBusy] = useState(false)
+  const [withdrawing, setWithdrawing] = useState(false)
 
   const load = useCallback(async (id) => {
     setLoadError('')
-    setActionError('')
     try {
       const [pr, sr] = await Promise.all([
         apiRequest(`/guides/${id}`, { method: 'GET', skipAuth: true }),
@@ -56,92 +80,173 @@ export function GuideSettingsPage() {
   const toggleActive = async () => {
     if (!guideId) return
     setBusy(true)
-    setActionError('')
     try {
       const res = await apiRequest(`/guides/${guideId}/active`, { method: 'PATCH' })
       const text = await res.text()
       if (!res.ok) {
-        setActionError(await readJsonError(res, text))
+        addToast(await readJsonError(res, text), 'error')
         return
       }
       setProfile(text ? JSON.parse(text) : profile)
+      addToast('전환되었습니다.')
     } catch {
-      setActionError('요청 실패')
+      addToast('요청 실패', 'error')
     } finally {
       setBusy(false)
     }
   }
 
+  const handleWithdraw = async () => {
+    if (!window.confirm('가이드 계정을 탈퇴하시겠습니까? 이 작업은 되돌릴 수 없습니다.')) return
+    setWithdrawing(true)
+    try {
+      const res = await apiRequest('/members/me?role=GUIDE', { method: 'DELETE' })
+      const text = await res.text()
+      if (!res.ok) {
+        addToast(await readJsonError(res, text), 'error')
+        return
+      }
+      navigate('/auth/login', { replace: true })
+    } catch {
+      addToast('탈퇴 요청 실패', 'error')
+    } finally {
+      setWithdrawing(false)
+    }
+  }
+
   if (idLoading) {
     return (
-      <div className="g-panel">
-        <PageLoading />
-      </div>
+        <div className="g-panel">
+          <PageLoading />
+        </div>
     )
   }
 
   if (idError) {
     return (
-      <div className="g-panel">
-        <PageError message={idError} />
-      </div>
+        <div className="g-panel">
+          <PageError message={idError} />
+        </div>
     )
   }
 
   if (loadError) {
     return (
-      <div className="g-panel">
-        <PageError message={loadError} onRetry={() => guideId != null && void load(guideId)} />
-      </div>
+        <div className="g-panel">
+          <PageError message={loadError} onRetry={() => guideId != null && void load(guideId)} />
+        </div>
     )
   }
 
   return (
-    <div className="g-panel">
-      <h1>🔧 가이드 설정</h1>
-      <p className="g-hint">
-        노출·요금은 <Link to="/guide/mypage/fees">가이드 비용</Link>, 프로필 필드는{' '}
-        <Link to="/guide/mypage/profile">프로필 등록</Link>에서 수정합니다. 여기서는 서버에 있는 토글·승인·리뷰 요약만
-        다룹니다.
-      </p>
-      {actionError && <p className="g-error">{actionError}</p>}
+      <div className="g-panel">
+        <h1>🔧 가이드 설정</h1>
+        <p className="g-hint">
+          노출·요금은 <Link to="/guide/mypage/fees">가이드 비용</Link>, 프로필 필드는{' '}
+          <Link to="/guide/mypage/profile">프로필 등록</Link>에서 수정합니다. 여기서는 서버에 있는 토글·승인·리뷰 요약만
+          다룹니다.
+        </p>
+        <div className="gm-stack" style={{ marginTop: '1rem', maxWidth: '32rem' }}>
 
-      <div className="gm-stack" style={{ marginTop: '1rem', maxWidth: '32rem' }}>
-        <section className="gm-card">
-          <h2>활성화</h2>
-          <p className="gm-hint">
-            <code>PATCH /api/guides/&#123;guideId&#125;/active</code> — 서버에서 활성 여부를 토글합니다.
-          </p>
-          <p style={{ margin: '0.5rem 0', fontSize: '0.9rem' }}>
-            현재 상태: <strong>{profile?.isActive ? '활성' : '비활성'}</strong>
-          </p>
-          <button type="button" className="gm-btn" onClick={() => void toggleActive()} disabled={busy}>
-            {busy ? '처리 중…' : '활성 / 비활성 전환'}
-          </button>
-        </section>
+          {/* 활성화 섹션 */}
+          <section className="gm-card">
+            <h2>활성화</h2>
+            <p className="gm-hint">
+              <code>PATCH /api/guides/&#123;guideId&#125;/active</code> — 서버에서 활성 여부를 토글합니다.
+            </p>
+            <p style={{ margin: '0.5rem 0', fontSize: '0.9rem' }}>
+              현재 상태:{' '}
+              <strong style={{ color: profile?.isActive ? '#15803d' : '#b91c1c' }}>
+                {profile?.isActive ? '활성' : '비활성'}
+              </strong>
+            </p>
+            <div style={{ display: 'flex', gap: '0.6rem', marginTop: '0.5rem' }}>
+              {/* 활성화 버튼 */}
+              <button
+                  type="button"
+                  onClick={() => { if (!profile?.isActive) void toggleActive() }}
+                  disabled={busy || !!profile?.isActive}
+                  style={{
+                    padding: '0.5rem 1.2rem',
+                    borderRadius: 8,
+                    border: 'none',
+                    cursor: profile?.isActive ? 'default' : 'pointer',
+                    fontWeight: 600,
+                    fontSize: '0.9rem',
+                    background: profile?.isActive ? '#15803d' : '#e5e7eb',
+                    color: profile?.isActive ? '#fff' : '#6b7280',
+                    opacity: busy ? 0.6 : 1,
+                    transition: 'background 0.2s',
+                  }}
+              >
+                ✅ 활성화
+              </button>
+              {/* 비활성화 버튼 */}
+              <button
+                  type="button"
+                  onClick={() => { if (profile?.isActive) void toggleActive() }}
+                  disabled={busy || !profile?.isActive}
+                  style={{
+                    padding: '0.5rem 1.2rem',
+                    borderRadius: 8,
+                    border: 'none',
+                    cursor: !profile?.isActive ? 'default' : 'pointer',
+                    fontWeight: 600,
+                    fontSize: '0.9rem',
+                    background: !profile?.isActive ? '#b91c1c' : '#e5e7eb',
+                    color: !profile?.isActive ? '#fff' : '#6b7280',
+                    opacity: busy ? 0.6 : 1,
+                    transition: 'background 0.2s',
+                  }}
+              >
+                ⛔ 비활성화
+              </button>
+            </div>
+          </section>
 
-        <section className="gm-card">
-          <h2>관리자 승인</h2>
-          <p style={{ margin: 0, fontSize: '0.9rem' }}>
-            승인 여부: <strong>{profile?.isApproved ? '승인됨' : '미승인'}</strong>
-          </p>
-          <p className="gm-hint" style={{ marginTop: '0.5rem' }}>
-            승인 API는 관리자용 <code>PATCH /guides/&#123;id&#125;/approve</code> 입니다. 일반 가이드 계정에서는 호출하지
-            않습니다.
-          </p>
-        </section>
+          {/* 관리자 승인 섹션 */}
+          <section className="gm-card">
+            <h2>관리자 승인</h2>
+            <p style={{ margin: 0, fontSize: '0.9rem' }}>
+              승인 여부: <strong>{profile?.isApproved ? '승인됨' : '미승인'}</strong>
+            </p>
+            <p className="gm-hint" style={{ marginTop: '0.5rem' }}>
+              승인 API는 관리자용 <code>PATCH /guides/&#123;id&#125;/approve</code> 입니다. 일반 가이드 계정에서는 호출하지
+              않습니다.
+            </p>
+          </section>
 
-        <section className="gm-card">
-          <h2>리뷰 요약</h2>
-          <p className="gm-hint">
-            <code>GET /api/guides/&#123;guideId&#125;/reviews/summary</code>
-          </p>
-          <p style={{ margin: '0.5rem 0 0', fontSize: '0.95rem' }}>
-            평균 평점: <strong>{summary?.averageRating != null ? Number(summary.averageRating).toFixed(2) : '—'}</strong>{' '}
-            / 리뷰 수: <strong>{summary?.reviewCount ?? '—'}</strong>
-          </p>
-        </section>
+          {/* 계정 탈퇴 섹션 */}
+          <section className="gm-card">
+            <h2>계정 탈퇴</h2>
+            <p className="gm-hint">
+              <code>DELETE /members/me?role=GUIDE</code> — 가이드 자격을 탈퇴합니다. 탈퇴 후에는 가이드 기능을 사용할 수
+              없습니다.
+            </p>
+            <button
+                type="button"
+                className="gm-btn gm-btn--danger"
+                onClick={() => void handleWithdraw()}
+                disabled={withdrawing}
+            >
+              {withdrawing ? '처리 중…' : '가이드 탈퇴'}
+            </button>
+          </section>
+
+          {/* 리뷰 요약 섹션 */}
+          <section className="gm-card">
+            <h2>리뷰 요약</h2>
+            <p className="gm-hint">
+              <code>GET /api/guides/&#123;guideId&#125;/reviews/summary</code>
+            </p>
+            <p style={{ margin: '0.5rem 0 0', fontSize: '0.95rem' }}>
+              평균 평점: <strong>{summary?.averageRating != null ? Number(summary.averageRating).toFixed(2) : '—'}</strong>{' '}
+              / 리뷰 수: <strong>{summary?.reviewCount ?? '—'}</strong>
+            </p>
+          </section>
+
+        </div>
+        <Toast toasts={toasts} />
       </div>
-    </div>
   )
 }


### PR DESCRIPTION
# 🔗 이슈 번호
- Closes #301

---

## 💡 주요 변경 사항

가이드 마이페이지 및 가이드 스케줄 관리 플로우를 전반적으로 수정했습니다.

### 프론트엔드
- `GuideProfileEditPage.jsx`
  - Toast 알림 적용
  - 프로필 사진 업로드 처리 개선 (`useRef`)
  - `defaultCourse`, `guideStyle` 필드 추가
- `GuideFeesPage.jsx`
  - 활성화 토글 PATCH 연동
  - 기존 알림을 Toast로 교체
  - `isActive` 처리 개선
- `GuideSettingsPage.jsx`
  - 회원탈퇴 기능 추가 (`DELETE /members/me`)
  - `toggleActive` 성공 시 Toast 표시
- `GuideFeedSchedulePage.jsx`
  - 기존 슬롯 추가 방식 제거
  - 날짜 차단 / 해제(Block / Unblock) 방식으로 UI 및 동작 패러다임 전환
- `GuideDetailPage.jsx`
  - `formatLocalTime()` 추가
  - API 객체형 시간 응답 파싱 처리
- `GuideApplyPage.jsx`
  - 성공 후 이동 경로를 `/guide/mypage`로 수정

### CSS
- `GuideDashboardLayout.css`
  - `.g-success` 스타일 추가
- `GuideMypagePages.css`
  - `.gm-btn--danger` 스타일 추가

### 백엔드
가이드 스케줄 관리 방식을  
**“슬롯 등록 방식” → “기본 전체 오픈 + BLOCKED 날짜 잠금 방식”** 으로 변경했습니다.

- `BlockDateRequest.java`
  - 날짜 차단 요청용 DTO 추가
- `GuideScheduleRepository.java`
  - `findByGuideProfile_IdAndAvailableDate()` 추가
- `GuideScheduleService.java`
  - `getBlockedDates`, `blockDate`, `unblockDate` 메서드 추가
- `GuideScheduleController.java`
  - `GET /guides/{guideId}/schedules/blocked`
  - `POST /guides/{guideId}/schedules/block`
  - `DELETE /guides/{guideId}/schedules/block(ed)` 관련 엔드포인트 추가

---

## ⚠️ 주의 사항 / 질문

- 이번 작업의 핵심은 **가이드 스케줄 관리 패러다임 변경**입니다.  
  기존 슬롯 등록 기반 로직과 충돌 가능성이 없는지 중점적으로 봐주시면 좋겠습니다.
- 프론트 `GuideFeedSchedulePage`와 백엔드 스케줄 API가 새 Block/Unblock 흐름에 맞게 잘 연결되었는지 확인 부탁드립니다.
- `GuideProfileEditPage`의 프로필 사진 원형 CSS가 즉시 반영되지 않는 현상이 있었는데, HMR 캐시 이슈 가능성이 있어 실제 새로고침 기준으로도 확인 부탁드립니다.
- `GuideDetailPage`의 시간 파싱은 API 응답이 객체형으로 내려오는 경우를 기준으로 처리했습니다. 다른 시간 응답 형식과의 호환 여부도 확인 부탁드립니다.

---

## ✅ 체크리스트
- [ ] 빌드가 정상적으로 되는가?
- [ ] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [ ] .gitignore에 설정 파일이 잘 포함되었는가? (application-local.yml 등)