### PR TITLE
k6 deploy 구축

### DIFF
--- a/.github/workflows/k6-deploy.yml.yml
+++ b/.github/workflows/k6-deploy.yml.yml
@@ -1,0 +1,23 @@
+name: Deploy k6 Scripts
+
+on:
+  push:
+    paths:
+      - 'stress-test/**' # stress-test 폴더 내 파일 변경 시에만 실행
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Copy scripts to k6 EC2
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.K6_SERVER_HOST }}
+          username: ${{ secrets.K6_SERVER_USER }}
+          key: ${{ secrets.K6_SERVER_KEY }}
+          source: "stress-test/scripts/*"
+          target: "/home/ubuntu/stress-test"
+          strip_components: 1 # 폴더 구조를 유지하지 않고 scripts 안의 내용만 보낼 때 사용

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,26 +5,11 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="84d1b3de-8103-452e-83cf-38ecd34993e7" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/.gitignore" beforeDir="false" afterPath="$PROJECT_DIR$/.gitignore" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/.gitignore" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/LocalGuest.iml" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/compiler.xml" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/gradle.xml" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/misc.xml" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/modules.xml" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/modules/api-server/api-server_main.iml" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/modules/api-server/backend.api-server.main.iml" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/modules/module-ai-integration/backend.module-ai-integration.main.iml" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/modules/module-ai-integration/module-ai-integration_main.iml" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/modules/module-ai/backend.module-ai.main.iml" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/modules/module-ai/module-ai_main.iml" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/modules/module-auth/backend.module-auth.main.iml" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/modules/module-chat/backend.module-chat.main.iml" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/modules/module-chat/module-chat_main.iml" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/modules/module-common/backend.module-common.main.iml" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/modules/module-common/module-common_main.iml" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/modules/module-domain/backend.module-domain.main.iml" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/modules/module-domain/module-domain_main.iml" beforeDir="false" />
+      <change afterPath="$PROJECT_DIR$/.github/workflows/stress_test_cicd.yml" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/backend/module-common/src/main/java/com/team6/module/common/global/stressTest/StressTestController.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/stress-test/scripts/test1.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/backend/api-server/src/main/resources/application.yml" beforeDir="false" afterPath="$PROJECT_DIR$/backend/api-server/src/main/resources/application.yml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -53,41 +38,69 @@
       </state>
     </system>
   </component>
+  <component name="FileTemplateManagerImpl">
+    <option name="RECENT_TEMPLATES">
+      <list>
+        <option value="Class" />
+        <option value="GitHub Workflow" />
+      </list>
+    </option>
+  </component>
   <component name="Git.Settings">
     <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
   </component>
+  <component name="GithubPullRequestsUISettings"><![CDATA[{
+  "selectedUrlAndAccountId": {
+    "url": "https://github.com/changhyunmoon/LocalGuest.git",
+    "accountId": "ab2dd1a0-5e0b-4833-8ecb-19fd2fed9f7e"
+  }
+}]]></component>
   <component name="ProjectColorInfo">{
   &quot;associatedIndex&quot;: 6
 }</component>
   <component name="ProjectId" id="3CUUfaDPnzSfpshZ55xkgJA2fum" />
+  <component name="ProjectLevelVcsManager">
+    <ConfirmationsSetting value="2" id="Add" />
+  </component>
   <component name="ProjectViewState">
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;Gradle.Build backend.executor&quot;: &quot;Run&quot;,
-    &quot;ModuleVcsDetector.initialDetectionPerformed&quot;: &quot;true&quot;,
-    &quot;RequestMappingsPanelOrder0&quot;: &quot;0&quot;,
-    &quot;RequestMappingsPanelOrder1&quot;: &quot;1&quot;,
-    &quot;RequestMappingsPanelWidth0&quot;: &quot;75&quot;,
-    &quot;RequestMappingsPanelWidth1&quot;: &quot;75&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.typescript.service.memoryLimit.init&quot;: &quot;true&quot;,
-    &quot;Spring Boot.ApiServerApplication.executor&quot;: &quot;Run&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;Feat/be#305&quot;,
-    &quot;kotlin-language-version-configured&quot;: &quot;true&quot;,
-    &quot;last_opened_file_path&quot;: &quot;C:/Team6LocalGuest_4&quot;,
-    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
-    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
-    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
-    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
-    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "Gradle.Build backend.executor": "Run",
+    "ModuleVcsDetector.initialDetectionPerformed": "true",
+    "RequestMappingsPanelOrder0": "0",
+    "RequestMappingsPanelOrder1": "1",
+    "RequestMappingsPanelWidth0": "75",
+    "RequestMappingsPanelWidth1": "75",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "RunOnceActivity.typescript.service.memoryLimit.init": "true",
+    "Spring Boot.ApiServerApplication.executor": "Run",
+    "git-widget-placeholder": "Feat/be#320",
+    "kotlin-language-version-configured": "true",
+    "last_opened_file_path": "C:/mch/programmers/LocalGuest",
+    "node.js.detected.package.eslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "vue.rearranger.settings.migration": "true"
   }
-}</component>
+}]]></component>
   <component name="RunManager">
+    <configuration default="true" type="JetRunConfigurationType">
+      <module name="backend.module-ai.main" />
+      <method v="2">
+        <option name="Make" enabled="true" />
+      </method>
+    </configuration>
+    <configuration default="true" type="KotlinStandaloneScriptRunConfigurationType">
+      <module name="backend.module-ai.main" />
+      <option name="filePath" />
+      <method v="2" />
+    </configuration>
     <configuration name="ApiServerApplication" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot" nameIsGenerated="true">
       <module name="backend.api-server.main" />
       <option name="SPRING_BOOT_MAIN_CLASS" value="com.team6.apiserver.ApiServerApplication" />

--- a/backend/api-server/src/main/resources/application.yml
+++ b/backend/api-server/src/main/resources/application.yml
@@ -1,44 +1,6 @@
-# 프론트(Vite) 기본 API 베이스 `/api`·OAuth redirect-uri(`/api/login/...`)와 맞춘다.
-# 이 값이 없으면 컨트롤러는 `/chat/...`에만 붙고, 클라이언트는 `/api/chat/...`로 호출해 404(정적 리소스)가 난다.
-server:
-  servlet:
-    context-path: /api
-
 spring:
   profiles:
     active: local
-    # 초기 include 코드
-    # include : secret
-    include: secret-local
-
-  security:
-    oauth2:
-      client:
-        registration:
-          google:
-            client-id: ${GOOGLE_CLIENT_ID}        # 환경변수로 관리
-            client-secret: ${GOOGLE_CLIENT_SECRET} # 환경변수로 관리
-            scope:
-              - email
-              - profile
-            redirect-uri: http://localhost:8080/api/login/oauth2/code/google
-        provider:
-          google:
-            authorization-uri: https://accounts.google.com/o/oauth2/auth
-            token-uri: https://oauth2.googleapis.com/token
-            user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
-  mail:
-    host: ${MAIL_HOST:smtp.gmail.com}           # 환경변수 MAIL_HOST 값 사용
-    port: ${MAIL_PORT:587}       # 환경변수 없으면 기본값 587
-    # 로컬에서 MAIL_* 미설정이어도 부팅은 되어야 한다. (메일 기능은 미동작 가능)
-    username: ${MAIL_USERNAME:}
-    password: ${MAIL_PASSWORD:}
-    properties:
-      mail:
-        smtp:
-          auth: true
-          starttls:
-            enable: true
 
 ---
 spring:

--- a/backend/module-common/src/main/java/com/team6/module/common/global/stressTest/StressTestController.java
+++ b/backend/module-common/src/main/java/com/team6/module/common/global/stressTest/StressTestController.java
@@ -1,0 +1,56 @@
+package com.team6.module.common.global.stressTest;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@RestController
+@RequestMapping("/stress-test")
+public class StressTestController {
+
+    /**
+     * 1. CPU 부하 테스트 (복잡한 연산)
+     * k6에서 요청을 보낼 때 'loop' 파라미터로 난이도를 조절하세요.
+     */
+    @GetMapping("/cpu")
+    public ResponseEntity<String> cpuStress(@RequestParam(defaultValue = "100000") int loop) {
+        long sum = 0;
+        for (int i = 0; i < loop; i++) {
+            sum += Math.sqrt(i) * Math.atan(i); // 의미 없는 연산 반복
+        }
+        return ResponseEntity.ok("CPU Stress Success: " + sum);
+    }
+
+    /**
+     * 2. 메모리 부하 테스트 (객체 생성)
+     * 주의: 너무 크게 잡으면 Heap Space Error로 서버가 죽을 수 있습니다.
+     */
+    @GetMapping("/memory")
+    public ResponseEntity<String> memoryStress(@RequestParam(defaultValue = "10000") int size) {
+        List<String> list = new ArrayList<>();
+        for (int i = 0; i < size; i++) {
+            list.add(UUID.randomUUID().toString()); // 랜덤 문자열로 메모리 점유
+        }
+        return ResponseEntity.ok("Memory Stress Success: Allocated " + list.size() + " objects");
+    }
+
+    /**
+     * 3. 지연 시간 테스트 (Thread Sleep)
+     * DB나 외부 API 호출 시의 병목 현상을 시뮬레이션합니다.
+     */
+    @GetMapping("/delay")
+    public ResponseEntity<String> delayStress(@RequestParam(defaultValue = "500") int ms) {
+        try {
+            Thread.sleep(ms); // 의도적 지연
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        return ResponseEntity.ok("Delay Stress Success: " + ms + "ms");
+    }
+
+}

--- a/stress-test/scripts/test1.js
+++ b/stress-test/scripts/test1.js
@@ -1,0 +1,14 @@
+import http from 'k6/http';
+import {sleep} from 'k6';
+
+export const options = {
+    stages: [
+        { duration: '10m', target: 6000 }// 10분 동안 6,000명까지 증가
+    ],
+};
+
+export default function() {
+    //테스트할 api
+    http.get('http://43.202.182.58:8080/api/stress-test/cpu')
+    sleep(1);
+}


### PR DESCRIPTION
# 🔗 이슈 번호
- Closes #320 

---

## 💡 주요 변경 사항
부하 테스트 전용 컨트롤러 추가: 서버 자원(CPU, Memory, Delay) 성능 측정을 위한 테스트용 API 엔드포인트 구현 (/api/v1/stress-test/**)

k6 부하 테스트 시나리오 작성: stress-test/scripts/ 폴더 내에 JavaScript 기반의 단계별(Stages) 부하 테스트 스크립트 작성

GitHub Actions 배포 자동화: stress-test 폴더 변경 시 SCP를 통해 k6 전용 EC2 서버로 자동 배포되는 CI/CD 파이프라인 구축 (k6-deploy.yml)

---

## ⚠️ 주의 사항 / 질문
리뷰어가 중점적으로 봐주었으면 하는 부분이나 고민되는 지점을 적어주세요.

---

## ✅ 체크리스트
- [ ] 빌드가 정상적으로 되는가?
- [ ] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [ ] .gitignore에 설정 파일이 잘 포함되었는가? (application-local.yml 등)