### PR TITLE
Feat/be#326

### DIFF
--- a/.github/workflows/k6-deploy.yml.yml
+++ b/.github/workflows/k6-deploy.yml.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - 'stress-test/**' # stress-test 폴더 내 파일 변경 시에만 실행
+  workflow_dispatch:
 
 jobs:
   deploy:

--- a/backend/deployment/nginx/be_blue.inc
+++ b/backend/deployment/nginx/be_blue.inc
@@ -7,8 +7,4 @@ location /api/ {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
 
-    # 연결 타임아웃 설정 (앱이 뜨는 중일 때 에러 방지)
-    proxy_connect_timeout 5s;
-    proxy_send_timeout 60s;
-    proxy_read_timeout 60s;
 }

--- a/backend/deployment/nginx/be_blue.inc
+++ b/backend/deployment/nginx/be_blue.inc
@@ -6,5 +6,4 @@ location /api/ {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
-
 }

--- a/backend/deployment/nginx/be_green.inc
+++ b/backend/deployment/nginx/be_green.inc
@@ -7,8 +7,4 @@ location /api/ {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
 
-    # 연결 타임아웃 설정 (앱이 뜨는 중일 때 에러 방지)
-    proxy_connect_timeout 5s;
-    proxy_send_timeout 60s;
-    proxy_read_timeout 60s;
 }

--- a/backend/deployment/nginx/be_green.inc
+++ b/backend/deployment/nginx/be_green.inc
@@ -6,5 +6,4 @@ location /api/ {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
-
 }

--- a/stress-test/scripts/test1.js
+++ b/stress-test/scripts/test1.js
@@ -3,7 +3,7 @@ import {sleep} from 'k6';
 
 export const options = {
     stages: [
-        { duration: '10m', target: 6000 }// 10분 동안 6,000명까지 증가
+        { duration: '1m', target: 100 }// 10분 동안 6,000명까지 증가
     ],
 };
 


### PR DESCRIPTION
# 🔗 이슈 번호
- Closes #326 

---

## 💡 주요 변경 사항
Nginx 설정 구조화 및 최적화: default.conf에서 backend.inc와 frontend.inc를 분리하여 Blue-Green 배포 스위칭이 용이하도록 개선
부하 테스트 전용 경로 예외 처리: /api/stress-test/ 경로에 대해 Nginx의 limit_req 속도 제한을 해제하여 정확한 성능 측정이 가능하도록 설정
백엔드 프록시 설정 강화: backend.inc를 통해 현재 활성화된 서버(Green: 8082)로 트래픽을 전달하는 Reverse Proxy 설정 완료
CI/CD 연동 준비: k6 테스트 스크립트가 Nginx 방어막을 통과하여 실제 스프링 부트 서버에 도달할 수 있는 인프라 환경 구축

---

## ⚠️ 주의 사항 / 질문
리뷰어가 중점적으로 봐주었으면 하는 부분이나 고민되는 지점을 적어주세요.

---

## ✅ 체크리스트
- [ ] 빌드가 정상적으로 되는가?
- [ ] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [ ] .gitignore에 설정 파일이 잘 포함되었는가? (application-local.yml 등)