### PR TITLE
Feat/fe#322: 매칭 코스 미리보기/결제 플로우 UX 개선 및 결제 오류 수정

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,26 +5,15 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="84d1b3de-8103-452e-83cf-38ecd34993e7" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/.gitignore" beforeDir="false" afterPath="$PROJECT_DIR$/.gitignore" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/.gitignore" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/LocalGuest.iml" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/compiler.xml" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/gradle.xml" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/misc.xml" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/modules.xml" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/modules/api-server/api-server_main.iml" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/modules/api-server/backend.api-server.main.iml" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/modules/module-ai-integration/backend.module-ai-integration.main.iml" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/modules/module-ai-integration/module-ai-integration_main.iml" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/modules/module-ai/backend.module-ai.main.iml" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/modules/module-ai/module-ai_main.iml" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/modules/module-auth/backend.module-auth.main.iml" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/modules/module-chat/backend.module-chat.main.iml" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/modules/module-chat/module-chat_main.iml" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/modules/module-common/backend.module-common.main.iml" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/modules/module-common/module-common_main.iml" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/modules/module-domain/backend.module-domain.main.iml" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/modules/module-domain/module-domain_main.iml" beforeDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/backend/module-domain/src/main/java/com/team6/domain/matching/entity/MatchRequest.java" beforeDir="false" afterPath="$PROJECT_DIR$/backend/module-domain/src/main/java/com/team6/domain/matching/entity/MatchRequest.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/backend/module-domain/src/main/java/com/team6/domain/matching/service/PaymentService.java" beforeDir="false" afterPath="$PROJECT_DIR$/backend/module-domain/src/main/java/com/team6/domain/matching/service/PaymentService.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/AiQuickSearchPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/AiQuickSearchPage.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideCoursePanel.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideCoursePanel.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideInboxPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideInboxPage.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideMatchOptionsPage.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideMatchOptionsPage.css" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideMatchOptionsPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideMatchOptionsPage.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideProposalPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideProposalPage.jsx" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -56,37 +45,45 @@
   <component name="Git.Settings">
     <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
   </component>
+  <component name="McpProjectServerCommands">
+    <commands />
+    <urls />
+  </component>
   <component name="ProjectColorInfo">{
   &quot;associatedIndex&quot;: 6
 }</component>
   <component name="ProjectId" id="3CUUfaDPnzSfpshZ55xkgJA2fum" />
+  <component name="ProjectLevelVcsManager">
+    <ConfirmationsSetting value="1" id="Add" />
+  </component>
   <component name="ProjectViewState">
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;Gradle.Build backend.executor&quot;: &quot;Run&quot;,
-    &quot;ModuleVcsDetector.initialDetectionPerformed&quot;: &quot;true&quot;,
-    &quot;RequestMappingsPanelOrder0&quot;: &quot;0&quot;,
-    &quot;RequestMappingsPanelOrder1&quot;: &quot;1&quot;,
-    &quot;RequestMappingsPanelWidth0&quot;: &quot;75&quot;,
-    &quot;RequestMappingsPanelWidth1&quot;: &quot;75&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.typescript.service.memoryLimit.init&quot;: &quot;true&quot;,
-    &quot;Spring Boot.ApiServerApplication.executor&quot;: &quot;Run&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;Feat/be#305&quot;,
-    &quot;kotlin-language-version-configured&quot;: &quot;true&quot;,
-    &quot;last_opened_file_path&quot;: &quot;C:/Team6LocalGuest_4&quot;,
-    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
-    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
-    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
-    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
-    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "Gradle.Build backend.executor": "Run",
+    "Gradle.backend 빌드.executor": "Run",
+    "ModuleVcsDetector.initialDetectionPerformed": "true",
+    "RequestMappingsPanelOrder0": "0",
+    "RequestMappingsPanelOrder1": "1",
+    "RequestMappingsPanelWidth0": "75",
+    "RequestMappingsPanelWidth1": "75",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "RunOnceActivity.typescript.service.memoryLimit.init": "true",
+    "Spring Boot.ApiServerApplication.executor": "Run",
+    "git-widget-placeholder": "main",
+    "kotlin-language-version-configured": "true",
+    "last_opened_file_path": "C:/Team6LocalGuest_4",
+    "node.js.detected.package.eslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "vue.rearranger.settings.migration": "true"
   }
-}</component>
+}]]></component>
   <component name="RunManager">
     <configuration name="ApiServerApplication" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot" nameIsGenerated="true">
       <module name="backend.api-server.main" />

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/entity/MatchRequest.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/entity/MatchRequest.java
@@ -158,10 +158,12 @@ public class MatchRequest extends BaseTimeEntity {
     }
 
     /**
-     * 결제 완료 시 매칭 요청을 PAID로 전이한다. 이미 PAID 이후이면 변경하지 않는다(연장 결제 등).
+     * 결제 완료 시 매칭 요청을 PAID로 전이한다.
+     * 제시안 이전(PENDING) 결제 플로우도 허용하므로 PENDING/ACCEPTED 모두 PAID로 전이한다.
+     * 이미 PAID 이후이면 변경하지 않는다(연장 결제 등).
      */
-    public void markAsPaidIfAccepted() {
-        if (this.status == MatchRequestStatus.ACCEPTED) {
+    public void markAsPaidIfAcceptedOrPending() {
+        if (this.status == MatchRequestStatus.ACCEPTED || this.status == MatchRequestStatus.PENDING) {
             this.status = MatchRequestStatus.PAID;
             log.info("[Payment] 매칭 요청 결제 반영 — status=PAID, requestId={}", this.id);
         }

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/service/PaymentService.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/service/PaymentService.java
@@ -48,7 +48,8 @@ public class PaymentService {
 
     /**
      * 결제 요청 생성 — PENDING, Stub PG 주문번호 발급.
-     * 매칭 요청이 게스트 소유이며 ACCEPTED 일 때만 가능. (match_request_id, payment_type) 중복 불가.
+     * 매칭 요청이 게스트 소유이며 PENDING/ACCEPTED 일 때 가능.
+     * 동일 (match_request_id, payment_type) 재요청은 기존 결제를 재사용해 멱등 처리한다.
      */
     public PaymentResponseDto createPayment(Long guestId, PaymentCreateRequest request) {
         MatchRequest matchRequest = matchRequestRepository.findById(request.getMatchRequestId())
@@ -57,13 +58,34 @@ public class PaymentService {
         if (!matchRequest.getGuestId().equals(guestId)) {
             throw new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED);
         }
-        if (matchRequest.getStatus() != MatchRequestStatus.ACCEPTED) {
+        if (matchRequest.getStatus() != MatchRequestStatus.PENDING
+                && matchRequest.getStatus() != MatchRequestStatus.ACCEPTED) {
             throw new MatchingException(MatchingErrorCode.MATCH_REQUEST_INVALID_STATUS);
         }
 
-        if (paymentRepository.findByMatchRequest_IdAndPaymentType(matchRequest.getId(), request.getPaymentType())
-                .isPresent()) {
-            throw new MatchingException(MatchingErrorCode.PAYMENT_DUPLICATE_TYPE);
+        Payment existing = paymentRepository
+                .findByMatchRequest_IdAndPaymentType(matchRequest.getId(), request.getPaymentType())
+                .orElse(null);
+        if (existing != null) {
+            log.info("[Payment] 기존 결제 재사용 — paymentId={}, requestId={}, guestId={}, status={}, type={}",
+                    existing.getId(), matchRequest.getId(), guestId, existing.getStatus(), request.getPaymentType());
+            if (existing.getStatus() == PaymentStatus.PENDING && isKakaoProvider()) {
+                String partnerUserId = String.valueOf(guestId);
+                String itemName = "LocalGuest " + existing.getPaymentType();
+                KakaoPayClient.ReadyResult readyResult = kakaoPayClient.ready(
+                        existing.getPgOrderNo(),
+                        partnerUserId,
+                        itemName,
+                        existing.getAmount()
+                );
+                existing.storePgTransactionId(readyResult.tid());
+                return PaymentResponseDto.from(existing, readyResult.redirectUrl());
+            }
+            if (existing.getStatus() != PaymentStatus.PENDING
+                    && existing.getStatus() != PaymentStatus.COMPLETED) {
+                throw new MatchingException(MatchingErrorCode.PAYMENT_NOT_PENDING);
+            }
+            return PaymentResponseDto.from(existing);
         }
 
         String pgOrderNo = FakePgClient.STUB_PG_ORDER_PREFIX + UUID.randomUUID();
@@ -111,7 +133,9 @@ public class PaymentService {
         }
 
         if (payment.getStatus() == PaymentStatus.COMPLETED) {
-            throw new MatchingException(MatchingErrorCode.PAYMENT_ALREADY_COMPLETED);
+            log.info("[Payment] 이미 완료된 결제 재확인 요청 수신 — paymentId={}, pgOrderNo={}",
+                    payment.getId(), payment.getPgOrderNo());
+            return PaymentResponseDto.from(payment);
         }
         if (payment.getStatus() != PaymentStatus.PENDING) {
             throw new MatchingException(MatchingErrorCode.PAYMENT_NOT_PENDING);
@@ -121,6 +145,9 @@ public class PaymentService {
         if (isKakaoProvider()) {
             if (request.getPgToken() == null || request.getPgToken().isBlank()) {
                 throw new MatchingException(MatchingErrorCode.INVALID_REQUEST);
+            }
+            if (payment.getPgTransactionId() == null || payment.getPgTransactionId().isBlank()) {
+                throw new MatchingException(MatchingErrorCode.PAYMENT_PG_VERIFICATION_FAILED);
             }
             KakaoPayClient.ApproveResult approveResult = kakaoPayClient.approve(
                     payment.getPgTransactionId(),
@@ -135,7 +162,7 @@ public class PaymentService {
         }
 
         payment.complete(pgTransactionId);
-        payment.getMatchRequest().markAsPaidIfAccepted();
+        payment.getMatchRequest().markAsPaidIfAcceptedOrPending();
         syncGuideSchedulePaidSafely(payment);
 
         log.info("[Payment] Stub PG 승인 완료 — paymentId={}, pgTransactionId={}, paidAt={}, refundDeadline={}",

--- a/frontend/src/pages/AiQuickSearchPage.jsx
+++ b/frontend/src/pages/AiQuickSearchPage.jsx
@@ -411,7 +411,7 @@ export function AiQuickSearchPage() {
                                 feeds.slice(0, 6).map((f) => (
                                   <Link
                                     key={f.feedId}
-                                    to={`/guides/${g.guideId}/proposal`}
+                                    to={`/guides/${g.guideId}#match-request`}
                                     className="ais-feed-thumb"
                                     title={f.content ? String(f.content).slice(0, 80) : 'AI 추천 코스 상세보기'}
                                   >
@@ -424,7 +424,7 @@ export function AiQuickSearchPage() {
                                 ))
                               ) : (
                                 <Link
-                                  to={`/guides/${g.guideId}/proposal`}
+                                  to={`/guides/${g.guideId}#match-request`}
                                   className="ais-feed-empty"
                                   title="AI 추천 코스 상세보기"
                                 >
@@ -457,7 +457,7 @@ export function AiQuickSearchPage() {
                                 </div>
                               </div>
                               <Link
-                                to={`/guides/${g.guideId}/proposal`}
+                                to={`/guides/${g.guideId}#match-request`}
                                 className={`ais-profile-btn ${idx === 0 ? 'ais-profile-btn--primary' : ''}`}
                               >
                                 AI 추천 코스 상세보기

--- a/frontend/src/pages/GuideCoursePanel.jsx
+++ b/frontend/src/pages/GuideCoursePanel.jsx
@@ -81,7 +81,7 @@ export function parseCourseDetail(text) {
  *   guideId: number,
  *   schedule: { scheduleId: number, availableDate: string, startTime: string, endTime: string, destination?: string },
  *   onClose: () => void,
- *   onSaved: () => void,
+ *   onSaved: (savedForm?: { meetingPoint?: string, guideMessage?: string, courseDetail?: string, isPaid?: boolean }) => void,
  * }} props
  */
 export function GuideCoursePanel({ guideId, schedule, onClose, onSaved }) {
@@ -283,25 +283,60 @@ export function GuideCoursePanel({ guideId, schedule, onClose, onSaved }) {
     setSaveMsg('')
     setError('')
     try {
-      const res = await apiRequest(
+      const payload = {
+        meetingPoint: meetingPoint.trim(),
+        guideMessage: guideMessage.trim(),
+        courseDetail: serializeCourse(spots),
+      }
+      let res = await apiRequest(
         `/guides/${guideId}/schedules/${schedule.scheduleId}/form`,
         {
           method: 'PUT',
-          json: {
-            meetingPoint: meetingPoint.trim(),
-            guideMessage: guideMessage.trim(),
-            courseDetail: serializeCourse(spots),
-          },
+          json: payload,
         },
       )
-      const text = await res.text()
+      let text = await res.text()
+      if (!res.ok && res.status === 409) {
+        const acceptRes = await apiRequest(
+          `/guides/${guideId}/schedules/${schedule.scheduleId}/accept`,
+          { method: 'POST' },
+        )
+        const acceptText = await acceptRes.text()
+        if (!acceptRes.ok && acceptRes.status !== 409) {
+          const aj = (() => { try { return JSON.parse(acceptText) } catch { return null } })()
+          throw new Error(aj?.message ?? acceptText ?? '코스 저장 준비 실패')
+        }
+        res = await apiRequest(
+          `/guides/${guideId}/schedules/${schedule.scheduleId}/form`,
+          {
+            method: 'PUT',
+            json: payload,
+          },
+        )
+        text = await res.text()
+      }
       if (!res.ok) {
         const j = (() => { try { return JSON.parse(text) } catch { return null } })()
         throw new Error(j?.message ?? text ?? '저장 실패')
       }
+      const savedForm = (() => {
+        if (!text) return null
+        try {
+          return JSON.parse(text)
+        } catch {
+          return null
+        }
+      })()
+      const mergedSavedForm = {
+        ...(savedForm ?? {}),
+        // 결제 전에는 응답 courseDetail이 null로 마스킹되므로, 저장 직전 원본 값을 콜백으로 전달한다.
+        courseDetail: payload.courseDetail,
+        meetingPoint: savedForm?.meetingPoint ?? payload.meetingPoint,
+        guideMessage: savedForm?.guideMessage ?? payload.guideMessage,
+      }
       setSaveMsg('저장되었습니다!')
       setTimeout(() => setSaveMsg(''), 2500)
-      onSaved()
+      onSaved(mergedSavedForm)
     } catch (e) {
       setError(e instanceof Error ? e.message : '저장 실패')
     } finally {

--- a/frontend/src/pages/GuideInboxPage.jsx
+++ b/frontend/src/pages/GuideInboxPage.jsx
@@ -3,7 +3,9 @@ import { Link } from 'react-router-dom'
 
 import { apiRequest } from '../api/client.js'
 import { useAuth } from '../context/useAuth.js'
+import { useResolvedGuideId } from '../hooks/useResolvedGuideId.js'
 import { fetchGuideMatchRequests } from '../lib/matchingGuest.js'
+import { GuideCoursePanel, parseCourseDetail } from './GuideCoursePanel.jsx'
 
 import './GuideInboxPage.css'
 
@@ -36,14 +38,14 @@ function statusLabel(status) {
 
 export function GuideInboxPage() {
   const { isGuide } = useAuth()
+  const { guideId } = useResolvedGuideId()
   const [rows, setRows] = useState([])
+  const [schedulesById, setSchedulesById] = useState({})
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(true)
   const [busyId, setBusyId] = useState(null)
   const [toast, setToast] = useState('')
-  const [proposeFor, setProposeFor] = useState(null)
-  const [proposedSchedule, setProposedSchedule] = useState('')
-  const [proposeMessage, setProposeMessage] = useState('')
+  const [courseTarget, setCourseTarget] = useState(null)
 
   const fetchList = useCallback(async () => {
     setError('')
@@ -94,39 +96,104 @@ export function GuideInboxPage() {
     }
   }
 
-  const openPropose = (r) => {
-    setProposeFor(r.requestId)
-    setProposedSchedule(r.proposedSchedule ?? '')
-    setProposeMessage(r.proposeMessage ?? '')
-  }
-
-  const closePropose = () => {
-    setProposeFor(null)
-    setProposedSchedule('')
-    setProposeMessage('')
-  }
-
-  const submitPropose = async () => {
-    if (proposeFor == null) return
-    const body = {
-      proposedSchedule: proposedSchedule.trim(),
-      proposeMessage: proposeMessage.trim() || undefined,
-    }
-    if (!body.proposedSchedule) {
-      setToast('제시 일정(proposedSchedule)은 필수입니다.')
+  const loadSchedules = useCallback(async () => {
+    if (!guideId) {
+      setSchedulesById({})
       return
     }
-    setBusyId(proposeFor)
+    try {
+      const res = await apiRequest(`/guides/${guideId}/schedules`, { method: 'GET', skipAuth: true })
+      const text = await res.text()
+      if (!res.ok) {
+        setSchedulesById({})
+        return
+      }
+      const schedules = text ? JSON.parse(text) : []
+      const map = {}
+      for (const schedule of Array.isArray(schedules) ? schedules : []) {
+        if (schedule?.scheduleId != null) {
+          map[Number(schedule.scheduleId)] = schedule
+        }
+      }
+      setSchedulesById(map)
+    } catch {
+      setSchedulesById({})
+    }
+  }, [guideId])
+
+  useEffect(() => {
+    void loadSchedules()
+  }, [loadSchedules])
+
+  const openCourseWriter = async (r) => {
+    if (guideId == null) {
+      setToast('가이드 프로필 정보를 불러오는 중입니다. 잠시 후 다시 시도해 주세요.')
+      return
+    }
+    const sid = Number(r.scheduleId)
+    if (Number.isNaN(sid)) {
+      setToast('연결된 스케줄이 없어 코스를 작성할 수 없습니다.')
+      return
+    }
+    const linkedSchedule = schedulesById[sid]
+    if (linkedSchedule?.status === 'PENDING') {
+      setBusyId(r.requestId)
+      try {
+        const acceptRes = await apiRequest(`/guides/${guideId}/schedules/${sid}/accept`, { method: 'POST' })
+        const acceptText = await acceptRes.text()
+        if (!acceptRes.ok) {
+          if (acceptRes.status !== 409) {
+            setToast(await readJsonError(acceptRes, acceptText))
+            return
+          }
+        }
+        await loadSchedules()
+      } catch {
+        setToast('코스 작성 준비 중 오류가 발생했습니다.')
+        return
+      } finally {
+        setBusyId(null)
+      }
+    }
+    setCourseTarget({
+      requestId: r.requestId,
+      scheduleId: sid,
+      availableDate: linkedSchedule?.availableDate ?? r.desiredDate ?? '',
+      startTime: linkedSchedule?.startTime ?? '00:00',
+      endTime: linkedSchedule?.endTime ?? '23:59',
+      destination: r.destination ?? '',
+    })
+  }
+
+  const buildProposedSchedule = (courseDetail) => {
+    const spots = parseCourseDetail(courseDetail).filter((spot) => String(spot.name ?? '').trim())
+    if (spots.length === 0) return ''
+    return spots.map((spot) => spot.name.trim()).join(' -> ')
+  }
+
+  const submitProposalFromForm = async (requestId, savedForm) => {
+    const proposedSchedule = buildProposedSchedule(savedForm?.courseDetail ?? '')
+    const proposeMessage = String(savedForm?.guideMessage ?? '').trim()
+    const body = {
+      proposedSchedule,
+      proposeMessage: proposeMessage || undefined,
+    }
+    if (!proposedSchedule) {
+      setToast('코스 스팟을 1개 이상 작성해야 제시안을 보낼 수 있습니다.')
+      return
+    }
+    setBusyId(requestId)
     setToast('')
     try {
-      const res = await apiRequest(`/matching/requests/${proposeFor}/propose`, { method: 'PATCH', json: body })
+      const res = await apiRequest(`/matching/requests/${requestId}/propose`, { method: 'PATCH', json: body })
       const text = await res.text()
       if (!res.ok) {
         setToast(await readJsonError(res, text))
         return
       }
-      closePropose()
       await fetchList()
+      await loadSchedules()
+      setCourseTarget(null)
     } catch {
       setToast('제시안 전송 실패')
     } finally {
@@ -190,8 +257,8 @@ export function GuideInboxPage() {
                     <td className="inbox-actions">
                       {r.status === 'PENDING' && (
                         <>
-                          <button type="button" className="inbox-btn" onClick={() => openPropose(r)} disabled={busyId != null}>
-                            제시안 보내기
+                          <button type="button" className="inbox-btn" onClick={() => openCourseWriter(r)} disabled={busyId != null}>
+                            코스 작성하기
                           </button>
                           <button
                             type="button"
@@ -236,8 +303,8 @@ export function GuideInboxPage() {
                 )}
                 {r.status === 'PENDING' && (
                   <div className="inbox-card-actions">
-                    <button type="button" className="inbox-btn" onClick={() => openPropose(r)} disabled={busyId != null}>
-                      제시안 보내기
+                    <button type="button" className="inbox-btn" onClick={() => openCourseWriter(r)} disabled={busyId != null}>
+                      코스 작성하기
                     </button>
                     <button
                       type="button"
@@ -255,42 +322,13 @@ export function GuideInboxPage() {
         </>
       )}
 
-      {proposeFor != null && (
-        <div className="inbox-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="inbox-propose-title">
-          <div className="inbox-modal">
-            <h2 id="inbox-propose-title">제시안 보내기</h2>
-            <p className="inbox-hint">요청 #{proposeFor}</p>
-            <label className="inbox-modal-label" htmlFor="psched">
-              제시 일정 (필수)
-            </label>
-            <textarea
-              id="psched"
-              className="inbox-modal-text"
-              value={proposedSchedule}
-              onChange={(e) => setProposedSchedule(e.target.value)}
-              rows={4}
-              placeholder="예: 10:00 명동 집합 → 남산 코스 → 18:00 해산"
-            />
-            <label className="inbox-modal-label" htmlFor="pmsg">
-              메시지 (선택)
-            </label>
-            <textarea
-              id="pmsg"
-              className="inbox-modal-text"
-              value={proposeMessage}
-              onChange={(e) => setProposeMessage(e.target.value)}
-              rows={3}
-            />
-            <div className="inbox-modal-actions">
-              <button type="button" className="inbox-btn inbox-btn--ghost" onClick={closePropose} disabled={busyId != null}>
-                취소
-              </button>
-              <button type="button" className="inbox-btn" onClick={() => void submitPropose()} disabled={busyId != null}>
-                {busyId === proposeFor ? '전송 중…' : '전송'}
-              </button>
-            </div>
-          </div>
-        </div>
+      {courseTarget && guideId != null && (
+        <GuideCoursePanel
+          guideId={guideId}
+          schedule={courseTarget}
+          onClose={() => setCourseTarget(null)}
+          onSaved={(savedForm) => void submitProposalFromForm(courseTarget.requestId, savedForm)}
+        />
       )}
     </div>
   )

--- a/frontend/src/pages/GuideMatchOptionsPage.css
+++ b/frontend/src/pages/GuideMatchOptionsPage.css
@@ -33,6 +33,64 @@
   line-height: 1.45;
 }
 
+.gmo-watch-banner {
+  margin: 0 0 0.8rem;
+  padding: 0.62rem 0.85rem;
+  border-radius: 12px;
+  background: #eff6ff;
+  border: 1px solid #bfdbfe;
+  font-size: 0.79rem;
+  color: #1e3a8a;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.gmo-watch-banner p {
+  margin: 0;
+}
+
+.gmo-watch-btn {
+  border: 1px solid #93c5fd;
+  border-radius: 8px;
+  background: #fff;
+  color: #1d4ed8;
+  font-size: 0.76rem;
+  font-weight: 700;
+  padding: 0.34rem 0.62rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.gmo-watch-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.gmo-arrived-banner {
+  margin: 0 0 0.8rem;
+  padding: 0.68rem 0.9rem;
+  border-radius: 12px;
+  background: #ecfdf3;
+  border: 1px solid #86efac;
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: #166534;
+  animation: gmoArrivedPop 0.35s ease-out;
+}
+
+@keyframes gmoArrivedPop {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 .gmo-hero {
   display: flex;
   gap: 1rem;
@@ -118,6 +176,8 @@
   border: 1px solid #e8eaed;
   border-radius: 16px;
   padding: 1rem 1.05rem;
+  display: flex;
+  flex-direction: column;
 }
 
 .gmo-preview h2 {
@@ -130,14 +190,28 @@
 .gmo-map {
   position: relative;
   min-height: 220px;
+  flex: 1;
   border-radius: 12px;
   background: linear-gradient(160deg, #f3f4f6, #e5e7eb);
+  overflow: hidden;
+}
+
+.gmo-map-canvas {
+  position: absolute;
+  inset: 0;
+}
+
+.gmo-map-overlay {
+  position: absolute;
+  inset: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   text-align: center;
   padding: 1.25rem;
+  background: rgba(243, 244, 246, 0.68);
+  backdrop-filter: blur(1px);
 }
 
 .gmo-lock {
@@ -168,6 +242,240 @@
   max-width: 16rem;
 }
 
+.gmo-preview-steps {
+  margin: 0 0 0.65rem;
+  width: 100%;
+  padding-left: 1.2rem;
+  text-align: left;
+  color: #1f2937;
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+
+.gmo-preview-step {
+  margin: 0 0 0.25rem;
+}
+
+.gmo-preview-note {
+  margin: 0.2rem 0 0;
+  max-width: 16rem;
+  font-size: 0.75rem;
+  line-height: 1.45;
+  color: #4b5563;
+}
+
+.gmo-half-preview {
+  margin-top: 1rem;
+  margin-bottom: 0.4rem;
+  padding: 0.95rem 1rem;
+  border-radius: 14px;
+  border: 1px solid #e8eaed;
+  background: linear-gradient(180deg, #f8faff 0%, #f4f7ff 100%);
+}
+
+.gmo-half-title {
+  margin: 0 0 0.45rem;
+  font-size: 0.84rem;
+  font-weight: 800;
+  color: #1f2937;
+}
+
+.gmo-half-visible {
+  margin: 0.45rem 0 0;
+  white-space: pre-wrap;
+  font-size: 0.82rem;
+  line-height: 1.55;
+  color: #1f2937;
+}
+
+.gmo-half-blur {
+  margin: 0.25rem 0 0;
+  white-space: pre-wrap;
+  font-size: 0.86rem;
+  line-height: 1.55;
+  color: rgba(31, 41, 55, 0.7);
+  filter: blur(4px);
+  user-select: none;
+  pointer-events: none;
+}
+
+.gmo-half-foot {
+  margin: 0.55rem 0 0;
+  font-size: 0.76rem;
+  color: #6b7280;
+}
+
+.gmo-spot-preview-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.gmo-spot-preview-item {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  min-height: 2.7rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 11px;
+  padding: 0.45rem 0.65rem;
+  background: #fff;
+}
+
+.gmo-spot-preview-num {
+  width: 1.65rem;
+  height: 1.65rem;
+  border-radius: 50%;
+  background: #111827;
+  color: #fff;
+  font-size: 0.77rem;
+  font-weight: 800;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.gmo-spot-preview-name {
+  font-size: 0.86rem;
+  color: #111827;
+}
+
+.gmo-locked-zone {
+  margin-top: 0.75rem;
+  position: relative;
+  border-radius: 14px;
+  overflow: hidden;
+  border: 1px solid #dbe3f0;
+  background: linear-gradient(180deg, #eef2ff 0%, #e9eefc 100%);
+  min-height: 180px;
+}
+
+.gmo-locked-blur {
+  padding: 0.75rem 0.8rem;
+  filter: blur(5px);
+  transform: scale(1.02);
+  opacity: 0.92;
+  user-select: none;
+  pointer-events: none;
+}
+
+.gmo-locked-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.8rem;
+  pointer-events: none;
+}
+
+.gmo-pay-hint-card {
+  margin-top: 0;
+  padding: 0.75rem 0.8rem;
+  border-radius: 12px;
+  border: 1px solid #d1d5db;
+  background: #fff;
+  box-shadow: 0 8px 22px rgba(15, 23, 42, 0.16);
+  pointer-events: auto;
+  text-align: center;
+  max-width: 260px;
+  width: 100%;
+}
+
+.gmo-pay-hint-title {
+  margin: 0;
+  font-size: 0.82rem;
+  font-weight: 800;
+  color: #1e3a8a;
+}
+
+.gmo-pay-hint-sub {
+  margin: 0.28rem 0 0.5rem;
+  font-size: 0.76rem;
+  color: #475569;
+}
+
+.gmo-pay-hint-btn {
+  border: none;
+  border-radius: 8px;
+  background: #2563eb;
+  color: #fff;
+  font-size: 0.78rem;
+  font-weight: 700;
+  padding: 0.42rem 0.7rem;
+  cursor: pointer;
+}
+
+.gmo-pay-hint-inline {
+  margin-top: 0.55rem;
+}
+
+.gmo-course-pending {
+  margin-top: 1rem;
+  margin-bottom: 0.4rem;
+  padding: 0.95rem 1rem;
+  border-radius: 14px;
+  border: 1px solid #dbeafe;
+  background: linear-gradient(120deg, #eff6ff 0%, #f8faff 55%, #eff6ff 100%);
+  background-size: 210% 100%;
+  animation: gmoPendingWave 2.4s ease-in-out infinite;
+}
+
+.gmo-course-pending-dot {
+  display: inline-block;
+  width: 0.58rem;
+  height: 0.58rem;
+  border-radius: 50%;
+  background: #2563eb;
+  box-shadow: 0 0 0 rgba(37, 99, 235, 0.35);
+  animation: gmoPulse 1.25s ease-out infinite;
+}
+
+.gmo-course-pending-title {
+  margin: 0.25rem 0 0;
+  font-size: 0.9rem;
+  font-weight: 800;
+  color: #1e3a8a;
+}
+
+.gmo-course-pending-sub {
+  margin: 0.25rem 0 0;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  color: #334155;
+}
+
+@keyframes gmoPulse {
+  0% {
+    transform: scale(1);
+    box-shadow: 0 0 0 0 rgba(37, 99, 235, 0.35);
+  }
+  70% {
+    transform: scale(1.05);
+    box-shadow: 0 0 0 8px rgba(37, 99, 235, 0);
+  }
+  100% {
+    transform: scale(1);
+    box-shadow: 0 0 0 0 rgba(37, 99, 235, 0);
+  }
+}
+
+@keyframes gmoPendingWave {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}
+
 .gmo-side {
   background: #fff;
   border: 1px solid #e8eaed;
@@ -175,6 +483,12 @@
   padding: 1rem 1.05rem;
   display: flex;
   flex-direction: column;
+}
+
+.gmo-side--focus {
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2), 0 8px 24px rgba(37, 99, 235, 0.15);
+  transition: box-shadow 0.22s ease, border-color 0.22s ease;
 }
 
 .gmo-side h2 {
@@ -282,6 +596,13 @@
   background: #111418;
 }
 
+.gmo-course-gate {
+  margin-top: 0.55rem;
+  font-size: 0.77rem;
+  line-height: 1.45;
+  color: #64748b;
+}
+
 .gmo-err {
   margin-top: 0.65rem;
   font-size: 0.82rem;
@@ -297,6 +618,13 @@
   font-size: 1rem;
   font-weight: 800;
   color: #111827;
+}
+
+.gmo-reviews-readonly {
+  margin: 0 0 0.9rem;
+  font-size: 0.82rem;
+  line-height: 1.45;
+  color: #64748b;
 }
 
 .gmo-review-form {

--- a/frontend/src/pages/GuideMatchOptionsPage.jsx
+++ b/frontend/src/pages/GuideMatchOptionsPage.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useLocation, useNavigate, useParams } from 'react-router-dom'
 
 import { PageError, PageLoading } from '../components/PageStates.jsx'
@@ -9,25 +9,41 @@ import './GuideMatchOptionsPage.css'
 
 const PRICE_CHAT = 10000
 const PRICE_ACCOMPANY = 50000
+const KAKAO_APP_KEY = import.meta.env.VITE_KAKAO_MAP_APP_KEY
 
-function findLatestProposal(list, guideId) {
-  const gid = Number(guideId)
-  if (!Array.isArray(list)) return null
-  const rows = list.filter(
-    (r) =>
-      Number(r.guideId) === gid &&
-      r.status === 'ACCEPTED' &&
-      (String(r.proposedSchedule ?? '').trim() || String(r.proposeMessage ?? '').trim()),
-  )
-  rows.sort((a, b) => {
-    const ta = a.createdAt ? new Date(a.createdAt).getTime() : 0
-    const tb = b.createdAt ? new Date(b.createdAt).getTime() : 0
-    return tb - ta
+function loadKakaoSdk(appKey) {
+  if (!appKey) return Promise.reject(new Error('카카오맵 앱 키가 없습니다.'))
+  if (window.kakao?.maps?.services) return Promise.resolve(window.kakao)
+  return new Promise((resolve, reject) => {
+    const existing = document.getElementById('kakao-map-sdk')
+    if (existing) {
+      existing.addEventListener('load', () => window.kakao.maps.load(() => resolve(window.kakao)))
+      existing.addEventListener('error', () => reject(new Error('카카오맵 SDK 로드 실패')))
+      return
+    }
+    const script = document.createElement('script')
+    script.id = 'kakao-map-sdk'
+    script.async = true
+    script.src = `https://dapi.kakao.com/v2/maps/sdk.js?appkey=${appKey}&autoload=false&libraries=services`
+    script.onload = () => window.kakao.maps.load(() => resolve(window.kakao))
+    script.onerror = () => reject(new Error('카카오맵 SDK 로드 실패'))
+    document.head.appendChild(script)
   })
-  return rows[0] ?? null
 }
 
-/** 제안문이 없어도, 이 가이드에 대한 최신 매칭 요청 id (결제·후기 UI 연결용) */
+function geocodeAddress(kakao, query) {
+  return new Promise((resolve) => {
+    const geocoder = new kakao.maps.services.Geocoder()
+    geocoder.addressSearch(query, (result, status) => {
+      if (status !== kakao.maps.services.Status.OK || !result?.length) {
+        resolve(null)
+        return
+      }
+      resolve({ lat: Number(result[0].y), lng: Number(result[0].x) })
+    })
+  })
+}
+
 function findLatestRequestForGuide(list, guideId) {
   const gid = Number(guideId)
   if (!Array.isArray(list)) return null
@@ -44,6 +60,23 @@ function formatKrw(n) {
   return `₩ ${Number(n).toLocaleString('ko-KR')}`
 }
 
+function parsePreviewSpots(proposedSchedule) {
+  const raw = String(proposedSchedule ?? '').trim()
+  if (!raw) return []
+  const normalized = raw.replace(/\s*->\s*/g, '\n')
+  const rows = normalized
+    .split(/\r?\n|,/)
+    .map((v) => v.trim())
+    .filter(Boolean)
+  return rows
+}
+
+function hasProposalContent(row) {
+  if (!row) return false
+  if (String(row.status ?? '').toUpperCase() !== 'ACCEPTED') return false
+  return !!(String(row.proposedSchedule ?? '').trim() || String(row.proposeMessage ?? '').trim())
+}
+
 export function GuideMatchOptionsPage() {
   const { guideId } = useParams()
   const location = useLocation()
@@ -54,19 +87,27 @@ export function GuideMatchOptionsPage() {
   const [error, setError] = useState('')
   const [profile, setProfile] = useState(null)
   const [requestId, setRequestId] = useState(stateRequestId != null ? Number(stateRequestId) : null)
+  const [activeRequest, setActiveRequest] = useState(null)
   const [paymentType, setPaymentType] = useState(/** @type {'CHAT' | 'ACCOMPANY'} */ ('CHAT'))
   const [reviews, setReviews] = useState([])
-  const [reviewText, setReviewText] = useState('')
   const [paying, setPaying] = useState(false)
-  const [reviewSubmitting, setReviewSubmitting] = useState(false)
   const [payErr, setPayErr] = useState('')
-  const [reviewErr, setReviewErr] = useState('')
+  const [payFocus, setPayFocus] = useState(false)
+  const [proposalArrivedNotice, setProposalArrivedNotice] = useState(false)
+  const [checkingProposal, setCheckingProposal] = useState(false)
+  const matchingOptionsRef = useRef(null)
+  const previewMapRef = useRef(null)
+  const hasProposalRef = useRef(false)
+  const initializedProposalRef = useRef(false)
 
   const amount = paymentType === 'CHAT' ? PRICE_CHAT : PRICE_ACCOMPANY
 
-  const load = useCallback(async () => {
-    setLoading(true)
-    setError('')
+  const load = useCallback(async (options = {}) => {
+    const silent = Boolean(options?.silent)
+    if (!silent) {
+      setLoading(true)
+      setError('')
+    }
     try {
       const res = await apiRequest(`/guides/${guideId}/detail`, { method: 'GET', skipAuth: true })
       const text = await res.text()
@@ -80,16 +121,22 @@ export function GuideMatchOptionsPage() {
 
       let rid = stateRequestId != null ? Number(stateRequestId) : null
       if (rid == null || Number.isNaN(rid)) {
-        const proposed = findLatestProposal(safeList, guideId)
-        rid = proposed?.requestId != null ? Number(proposed.requestId) : null
-        if (rid == null) {
-          const anyReq = findLatestRequestForGuide(safeList, guideId)
-          rid = anyReq?.requestId != null ? Number(anyReq.requestId) : null
-        }
+        const latest = findLatestRequestForGuide(safeList, guideId)
+        rid = latest?.requestId != null ? Number(latest.requestId) : null
       }
 
       const activeRid = rid != null && !Number.isNaN(rid) ? rid : null
       const row = activeRid != null ? safeList.find((r) => Number(r.requestId) === Number(activeRid)) : null
+      const hasProposalNow = hasProposalContent(row)
+      if (initializedProposalRef.current) {
+        if (!hasProposalRef.current && hasProposalNow) {
+          setProposalArrivedNotice(true)
+        }
+      } else {
+        initializedProposalRef.current = true
+      }
+      hasProposalRef.current = hasProposalNow
+      setActiveRequest(row ?? null)
       if (row && (row.status === 'PAID' || row.status === 'IN_PROGRESS')) {
         let payments = []
         try {
@@ -117,9 +164,13 @@ export function GuideMatchOptionsPage() {
         setReviews([])
       }
     } catch (e) {
-      setError(e instanceof Error ? e.message : '오류')
+      if (!silent) {
+        setError(e instanceof Error ? e.message : '오류')
+      }
     } finally {
-      setLoading(false)
+      if (!silent) {
+        setLoading(false)
+      }
     }
   }, [guideId, stateRequestId, navigate])
 
@@ -140,10 +191,110 @@ export function GuideMatchOptionsPage() {
     return '“관광객은 모르는, 사진 찍기 좋은 조용한 루트를 안내합니다.”'
   }, [profile])
 
+  const previewSpots = useMemo(() => {
+    return parsePreviewSpots(activeRequest?.proposedSchedule)
+  }, [activeRequest])
+
+  const previewHint = useMemo(() => {
+    return String(activeRequest?.proposeMessage ?? '').trim()
+  }, [activeRequest])
+  const courseReadyForPayment = useMemo(() => {
+    return String(activeRequest?.proposedSchedule ?? '').trim().length > 0
+  }, [activeRequest])
+  const previewFirstSpot = previewSpots[0] ?? ''
+  const previewLockedSpots = previewSpots.slice(1)
+  const hasLockedPreview = previewLockedSpots.length > 0 || !!previewHint
+
+  useEffect(() => {
+    if (!payFocus) return
+    const timer = setTimeout(() => setPayFocus(false), 1400)
+    return () => clearTimeout(timer)
+  }, [payFocus])
+
+  useEffect(() => {
+    if (!proposalArrivedNotice) return
+    const timer = setTimeout(() => setProposalArrivedNotice(false), 5000)
+    return () => clearTimeout(timer)
+  }, [proposalArrivedNotice])
+
+  useEffect(() => {
+    if (requestId == null) return
+    if (courseReadyForPayment) return
+    const timer = setInterval(() => {
+      if (typeof document !== 'undefined' && document.visibilityState !== 'visible') return
+      void load({ silent: true })
+    }, 45000)
+    return () => clearInterval(timer)
+  }, [requestId, courseReadyForPayment, load])
+
+  useEffect(() => {
+    if (requestId == null || courseReadyForPayment) return
+    const onFocus = () => {
+      void load({ silent: true })
+    }
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') {
+        void load({ silent: true })
+      }
+    }
+    window.addEventListener('focus', onFocus)
+    document.addEventListener('visibilitychange', onVisibility)
+    return () => {
+      window.removeEventListener('focus', onFocus)
+      document.removeEventListener('visibilitychange', onVisibility)
+    }
+  }, [requestId, courseReadyForPayment, load])
+
+  const onCheckProposalNow = async () => {
+    if (checkingProposal) return
+    setCheckingProposal(true)
+    try {
+      await load({ silent: true })
+    } finally {
+      setCheckingProposal(false)
+    }
+  }
+
+  const moveToPaymentOptions = () => {
+    matchingOptionsRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    setPayFocus(true)
+  }
+
+  useEffect(() => {
+    if (!previewMapRef.current) return
+    let cancelled = false
+    ;(async () => {
+      try {
+        const kakao = await loadKakaoSdk(KAKAO_APP_KEY)
+        if (cancelled || !previewMapRef.current) return
+        const fallback = { lat: 33.4996, lng: 126.5312 }
+        const map = new kakao.maps.Map(previewMapRef.current, {
+          center: new kakao.maps.LatLng(fallback.lat, fallback.lng),
+          level: 7,
+        })
+        const query = profile?.region?.trim()
+        if (!query) return
+        const point = await geocodeAddress(kakao, query)
+        if (cancelled || !point) return
+        const center = new kakao.maps.LatLng(point.lat, point.lng)
+        map.setCenter(center)
+      } catch {
+        /* preview map fallback: keep grey background */
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [profile?.region])
+
   const onPay = async () => {
     setPayErr('')
     if (requestId == null) {
       setPayErr('매칭 요청이 없으면 결제할 수 없습니다. 가이드 제안을 받은 뒤 다시 시도해 주세요.')
+      return
+    }
+    if (!courseReadyForPayment) {
+      setPayErr('가이드가 코스를 작성한 뒤 결제를 진행할 수 있어요.')
       return
     }
     setPaying(true)
@@ -179,40 +330,6 @@ export function GuideMatchOptionsPage() {
     }
   }
 
-  const onReviewSubmit = async (e) => {
-    e.preventDefault()
-    setReviewErr('')
-    const content = reviewText.trim()
-    if (content.length < 10) {
-      setReviewErr('후기는 10자 이상 입력해 주세요.')
-      return
-    }
-    if (requestId == null) {
-      setReviewErr('리뷰는 매칭이 완료된 뒤 작성할 수 있어요.')
-      return
-    }
-    setReviewSubmitting(true)
-    try {
-      const res = await apiRequest('/reviews', {
-        method: 'POST',
-        json: {
-          guideId: Number(guideId),
-          matchRequestId: requestId,
-          rating: 5,
-          content,
-        },
-      })
-      const t = await res.text()
-      if (!res.ok) throw new Error(t || '등록에 실패했습니다.')
-      setReviewText('')
-      void load()
-    } catch (e) {
-      setReviewErr(e instanceof Error ? e.message : '오류')
-    } finally {
-      setReviewSubmitting(false)
-    }
-  }
-
   if (loading) {
     return (
       <div className="gmo">
@@ -241,6 +358,17 @@ export function GuideMatchOptionsPage() {
           아직 이 가이드와 연결된 <strong>매칭 요청</strong>이 없습니다. 코스는 미리보기만 제공되며, 결제는 제안을 받은 뒤에 가능합니다.
         </p>
       )}
+      {requestId != null && !courseReadyForPayment && (
+        <div className="gmo-watch-banner">
+          <p>가이드 제시안을 기다리는 중이에요. 이 탭으로 돌아오면 자동으로 최신 상태를 확인합니다.</p>
+          <button type="button" className="gmo-watch-btn" onClick={() => void onCheckProposalNow()} disabled={checkingProposal}>
+            {checkingProposal ? '확인 중…' : '지금 확인'}
+          </button>
+        </div>
+      )}
+      {proposalArrivedNotice && (
+        <p className="gmo-arrived-banner">제시안이 도착했어요! 아래에서 코스 일부를 확인하고 결제를 진행해 주세요.</p>
+      )}
 
       <header className="gmo-hero">
         <div
@@ -263,15 +391,22 @@ export function GuideMatchOptionsPage() {
         <section className="gmo-preview" aria-labelledby="gmo-preview-title">
           <h2 id="gmo-preview-title">추천 코스 미리보기</h2>
           <div className="gmo-map">
-            <div className="gmo-lock" aria-hidden>
-              🔒
+            <div ref={previewMapRef} className="gmo-map-canvas" />
+            <div className="gmo-map-overlay">
+              <div className="gmo-lock" aria-hidden>
+                🔒
+              </div>
+              <p className="gmo-map-title">매칭 후 상세 코스가 공개됩니다</p>
+              <p className="gmo-map-sub">결제 및 매칭을 완료하고 나만의 비밀 지도를 확인하세요.</p>
             </div>
-            <p className="gmo-map-title">매칭 후 상세 코스가 공개됩니다</p>
-            <p className="gmo-map-sub">결제 및 매칭을 완료하고 나만의 비밀 지도를 확인하세요.</p>
           </div>
         </section>
 
-        <aside className="gmo-side" aria-labelledby="gmo-side-title">
+        <aside
+          ref={matchingOptionsRef}
+          className={`gmo-side${payFocus ? ' gmo-side--focus' : ''}`}
+          aria-labelledby="gmo-side-title"
+        >
           <h2 id="gmo-side-title">가이드 매칭 옵션</h2>
 
           <label className="gmo-opt">
@@ -311,29 +446,81 @@ export function GuideMatchOptionsPage() {
             <strong>{formatKrw(amount)}</strong>
           </div>
 
-          <button type="button" className="gmo-pay" disabled={paying || requestId == null} onClick={() => void onPay()}>
-            {paying ? '처리 중…' : '결제하고 코스 열기'}
+          <button
+            type="button"
+            className="gmo-pay"
+            disabled={paying || requestId == null || !courseReadyForPayment}
+            onClick={() => void onPay()}
+          >
+            {paying ? '처리 중…' : !courseReadyForPayment ? '가이드 코스 작성 대기중' : '결제하고 코스 열기'}
           </button>
+          {!courseReadyForPayment && (
+            <p className="gmo-course-gate">가이드가 코스를 작성하면 결제 버튼이 활성화됩니다.</p>
+          )}
           {payErr && <p className="gmo-err">{payErr}</p>}
         </aside>
       </div>
 
+      {previewSpots.length > 0 && (
+        <section className="gmo-half-preview" aria-label="코스 텍스트 미리보기">
+          <p className="gmo-half-title">가이드가 작성한 코스 일부</p>
+          <ul className="gmo-spot-preview-list">
+            <li className="gmo-spot-preview-item">
+              <span className="gmo-spot-preview-num">1</span>
+              <span className="gmo-spot-preview-name">{previewFirstSpot}</span>
+            </li>
+          </ul>
+
+          {hasLockedPreview && (
+            <div className="gmo-locked-zone">
+              <div className="gmo-locked-blur" aria-hidden>
+                <ul className="gmo-spot-preview-list">
+                  {previewLockedSpots.map((spot, idx) => (
+                    <li key={`${idx + 1}-${spot.slice(0, 12)}`} className="gmo-spot-preview-item">
+                      <span className="gmo-spot-preview-num">{idx + 2}</span>
+                      <span className="gmo-spot-preview-name">{spot}</span>
+                    </li>
+                  ))}
+                </ul>
+                {previewHint && <p className="gmo-half-visible">가이드 메모: {previewHint}</p>}
+                <p className="gmo-half-foot">나머지 상세 코스는 결제 후 공개됩니다.</p>
+              </div>
+              <div className="gmo-locked-overlay">
+                <div className="gmo-pay-hint-card">
+                  <p className="gmo-pay-hint-title">아직 공개되지 않은 코스가 있어요</p>
+                  <p className="gmo-pay-hint-sub">결제하기를 누르면 위 매칭 옵션에서 바로 진행할 수 있어요.</p>
+                  <button type="button" className="gmo-pay-hint-btn" onClick={moveToPaymentOptions}>
+                    결제하기로 이동
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+          {!hasLockedPreview && (
+            <div className="gmo-pay-hint-inline">
+              <p className="gmo-half-foot">나머지 상세 코스는 결제 후 공개됩니다.</p>
+            </div>
+          )}
+          {!hasLockedPreview && (
+            <div className="gmo-pay-hint-inline">
+              <button type="button" className="gmo-pay-hint-btn" onClick={moveToPaymentOptions}>
+                결제하기로 이동
+              </button>
+            </div>
+          )}
+        </section>
+      )}
+      {previewSpots.length === 0 && (
+        <section className="gmo-course-pending" aria-live="polite">
+          <span className="gmo-course-pending-dot" aria-hidden />
+          <p className="gmo-course-pending-title">가이드가 코스를 작성 중이에요</p>
+          <p className="gmo-course-pending-sub">조금만 기다려 주세요. 작성이 완료되면 일부 코스가 여기에 먼저 공개됩니다.</p>
+        </section>
+      )}
+
       <section className="gmo-reviews" aria-labelledby="gmo-rev-title">
         <h2 id="gmo-rev-title">여행자들의 후기 ({rc})</h2>
-        {reviewErr && <p className="gmo-err">{reviewErr}</p>}
-        <form className="gmo-review-form" onSubmit={(e) => void onReviewSubmit(e)}>
-          <textarea
-            className="gmo-review-input"
-            rows={2}
-            placeholder="가이드에게 궁금한 점이나 후기를 남겨주세요…"
-            value={reviewText}
-            onChange={(e) => setReviewText(e.target.value)}
-            disabled={requestId == null}
-          />
-          <button type="submit" className="gmo-review-submit" disabled={reviewSubmitting || requestId == null}>
-            등록
-          </button>
-        </form>
+        <p className="gmo-reviews-readonly">후기는 투어가 완료된 뒤 작성할 수 있어요. 지금은 기존 후기만 확인할 수 있습니다.</p>
         <ul className="gmo-review-list">
           {reviews.length === 0 ? (
             <li className="gmo-review-item">

--- a/frontend/src/pages/GuideProposalPage.jsx
+++ b/frontend/src/pages/GuideProposalPage.jsx
@@ -29,21 +29,22 @@ function splitProposeMessage(msg) {
   return { courseLine: '', note: t }
 }
 
-function findLatestProposal(list, guideId) {
+function findLatestRequestForGuide(list, guideId) {
   const gid = Number(guideId)
   if (!Array.isArray(list)) return null
-  const rows = list.filter(
-    (r) =>
-      Number(r.guideId) === gid &&
-      r.status === 'ACCEPTED' &&
-      (String(r.proposedSchedule ?? '').trim() || String(r.proposeMessage ?? '').trim()),
-  )
+  const rows = list.filter((r) => Number(r.guideId) === gid)
   rows.sort((a, b) => {
     const ta = a.createdAt ? new Date(a.createdAt).getTime() : 0
     const tb = b.createdAt ? new Date(b.createdAt).getTime() : 0
     return tb - ta
   })
   return rows[0] ?? null
+}
+
+function hasVisibleProposal(row) {
+  if (!row) return false
+  if (String(row.status) !== 'ACCEPTED') return false
+  return !!(String(row.proposedSchedule ?? '').trim() || String(row.proposeMessage ?? '').trim())
 }
 
 function formatWon(n) {
@@ -85,9 +86,9 @@ export function GuideProposalPage() {
           setMatchState('list_error')
         } else {
           const list = lt ? JSON.parse(lt) : []
-          const match = findLatestProposal(list, guideId)
-          setProposal(match)
-          setMatchState(match ? 'has_match' : 'no_match')
+          const latest = findLatestRequestForGuide(list, guideId)
+          setProposal(latest)
+          setMatchState(hasVisibleProposal(latest) ? 'has_match' : 'no_match')
         }
       }
     } catch (e) {


### PR DESCRIPTION
# 🔗 이슈 번호
- Closes #322 

---

## 💡 주요 변경 사항
- 제시안/코스 작성 플로우 개편
  - “제시안 보내기” 모달 제거 후 즉시 코스 작성 진입
  - 가이드 작성 데이터가 게스트 화면까지 이어지는 흐름 정리
- 코스 공개 정책 UX 반영
  - 결제 전: 1번 스팟 노출 + 나머지 블러 처리
  - 결제 후: 전체 코스 상세 공개
- 게스트 UX 개선
  - 가이드 코스 작성 중 안내 문구/애니메이션 추가
  - 제시안 도착 인지 개선(수동 확인 + 포커스/가시성 기반 갱신)
  - 결제 가능 시점 전까지 결제 액션 비활성화
- 후기 영역 동작 정리
  - 여행 전 후기 작성 입력 비활성화(조회 중심 UI)
- 지도/루트 표시 개선
  - 미리보기 영역의 지도 채움/시인성 개선
- 결제 오류 수정 (핵심)
  - 결제 생성(create) 재요청 시 멱등 처리 강화
  - 결제 확정(confirm) 중복 호출/뒤로가기 재진입 시 예외 처리 보완
  - 상태 전이(PENDING/ACCEPTED/PAID) 처리 안정화

---

## ⚠️ 주의 사항 / 질문
- 결제 재시도(뒤로가기 포함) 시나리오에서 동일 결제건을 멱등하게 처리하는 정책이 팀 의도와 일치하는지 확인 부탁드립니다.
- 결제 전 코스 미리보기(1번만 노출, 나머지 블러)의 노출 범위가 기획 의도와 맞는지 검토 부탁드립니다.
- 후기 작성 비활성화 시점(여행 완료 전/후) 기준을 현재 정책으로 확정할지 의견 부탁드립니다.

---

## ✅ 체크리스트
- [x] 빌드가 정상적으로 되는가?
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [x] .gitignore에 설정 파일이 잘 포함되었는가? (application-local.yml 등)
- [x] 결제 생성/확정 재시도 시 500 오류가 재현되지 않는가?
- [x] 결제 전/후 코스 공개 범위가 의도대로 동작하는가?