### PR TITLE
Feat/fe#329: 가이드 상세·매칭 요청 화면에 소개·피드·후기 통합

### DIFF
--- a/frontend/src/pages/GuideDetailPage.css
+++ b/frontend/src/pages/GuideDetailPage.css
@@ -1,0 +1,295 @@
+/* Guest guide “product detail” — keep separate from guide dashboard CSS */
+
+.gdp {
+  max-width: 920px;
+  margin: 0 auto;
+  padding: 1rem 1rem 2.5rem;
+}
+
+.gdp-back {
+  margin-bottom: 0.75rem;
+}
+
+.gdp-back a {
+  color: #374151;
+  text-decoration: none;
+  font-size: 0.95rem;
+}
+
+.gdp-back a:hover {
+  text-decoration: underline;
+}
+
+.gdp-hero {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 1.25rem;
+  align-items: start;
+  padding: 1.25rem 0 1.5rem;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+@media (max-width: 560px) {
+  .gdp-hero {
+    grid-template-columns: 1fr;
+  }
+}
+
+.gdp-hero-avatar {
+  width: 120px;
+  height: 120px;
+  border-radius: 16px;
+  background: linear-gradient(145deg, #f3f4f6, #e5e7eb);
+  background-size: cover;
+  background-position: center;
+  flex-shrink: 0;
+}
+
+.gdp-hero-body h1 {
+  margin: 0 0 0.35rem;
+  font-size: 1.65rem;
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+}
+
+.gdp-hero-meta {
+  margin: 0;
+  color: #4b5563;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.gdp-hero-rating {
+  margin: 0.5rem 0 0;
+  font-size: 0.9rem;
+  color: #111827;
+}
+
+.gdp-hero-rating span {
+  color: #6b7280;
+  font-weight: 400;
+}
+
+.gdp-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: 0.65rem;
+}
+
+.gdp-tag {
+  display: inline-block;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  background: #f3f4f6;
+  color: #374151;
+  font-size: 0.8rem;
+}
+
+.gdp-section {
+  margin-top: 2rem;
+}
+
+.gdp-section-title {
+  margin: 0 0 0.75rem;
+  font-size: 1.05rem;
+  font-weight: 650;
+  letter-spacing: -0.01em;
+  color: #111827;
+}
+
+.gdp-prose {
+  margin: 0;
+  color: #374151;
+  line-height: 1.65;
+  white-space: pre-wrap;
+}
+
+.gdp-dl {
+  margin: 0;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.gdp-dl > div {
+  padding: 0.75rem 0.9rem;
+  border-radius: 10px;
+  background: #f9fafb;
+  border: 1px solid #f3f4f6;
+}
+
+.gdp-dl dt {
+  margin: 0 0 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #6b7280;
+}
+
+.gdp-dl dd {
+  margin: 0;
+  font-size: 0.92rem;
+  color: #1f2937;
+  line-height: 1.55;
+  white-space: pre-wrap;
+}
+
+.gdp-careers {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.gdp-career {
+  padding: 0.85rem 1rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  background: #fff;
+}
+
+.gdp-career-title {
+  font-weight: 600;
+  color: #111827;
+}
+
+.gdp-career-date {
+  font-size: 0.8rem;
+  color: #6b7280;
+  margin-top: 0.2rem;
+}
+
+.gdp-career-desc {
+  margin: 0.45rem 0 0;
+  font-size: 0.9rem;
+  color: #4b5563;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.gdp-gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 0.65rem;
+}
+
+.gdp-gallery-item {
+  aspect-ratio: 1;
+  border-radius: 10px;
+  background: #f3f4f6 center / cover no-repeat;
+  border: 1px solid #e5e7eb;
+}
+
+.gdp-feeds {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.gdp-feed-card {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #fff;
+  text-decoration: none;
+  color: inherit;
+  transition: box-shadow 0.15s ease, border-color 0.15s ease;
+}
+
+.gdp-feed-card:hover {
+  border-color: #d1d5db;
+  box-shadow: 0 6px 20px rgba(15, 23, 42, 0.06);
+}
+
+.gdp-feed-card-img {
+  height: 120px;
+  background: #f3f4f6 center / cover no-repeat;
+}
+
+.gdp-feed-card-body {
+  padding: 0.75rem 0.85rem 0.9rem;
+}
+
+.gdp-feed-card-title {
+  font-weight: 600;
+  font-size: 0.92rem;
+  margin: 0 0 0.35rem;
+  line-height: 1.35;
+  color: #111827;
+}
+
+.gdp-feed-card-snippet {
+  margin: 0;
+  font-size: 0.82rem;
+  color: #6b7280;
+  line-height: 1.45;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.gdp-reviews {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.gdp-review {
+  padding: 0.85rem 1rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  background: #fafafa;
+}
+
+.gdp-review-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.35rem;
+}
+
+.gdp-review-name {
+  font-weight: 600;
+  font-size: 0.88rem;
+  color: #111827;
+}
+
+.gdp-review-stars {
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+}
+
+.gdp-review-text {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #374151;
+  line-height: 1.55;
+  white-space: pre-wrap;
+}
+
+.gdp-muted {
+  margin: 0;
+  color: #6b7280;
+  font-size: 0.9rem;
+}
+
+.gdp-match {
+  margin-top: 2.25rem;
+  padding: 1.25rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  background: #fafafa;
+}
+
+.gdp-match h2 {
+  margin-top: 0;
+  font-size: 1.15rem;
+}

--- a/frontend/src/pages/GuideDetailPage.jsx
+++ b/frontend/src/pages/GuideDetailPage.jsx
@@ -1,9 +1,11 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Link, useParams, useLocation, useNavigate } from 'react-router-dom'
 
 import { PageEmpty, PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client'
 import { useAuth } from '../context/useAuth.js'
+
+import './GuideDetailPage.css'
 
 /**
  * @param {unknown} raw
@@ -76,6 +78,68 @@ function normalizeSchedule(schedule) {
   }
 }
 
+/**
+ * @param {unknown} keywords
+ * @returns {string[]}
+ */
+function parseProfileTags(keywords) {
+  if (keywords == null || keywords === '') return []
+  return String(keywords)
+    .split(/[,#\s]+/)
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .slice(0, 10)
+    .map((t) => (t.startsWith('#') ? t : `#${t}`))
+}
+
+/**
+ * @param {unknown} content
+ * @returns {string}
+ */
+function feedCardTitle(content) {
+  if (!content || !String(content).trim()) return '피드'
+  const line = String(content).split(/\r?\n/)[0]?.trim()
+  if (!line) return '피드'
+  return line.length > 72 ? `${line.slice(0, 72)}…` : line
+}
+
+/**
+ * @param {unknown} content
+ * @returns {string}
+ */
+function feedSnippet(content) {
+  if (!content) return ''
+  const lines = String(content).split(/\r?\n/)
+  const rest = lines.slice(1).join(' ').trim()
+  const chunk = rest || lines[0]?.trim() || ''
+  return chunk.length > 140 ? `${chunk.slice(0, 140)}…` : chunk
+}
+
+/**
+ * @param {unknown} raw
+ * @returns {string}
+ */
+function formatCareerDate(raw) {
+  if (raw == null || raw === '') return ''
+  const s = String(raw)
+  return s.length >= 10 ? s.slice(0, 10) : s
+}
+
+/**
+ * @param {any} feed
+ * @returns {string}
+ */
+function feedPrimaryImage(feed) {
+  const urls = Array.isArray(feed?.imageUrls) ? feed.imageUrls : []
+  const u0 = urls.find((u) => u && String(u).trim())
+  if (u0) return String(u0).trim()
+  if (feed?.imageUrl) {
+    const first = String(feed.imageUrl).split(',')[0]?.trim()
+    if (first) return first
+  }
+  return ''
+}
+
 export function GuideDetailPage() {
   const { guideId } = useParams()
   const location = useLocation()
@@ -84,6 +148,7 @@ export function GuideDetailPage() {
 
   const [detail, setDetail] = useState(null)
   const [schedules, setSchedules] = useState([])
+  const [reviews, setReviews] = useState([])
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(true)
 
@@ -105,13 +170,16 @@ export function GuideDetailPage() {
           throw new Error(text || '조회 실패')
         }
         const data = text ? JSON.parse(text) : null
-        if (!cancelled) {
-          setDetail(data)
-          const p = data?.profile
-          if (p?.region) setDestination(String(p.region).trim())
-        }
+        if (cancelled) return
+        setDetail(data)
+        const p = data?.profile
+        if (p?.region) setDestination(String(p.region).trim())
 
-        const schRes = await apiRequest(`/guides/${guideId}/schedules`, { method: 'GET', skipAuth: true })
+        const [schRes, revRes] = await Promise.all([
+          apiRequest(`/guides/${guideId}/schedules`, { method: 'GET', skipAuth: true }),
+          apiRequest(`/reviews/guide/${guideId}?size=12&sort=createdAt,desc`, { method: 'GET', skipAuth: true }),
+        ])
+
         const schText = await schRes.text()
         if (schRes.ok) {
           const parsed = schText ? JSON.parse(schText) : []
@@ -126,6 +194,18 @@ export function GuideDetailPage() {
         } else if (!cancelled) {
           setSchedules([])
         }
+
+        let revList = []
+        if (revRes.ok) {
+          try {
+            const revText = await revRes.text()
+            const revJson = revText ? JSON.parse(revText) : {}
+            revList = Array.isArray(revJson.content) ? revJson.content : []
+          } catch {
+            revList = []
+          }
+        }
+        if (!cancelled) setReviews(revList)
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : '오류')
       } finally {
@@ -144,6 +224,26 @@ export function GuideDetailPage() {
       })
     }
   }, [loading, detail, location.hash])
+
+  const tags = useMemo(() => parseProfileTags(detail?.profile?.keywords), [detail])
+
+  const ratingLine = useMemo(() => {
+    const p = detail?.profile
+    if (!p) return null
+    const avg = p.averageRating
+    const cnt = p.reviewCount != null ? Number(p.reviewCount) : 0
+    if (avg == null || avg === '') {
+      return cnt > 0 ? `리뷰 ${cnt}건` : '아직 리뷰가 없어요'
+    }
+    const stars = Number(avg)
+    const label = Number.isFinite(stars) ? stars.toFixed(1) : String(avg)
+    return (
+      <>
+        ⭐ <strong>{label}</strong>
+        {cnt > 0 ? <span> · 리뷰 {cnt}건</span> : null}
+      </>
+    )
+  }, [detail])
 
   const onSubmitMatch = async (e) => {
     e.preventDefault()
@@ -212,53 +312,195 @@ export function GuideDetailPage() {
 
   if (loading) {
     return (
-      <div style={{ maxWidth: 720, margin: '0 auto', padding: '1rem' }}>
+      <div className="gdp" style={{ maxWidth: 720, margin: '0 auto', padding: '1rem' }}>
         <PageLoading />
       </div>
     )
   }
   if (error) {
     return (
-      <div style={{ maxWidth: 720, margin: '0 auto', padding: '1rem' }}>
+      <div className="gdp" style={{ maxWidth: 720, margin: '0 auto', padding: '1rem' }}>
         <PageError message={error} />
       </div>
     )
   }
   if (!detail?.profile) {
     return (
-      <div style={{ maxWidth: 720, margin: '0 auto', padding: '1rem' }}>
+      <div className="gdp" style={{ maxWidth: 720, margin: '0 auto', padding: '1rem' }}>
         <PageEmpty title="표시할 프로필이 없습니다">가이드 ID를 확인하거나 목록으로 돌아가 주세요.</PageEmpty>
       </div>
     )
   }
 
   const p = detail.profile
+  const careers = Array.isArray(detail.careers) ? detail.careers : []
+  const images = Array.isArray(detail.images) ? detail.images : []
+  const feeds = Array.isArray(detail.feeds) ? detail.feeds : []
+  const avatarStyle = p.profileImage ? { backgroundImage: `url(${p.profileImage})` } : undefined
+
+  const storyBlocks = [
+    p.residenceYears != null && Number(p.residenceYears) > 0
+      ? { label: '거주', text: `이 지역에 약 ${p.residenceYears}년 살았어요.` }
+      : null,
+    p.localStory && String(p.localStory).trim()
+      ? { label: '지역 이야기', text: String(p.localStory).trim() }
+      : null,
+    p.guideStyle && String(p.guideStyle).trim()
+      ? { label: '가이드 스타일', text: String(p.guideStyle).trim() }
+      : null,
+    p.defaultCourse && String(p.defaultCourse).trim()
+      ? { label: '추천 코스', text: String(p.defaultCourse).trim() }
+      : null,
+  ].filter(Boolean)
 
   return (
-    <div>
-      <p>
+    <div className="gdp">
+      <p className="gdp-back">
         <Link to="/guides">← 목록</Link>
       </p>
-      <h1 style={{ marginTop: 0 }}>{p.nickname}</h1>
-      <p style={{ color: '#555' }}>
-        {p.region} · {p.language} · {p.pricePerHour != null ? `${p.pricePerHour} / 시간` : ''}
-      </p>
-      {p.bio && <p style={{ lineHeight: 1.6 }}>{p.bio}</p>}
-      <p style={{ fontSize: '0.85rem', color: '#777' }}>
-        승인: {String(p.isApproved)} · 활성: {String(p.isActive)}
-      </p>
 
-      <section
-        id="match-request"
-        style={{
-          marginTop: '2rem',
-          padding: '1.25rem',
-          border: '1px solid #e5e7eb',
-          borderRadius: 12,
-          background: '#fafafa',
-        }}
-      >
-        <h2 style={{ marginTop: 0, fontSize: '1.15rem' }}>매칭 요청하기</h2>
+      <header className="gdp-hero">
+        <div className="gdp-hero-avatar" style={avatarStyle} role="img" aria-label={p.nickname ?? '가이드'} />
+        <div className="gdp-hero-body">
+          <h1>{p.nickname}</h1>
+          <p className="gdp-hero-meta">
+            {p.region} · {p.language}
+            {p.pricePerHour != null ? ` · ${Number(p.pricePerHour).toLocaleString('ko-KR')}원 / 시간` : ''}
+          </p>
+          {ratingLine && <p className="gdp-hero-rating">{ratingLine}</p>}
+          {tags.length > 0 && (
+            <div className="gdp-tags">
+              {tags.map((t) => (
+                <span key={t} className="gdp-tag">
+                  {t}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      </header>
+
+      {(p.bio && String(p.bio).trim()) || storyBlocks.length > 0 ? (
+        <section className="gdp-section" aria-labelledby="gdp-intro">
+          <h2 id="gdp-intro" className="gdp-section-title">
+            소개
+          </h2>
+          {p.bio && String(p.bio).trim() ? (
+            <p className="gdp-prose">{String(p.bio).trim()}</p>
+          ) : (
+            <p className="gdp-muted">등록된 한 줄 소개가 없어요. 피드와 후기를 참고해 주세요.</p>
+          )}
+          {storyBlocks.length > 0 && (
+            <dl className="gdp-dl" style={{ marginTop: '1rem' }}>
+              {storyBlocks.map((row) => (
+                <div key={row.label}>
+                  <dt>{row.label}</dt>
+                  <dd>{row.text}</dd>
+                </div>
+              ))}
+            </dl>
+          )}
+        </section>
+      ) : null}
+
+      {careers.length > 0 ? (
+        <section className="gdp-section" aria-labelledby="gdp-career">
+          <h2 id="gdp-career" className="gdp-section-title">
+            경력 · 자격
+          </h2>
+          <ul className="gdp-careers">
+            {careers.map((c) => (
+              <li key={c.careerId ?? c.title} className="gdp-career">
+                <div className="gdp-career-title">{c.title ?? '경력'}</div>
+                {c.acquiredAt && <div className="gdp-career-date">{formatCareerDate(c.acquiredAt)}</div>}
+                {c.description && String(c.description).trim() ? (
+                  <p className="gdp-career-desc">{String(c.description).trim()}</p>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      {images.length > 0 ? (
+        <section className="gdp-section" aria-labelledby="gdp-photos">
+          <h2 id="gdp-photos" className="gdp-section-title">
+            사진
+          </h2>
+          <div className="gdp-gallery">
+            {images.map((img) => (
+              <div
+                key={img.imageId ?? img.imageUrl}
+                className="gdp-gallery-item"
+                style={img.imageUrl ? { backgroundImage: `url(${img.imageUrl})` } : undefined}
+                role="img"
+                aria-label=""
+              />
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {feeds.length > 0 ? (
+        <section className="gdp-section" aria-labelledby="gdp-feeds">
+          <h2 id="gdp-feeds" className="gdp-section-title">
+            피드 · 코스
+          </h2>
+          <div className="gdp-feeds">
+            {feeds.map((f) => {
+              const href = `/guides/${guideId}/feeds/${f.feedId}`
+              const bg = feedPrimaryImage(f)
+              return (
+                <Link key={f.feedId} to={href} className="gdp-feed-card">
+                  <div
+                    className="gdp-feed-card-img"
+                    style={bg ? { backgroundImage: `url(${bg})` } : undefined}
+                  />
+                  <div className="gdp-feed-card-body">
+                    <h3 className="gdp-feed-card-title">{feedCardTitle(f.content)}</h3>
+                    <p className="gdp-feed-card-snippet">{feedSnippet(f.content)}</p>
+                  </div>
+                </Link>
+              )
+            })}
+          </div>
+        </section>
+      ) : (
+        <section className="gdp-section" aria-labelledby="gdp-feeds-empty">
+          <h2 id="gdp-feeds-empty" className="gdp-section-title">
+            피드 · 코스
+          </h2>
+          <p className="gdp-muted">아직 등록된 피드가 없어요.</p>
+        </section>
+      )}
+
+      <section className="gdp-section" aria-labelledby="gdp-reviews">
+        <h2 id="gdp-reviews" className="gdp-section-title">
+          후기
+        </h2>
+        {reviews.length === 0 ? (
+          <p className="gdp-muted">아직 표시할 후기가 없어요.</p>
+        ) : (
+          <ul className="gdp-reviews">
+            {reviews.map((r) => (
+              <li key={r.id} className="gdp-review">
+                <div className="gdp-review-head">
+                  <span className="gdp-review-name">{r.writeNickname ?? '여행자'}</span>
+                  <span className="gdp-review-stars">
+                    {'⭐'.repeat(Math.min(5, Math.max(0, Number(r.rating) || 0)))}
+                  </span>
+                </div>
+                {r.content && String(r.content).trim() ? (
+                  <p className="gdp-review-text">{String(r.content).trim()}</p>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="gdp-match" id="match-request">
+        <h2>매칭 요청하기</h2>
         <p style={{ color: '#4b5563', fontSize: '0.95rem', lineHeight: 1.5 }}>
           예약 가능한 일정을 고르고 목적지를 적으면 가이드에게 매칭 요청이 전달됩니다. (가이드가 일정을 아직 등록하지 않았다면
           요청할 수 없어요.)


### PR DESCRIPTION
## 🔗 이슈 번호

Closes #329

## 💡 주요 변경 사항

- `GuideDetailPage.jsx`: 히어로(프로필 이미지·닉네임·지역/언어/시급·평점·키워드), **소개**(bio + 거주/지역 스토리/가이드 스타일/추천 코스), **경력**, **사진 갤러리**, **피드 카드 그리드**(피드 상세로 이동), **후기 목록**(`/reviews/guide/{guideId}`) 섹션 추가 후 기존 **매칭 요청** 블록 유지(`#match-request` 스크롤 동작 유지).
- `GuideDetailPage.css`: 게스트 가이드 상세 전용 스타일 분리.
- 게스트 화면에서 **승인·활성 boolean raw 문구** 제거.

## ⚠️ 주의 사항 / 질문

- 가이드 역할 **대시보드**(`guideRoutes`, `GuideDashboardLayout`, `GuideFeesPage` 등)는 **수정하지 않음** — 팀원 가이드 쪽 작업과 충돌 최소화.
- 리뷰 **요약 숫자**는 프로필(`averageRating`, `reviewCount`) 기준이며, 목록은 review API `content` 기준. 불일치 시 백엔드/캐시 정책 확인 필요할 수 있음.

## ✅ 체크리스트

- [x] 빌드가 정상적으로 되는가? (`npm run build`)
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가? (`Feat/fe#329: ...`)
- [x] `.gitignore`에 설정 파일이 잘 포함되었는가? (본 PR에서 `application-local.yml` 등 비밀 설정 **미변경**)