### PR TITLE
Feat/fe#333 매칭 코스 페이지 — 동행 단일 요금·세로 레이아웃·결제 직행

### DIFF
--- a/frontend/src/pages/GuideMatchOptionsPage.css
+++ b/frontend/src/pages/GuideMatchOptionsPage.css
@@ -104,6 +104,30 @@
   position: relative;
 }
 
+.gmo-hero--clickable {
+  cursor: pointer;
+  transition:
+    box-shadow 0.18s ease,
+    border-color 0.18s ease;
+}
+
+.gmo-hero--clickable:hover {
+  border-color: #d1d5db;
+  box-shadow: 0 10px 32px rgba(15, 23, 42, 0.08);
+}
+
+.gmo-hero--clickable:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 3px;
+}
+
+.gmo-hero-hint {
+  margin: 0.45rem 0 0;
+  font-size: 0.72rem;
+  color: #64748b;
+  font-weight: 500;
+}
+
 .gmo-hero-ph {
   width: 5.5rem;
   height: 5.5rem;
@@ -572,5 +596,261 @@
   margin-top: 0.65rem;
   font-size: 0.82rem;
   color: #b91c1c;
+}
+
+/* 가이드 카드 클릭 → 소개·피드·후기 모달 */
+.gmo-profile-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 1.25rem 1rem 2rem;
+  box-sizing: border-box;
+  background: rgba(15, 23, 42, 0.45);
+  overflow-y: auto;
+}
+
+.gmo-profile-dialog {
+  width: 100%;
+  max-width: 520px;
+  margin-top: 0.5rem;
+  margin-bottom: auto;
+  background: #fff;
+  border-radius: 16px;
+  border: 1px solid #e5e7eb;
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.18);
+  padding: 1rem 1.1rem 1.15rem;
+  box-sizing: border-box;
+  max-height: min(88vh, 720px);
+  overflow-y: auto;
+}
+
+.gmo-profile-dialog-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.gmo-profile-dialog-title {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 800;
+  color: #111827;
+  line-height: 1.25;
+}
+
+.gmo-profile-dialog-close {
+  flex-shrink: 0;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  background: #f9fafb;
+  color: #374151;
+  font-size: 0.8rem;
+  font-weight: 700;
+  padding: 0.4rem 0.75rem;
+  cursor: pointer;
+}
+
+.gmo-profile-dialog-close:hover {
+  background: #f3f4f6;
+}
+
+.gmo-profile-dialog-meta {
+  margin: 0.35rem 0 0.5rem;
+  font-size: 0.82rem;
+  color: #64748b;
+}
+
+.gmo-profile-dialog-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-bottom: 0.75rem;
+}
+
+.gmo-profile-dialog-tag {
+  font-size: 0.72rem;
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  background: #f3f4f6;
+  color: #4b5563;
+}
+
+.gmo-profile-dialog-section {
+  margin-top: 1rem;
+  padding-top: 0.85rem;
+  border-top: 1px solid #f1f5f9;
+}
+
+.gmo-profile-dialog-h3 {
+  margin: 0 0 0.5rem;
+  font-size: 0.88rem;
+  font-weight: 800;
+  color: #111827;
+}
+
+.gmo-profile-dialog-prose {
+  margin: 0;
+  font-size: 0.86rem;
+  line-height: 1.6;
+  color: #374151;
+  white-space: pre-wrap;
+}
+
+.gmo-profile-dialog-muted {
+  margin: 0;
+  font-size: 0.82rem;
+  color: #94a3b8;
+  line-height: 1.45;
+}
+
+.gmo-profile-dialog-dl {
+  margin: 0.65rem 0 0;
+  display: grid;
+  gap: 0.55rem;
+}
+
+.gmo-profile-dialog-dl > div {
+  padding: 0.55rem 0.65rem;
+  border-radius: 10px;
+  background: #f8fafc;
+  border: 1px solid #f1f5f9;
+}
+
+.gmo-profile-dialog-dl dt {
+  margin: 0 0 0.2rem;
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #64748b;
+}
+
+.gmo-profile-dialog-dl dd {
+  margin: 0;
+  font-size: 0.8rem;
+  color: #334155;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.gmo-profile-dialog-feeds {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.gmo-profile-dialog-feed {
+  display: flex;
+  gap: 0.65rem;
+  align-items: stretch;
+  text-decoration: none;
+  color: inherit;
+  padding: 0.5rem;
+  border-radius: 12px;
+  border: 1px solid #e8eaed;
+  background: #fafafa;
+  transition:
+    border-color 0.15s ease,
+    background 0.15s ease;
+}
+
+.gmo-profile-dialog-feed:hover {
+  border-color: #d1d5db;
+  background: #fff;
+}
+
+.gmo-profile-dialog-feed-img {
+  width: 4.25rem;
+  min-height: 4.25rem;
+  flex-shrink: 0;
+  border-radius: 10px;
+  background: #e5e7eb center / cover no-repeat;
+}
+
+.gmo-profile-dialog-feed-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.gmo-profile-dialog-feed-title {
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: #111827;
+  line-height: 1.35;
+}
+
+.gmo-profile-dialog-feed-snippet {
+  font-size: 0.74rem;
+  color: #64748b;
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.gmo-profile-dialog-reviews {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.gmo-profile-dialog-review {
+  padding: 0.55rem 0.65rem;
+  border-radius: 10px;
+  border: 1px solid #f1f5f9;
+  background: #fafafa;
+}
+
+.gmo-profile-dialog-review-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  margin-bottom: 0.25rem;
+}
+
+.gmo-profile-dialog-review-name {
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: #111827;
+}
+
+.gmo-profile-dialog-review-stars {
+  font-size: 0.75rem;
+}
+
+.gmo-profile-dialog-review-text {
+  margin: 0;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  color: #475569;
+  white-space: pre-wrap;
+}
+
+.gmo-profile-dialog-footer {
+  margin: 1rem 0 0;
+  padding-top: 0.75rem;
+  border-top: 1px solid #f1f5f9;
+  font-size: 0.8rem;
+}
+
+.gmo-profile-dialog-footer a {
+  color: #2563eb;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.gmo-profile-dialog-footer a:hover {
+  text-decoration: underline;
 }
 

--- a/frontend/src/pages/GuideMatchOptionsPage.css
+++ b/frontend/src/pages/GuideMatchOptionsPage.css
@@ -158,17 +158,12 @@
   }
 }
 
-.gmo-grid {
-  display: grid;
-  grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+/* 세로 흐름: 가격 → 지도 (가이드는 상단 히어로, 일정은 하단 코스 블록) */
+.gmo-main-flow {
+  display: flex;
+  flex-direction: column;
   gap: 1rem;
-  align-items: stretch;
-}
-
-@media (max-width: 800px) {
-  .gmo-grid {
-    grid-template-columns: 1fr;
-  }
+  margin-bottom: 0.25rem;
 }
 
 .gmo-preview {
@@ -476,7 +471,7 @@
   }
 }
 
-.gmo-side {
+.gmo-price-panel {
   background: #fff;
   border: 1px solid #e8eaed;
   border-radius: 16px;
@@ -485,73 +480,40 @@
   flex-direction: column;
 }
 
-.gmo-side--focus {
-  border-color: #2563eb;
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2), 0 8px 24px rgba(37, 99, 235, 0.15);
-  transition: box-shadow 0.22s ease, border-color 0.22s ease;
-}
-
-.gmo-side h2 {
-  margin: 0 0 0.85rem;
+.gmo-price-panel h2 {
+  margin: 0 0 0.5rem;
   font-size: 0.95rem;
   font-weight: 800;
   color: #111827;
 }
 
-.gmo-opt {
-  display: block;
-  margin-bottom: 0.55rem;
-  cursor: pointer;
+.gmo-price-lead {
+  margin: 0 0 0.85rem;
+  font-size: 0.78rem;
+  line-height: 1.5;
+  color: #64748b;
 }
 
-.gmo-opt input {
-  position: absolute;
-  opacity: 0;
-  pointer-events: none;
-}
-
-.gmo-opt-inner {
+.gmo-price-highlight {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
-  padding: 0.75rem 0.85rem;
+  padding: 0.85rem 0.95rem;
   border-radius: 12px;
-  border: 2px solid #e5e7eb;
-  transition:
-    border-color 0.15s ease,
-    background 0.15s ease;
-}
-
-.gmo-opt input:focus-visible + .gmo-opt-inner {
-  outline: 2px solid #111827;
-  outline-offset: 2px;
-}
-
-.gmo-opt input:checked + .gmo-opt-inner {
-  border-color: #1f2328;
+  border: 2px solid #1f2328;
   background: #fafafa;
+  margin-bottom: 0.65rem;
 }
 
-.gmo-opt-text {
-  display: flex;
-  flex-direction: column;
-  gap: 0.15rem;
-}
-
-.gmo-opt-title {
-  font-size: 0.86rem;
+.gmo-price-label {
+  font-size: 0.8rem;
   font-weight: 700;
-  color: #111827;
+  color: #374151;
 }
 
-.gmo-opt-desc {
-  font-size: 0.72rem;
-  color: #6b7280;
-}
-
-.gmo-opt-price {
-  font-size: 0.88rem;
+.gmo-price-value {
+  font-size: 1rem;
   font-weight: 800;
   color: #111827;
   white-space: nowrap;
@@ -561,13 +523,16 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-top: auto;
-  padding-top: 1rem;
+  padding-top: 0.65rem;
   margin-bottom: 0.85rem;
   border-top: 1px solid #eef0f3;
   font-size: 0.88rem;
   font-weight: 700;
   color: #374151;
+}
+
+.gmo-total--single {
+  margin-top: 0;
 }
 
 .gmo-total strong {
@@ -609,95 +574,3 @@
   color: #b91c1c;
 }
 
-.gmo-reviews {
-  margin-top: 1.75rem;
-}
-
-.gmo-reviews h2 {
-  margin: 0 0 0.75rem;
-  font-size: 1rem;
-  font-weight: 800;
-  color: #111827;
-}
-
-.gmo-reviews-readonly {
-  margin: 0 0 0.9rem;
-  font-size: 0.82rem;
-  line-height: 1.45;
-  color: #64748b;
-}
-
-.gmo-review-form {
-  display: flex;
-  gap: 0.5rem;
-  margin-bottom: 1rem;
-  align-items: stretch;
-}
-
-.gmo-review-input {
-  flex: 1;
-  border: 1px solid #e5e7eb;
-  border-radius: 12px;
-  padding: 0.55rem 0.75rem;
-  font: inherit;
-  font-size: 0.86rem;
-  resize: vertical;
-  min-height: 2.75rem;
-}
-
-.gmo-review-submit {
-  flex-shrink: 0;
-  padding: 0 1rem;
-  border-radius: 12px;
-  border: none;
-  background: #1f2328;
-  color: #fff;
-  font-weight: 700;
-  font-size: 0.82rem;
-  cursor: pointer;
-}
-
-.gmo-review-submit:disabled {
-  opacity: 0.45;
-  cursor: not-allowed;
-}
-
-.gmo-review-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.65rem;
-}
-
-.gmo-review-item {
-  display: flex;
-  gap: 0.65rem;
-  padding: 0.75rem 0.85rem;
-  border: 1px solid #e8eaed;
-  border-radius: 14px;
-  background: #fff;
-}
-
-.gmo-review-av {
-  width: 2.25rem;
-  height: 2.25rem;
-  border-radius: 50%;
-  background: #e5e7eb;
-  flex-shrink: 0;
-}
-
-.gmo-review-name {
-  margin: 0 0 0.25rem;
-  font-size: 0.82rem;
-  font-weight: 700;
-  color: #111827;
-}
-
-.gmo-review-text {
-  margin: 0;
-  font-size: 0.82rem;
-  line-height: 1.5;
-  color: #4b5563;
-}

--- a/frontend/src/pages/GuideMatchOptionsPage.jsx
+++ b/frontend/src/pages/GuideMatchOptionsPage.jsx
@@ -77,6 +77,42 @@ function hasProposalContent(row) {
   return !!(String(row.proposedSchedule ?? '').trim() || String(row.proposeMessage ?? '').trim())
 }
 
+function parseProfileTags(keywords) {
+  if (keywords == null || keywords === '') return []
+  return String(keywords)
+    .split(/[,#\s]+/)
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .slice(0, 10)
+    .map((t) => (t.startsWith('#') ? t : `#${t}`))
+}
+
+function feedCardTitle(content) {
+  if (!content || !String(content).trim()) return '피드'
+  const line = String(content).split(/\r?\n/)[0]?.trim()
+  if (!line) return '피드'
+  return line.length > 72 ? `${line.slice(0, 72)}…` : line
+}
+
+function feedSnippet(content) {
+  if (!content) return ''
+  const lines = String(content).split(/\r?\n/)
+  const rest = lines.slice(1).join(' ').trim()
+  const chunk = rest || lines[0]?.trim() || ''
+  return chunk.length > 140 ? `${chunk.slice(0, 140)}…` : chunk
+}
+
+function feedPrimaryImage(feed) {
+  const urls = Array.isArray(feed?.imageUrls) ? feed.imageUrls : []
+  const u0 = urls.find((u) => u && String(u).trim())
+  if (u0) return String(u0).trim()
+  if (feed?.imageUrl) {
+    const first = String(feed.imageUrl).split(',')[0]?.trim()
+    if (first) return first
+  }
+  return ''
+}
+
 export function GuideMatchOptionsPage() {
   const { guideId } = useParams()
   const location = useLocation()
@@ -96,6 +132,13 @@ export function GuideMatchOptionsPage() {
   const hasProposalRef = useRef(false)
   const initializedProposalRef = useRef(false)
 
+  /** `/guides/:id/detail` 전체 (모달에서 피드·소개 확장용) */
+  const [guideDetail, setGuideDetail] = useState(null)
+  const [profileModalOpen, setProfileModalOpen] = useState(false)
+  const [modalReviews, setModalReviews] = useState([])
+  const [modalReviewsLoading, setModalReviewsLoading] = useState(false)
+  const [modalReviewsErr, setModalReviewsErr] = useState('')
+
   const accompanyPackageWon = useMemo(() => {
     const hourly = profile?.pricePerHour != null ? Number(profile.pricePerHour) : 0
     if (!Number.isFinite(hourly) || hourly <= 0) return 0
@@ -113,6 +156,7 @@ export function GuideMatchOptionsPage() {
       const text = await res.text()
       if (!res.ok) throw new Error(text || '가이드를 불러오지 못했습니다.')
       const detail = text ? JSON.parse(text) : null
+      setGuideDetail(detail)
       setProfile(detail?.profile ?? null)
 
       const listRes = await apiRequest('/matching/requests/guest/list', { method: 'GET' })
@@ -194,6 +238,81 @@ export function GuideMatchOptionsPage() {
   const previewFirstSpot = previewSpots[0] ?? ''
   const previewLockedSpots = previewSpots.slice(1)
   const hasLockedPreview = previewLockedSpots.length > 0 || !!previewHint
+
+  const modalTags = useMemo(() => parseProfileTags(profile?.keywords), [profile])
+
+  const modalFeeds = useMemo(() => {
+    const feeds = guideDetail?.feeds
+    return Array.isArray(feeds) ? feeds : []
+  }, [guideDetail])
+
+  const modalStoryBlocks = useMemo(() => {
+    const p = profile
+    if (!p) return []
+    return [
+      p.residenceYears != null && Number(p.residenceYears) > 0
+        ? { label: '거주', text: `이 지역에 약 ${p.residenceYears}년 살았어요.` }
+        : null,
+      p.localStory && String(p.localStory).trim()
+        ? { label: '지역 이야기', text: String(p.localStory).trim() }
+        : null,
+      p.guideStyle && String(p.guideStyle).trim()
+        ? { label: '가이드 스타일', text: String(p.guideStyle).trim() }
+        : null,
+      p.defaultCourse && String(p.defaultCourse).trim()
+        ? { label: '추천 코스', text: String(p.defaultCourse).trim() }
+        : null,
+    ].filter(Boolean)
+  }, [profile])
+
+  useEffect(() => {
+    if (!profileModalOpen) return
+    const onKey = (e) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        setProfileModalOpen(false)
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    const prevOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      window.removeEventListener('keydown', onKey)
+      document.body.style.overflow = prevOverflow
+    }
+  }, [profileModalOpen])
+
+  useEffect(() => {
+    if (!profileModalOpen || !guideId) return
+    let cancelled = false
+    setModalReviewsLoading(true)
+    setModalReviewsErr('')
+    void apiRequest(`/reviews/guide/${guideId}?size=15&sort=createdAt,desc`, { method: 'GET', skipAuth: true })
+      .then(async (revRes) => {
+        const revText = await revRes.text()
+        if (cancelled) return
+        if (!revRes.ok) {
+          setModalReviewsErr(revText || '후기를 불러오지 못했습니다.')
+          setModalReviews([])
+          return
+        }
+        const page = revText ? JSON.parse(revText) : {}
+        const raw = page?.content
+        setModalReviews(Array.isArray(raw) ? raw : [])
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setModalReviewsErr('후기를 불러오지 못했습니다.')
+          setModalReviews([])
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setModalReviewsLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [profileModalOpen, guideId])
 
   useEffect(() => {
     if (!proposalArrivedNotice) return
@@ -353,7 +472,21 @@ export function GuideMatchOptionsPage() {
         <p className="gmo-arrived-banner">제시안이 도착했어요! 아래에서 코스 일부를 확인하고 결제를 진행해 주세요.</p>
       )}
 
-      <header className="gmo-hero">
+      <header
+        className="gmo-hero gmo-hero--clickable"
+        role="button"
+        tabIndex={0}
+        aria-haspopup="dialog"
+        aria-expanded={profileModalOpen}
+        aria-label={`${profile.nickname ?? '가이드'} 상세 정보 열기`}
+        onClick={() => setProfileModalOpen(true)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            setProfileModalOpen(true)
+          }
+        }}
+      >
         <div
           className="gmo-hero-ph"
           style={profile.profileImage ? { backgroundImage: `url(${profile.profileImage})` } : undefined}
@@ -364,9 +497,10 @@ export function GuideMatchOptionsPage() {
             📍 {profile.region ?? ''} · ⭐ {rating} ({rc} 리뷰)
           </p>
           <p className="gmo-hero-quote">{quote}</p>
+          <p className="gmo-hero-hint">클릭하면 소개·피드·후기를 볼 수 있어요</p>
         </div>
-        <div className="gmo-likes" aria-label="좋아요">
-          <span aria-hidden>♡</span> {likes}
+        <div className="gmo-likes" aria-hidden>
+          <span>♡</span> {likes}
         </div>
       </header>
 
@@ -474,6 +608,129 @@ export function GuideMatchOptionsPage() {
           <p className="gmo-course-pending-title">가이드가 코스를 작성 중이에요</p>
           <p className="gmo-course-pending-sub">조금만 기다려 주세요. 작성이 완료되면 일부 코스가 여기에 먼저 공개됩니다.</p>
         </section>
+      )}
+
+      {profileModalOpen && (
+        <div
+          className="gmo-profile-modal"
+          role="presentation"
+          onMouseDown={(e) => {
+            if (e.target === e.currentTarget) setProfileModalOpen(false)
+          }}
+        >
+          <div
+            className="gmo-profile-dialog"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="gmo-profile-dialog-title"
+            onMouseDown={(e) => e.stopPropagation()}
+          >
+            <div className="gmo-profile-dialog-head">
+              <h2 id="gmo-profile-dialog-title" className="gmo-profile-dialog-title">
+                {profile.nickname ?? '가이드'}
+              </h2>
+              <button type="button" className="gmo-profile-dialog-close" onClick={() => setProfileModalOpen(false)}>
+                닫기
+              </button>
+            </div>
+            <p className="gmo-profile-dialog-meta">
+              📍 {profile.region ?? ''} · ⭐ {rating} ({rc} 리뷰)
+            </p>
+            {modalTags.length > 0 && (
+              <div className="gmo-profile-dialog-tags">
+                {modalTags.map((t) => (
+                  <span key={t} className="gmo-profile-dialog-tag">
+                    {t}
+                  </span>
+                ))}
+              </div>
+            )}
+
+            <section className="gmo-profile-dialog-section" aria-labelledby="gmo-modal-intro">
+              <h3 id="gmo-modal-intro" className="gmo-profile-dialog-h3">
+                소개
+              </h3>
+              {profile.bio && String(profile.bio).trim() ? (
+                <p className="gmo-profile-dialog-prose">{String(profile.bio).trim()}</p>
+              ) : (
+                <p className="gmo-profile-dialog-muted">등록된 한 줄 소개가 없어요.</p>
+              )}
+              {modalStoryBlocks.length > 0 && (
+                <dl className="gmo-profile-dialog-dl">
+                  {modalStoryBlocks.map((row) => (
+                    <div key={row.label}>
+                      <dt>{row.label}</dt>
+                      <dd>{row.text}</dd>
+                    </div>
+                  ))}
+                </dl>
+              )}
+            </section>
+
+            <section className="gmo-profile-dialog-section" aria-labelledby="gmo-modal-feeds">
+              <h3 id="gmo-modal-feeds" className="gmo-profile-dialog-h3">
+                피드
+              </h3>
+              {modalFeeds.length === 0 ? (
+                <p className="gmo-profile-dialog-muted">등록된 피드가 없어요.</p>
+              ) : (
+                <div className="gmo-profile-dialog-feeds">
+                  {modalFeeds.map((f) => {
+                    const href = `/guides/${guideId}/feeds/${f.feedId}`
+                    const bg = feedPrimaryImage(f)
+                    return (
+                      <Link key={f.feedId} to={href} className="gmo-profile-dialog-feed" onClick={() => setProfileModalOpen(false)}>
+                        <div
+                          className="gmo-profile-dialog-feed-img"
+                          style={bg ? { backgroundImage: `url(${bg})` } : undefined}
+                        />
+                        <div className="gmo-profile-dialog-feed-body">
+                          <span className="gmo-profile-dialog-feed-title">{feedCardTitle(f.content)}</span>
+                          <span className="gmo-profile-dialog-feed-snippet">{feedSnippet(f.content)}</span>
+                        </div>
+                      </Link>
+                    )
+                  })}
+                </div>
+              )}
+            </section>
+
+            <section className="gmo-profile-dialog-section" aria-labelledby="gmo-modal-reviews">
+              <h3 id="gmo-modal-reviews" className="gmo-profile-dialog-h3">
+                후기
+              </h3>
+              {modalReviewsLoading ? (
+                <p className="gmo-profile-dialog-muted">불러오는 중…</p>
+              ) : modalReviewsErr ? (
+                <p className="gmo-profile-dialog-muted">{modalReviewsErr}</p>
+              ) : modalReviews.length === 0 ? (
+                <p className="gmo-profile-dialog-muted">아직 등록된 후기가 없어요.</p>
+              ) : (
+                <ul className="gmo-profile-dialog-reviews">
+                  {modalReviews.map((r) => (
+                    <li key={r.id} className="gmo-profile-dialog-review">
+                      <div className="gmo-profile-dialog-review-head">
+                        <span className="gmo-profile-dialog-review-name">{r.writeNickname ?? '여행자'}</span>
+                        <span className="gmo-profile-dialog-review-stars">
+                          {'⭐'.repeat(Math.min(5, Math.max(0, Number(r.rating) || 0)))}
+                        </span>
+                      </div>
+                      {r.content && String(r.content).trim() ? (
+                        <p className="gmo-profile-dialog-review-text">{String(r.content).trim()}</p>
+                      ) : null}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
+
+            <p className="gmo-profile-dialog-footer">
+              <Link to={`/guides/${guideId}`} onClick={() => setProfileModalOpen(false)}>
+                전체 프로필 페이지로 이동 →
+              </Link>
+            </p>
+          </div>
+        </div>
       )}
     </div>
   )

--- a/frontend/src/pages/GuideMatchOptionsPage.jsx
+++ b/frontend/src/pages/GuideMatchOptionsPage.jsx
@@ -7,8 +7,8 @@ import { fetchGuestPayments, pickLatestCompletedPaymentIdForRequest } from '../l
 
 import './GuideMatchOptionsPage.css'
 
-const PRICE_CHAT = 10000
-const PRICE_ACCOMPANY = 50000
+/** 가이드 마이페이지 「종일 패키지」와 동일: 서버 `pricePerHour` × 8 (`GuideFeesPage`와 맞춤) */
+const FULL_DAY_HOURS = 8
 const KAKAO_APP_KEY = import.meta.env.VITE_KAKAO_MAP_APP_KEY
 
 function loadKakaoSdk(appKey) {
@@ -88,19 +88,19 @@ export function GuideMatchOptionsPage() {
   const [profile, setProfile] = useState(null)
   const [requestId, setRequestId] = useState(stateRequestId != null ? Number(stateRequestId) : null)
   const [activeRequest, setActiveRequest] = useState(null)
-  const [paymentType, setPaymentType] = useState(/** @type {'CHAT' | 'ACCOMPANY'} */ ('CHAT'))
-  const [reviews, setReviews] = useState([])
   const [paying, setPaying] = useState(false)
   const [payErr, setPayErr] = useState('')
-  const [payFocus, setPayFocus] = useState(false)
   const [proposalArrivedNotice, setProposalArrivedNotice] = useState(false)
   const [checkingProposal, setCheckingProposal] = useState(false)
-  const matchingOptionsRef = useRef(null)
   const previewMapRef = useRef(null)
   const hasProposalRef = useRef(false)
   const initializedProposalRef = useRef(false)
 
-  const amount = paymentType === 'CHAT' ? PRICE_CHAT : PRICE_ACCOMPANY
+  const accompanyPackageWon = useMemo(() => {
+    const hourly = profile?.pricePerHour != null ? Number(profile.pricePerHour) : 0
+    if (!Number.isFinite(hourly) || hourly <= 0) return 0
+    return Math.round(hourly * FULL_DAY_HOURS)
+  }, [profile])
 
   const load = useCallback(async (options = {}) => {
     const silent = Boolean(options?.silent)
@@ -153,16 +153,6 @@ export function GuideMatchOptionsPage() {
       }
 
       setRequestId(activeRid)
-
-      const revRes = await apiRequest(`/reviews/guide/${guideId}?size=12&sort=createdAt,desc`, { method: 'GET', skipAuth: true })
-      const revText = await revRes.text()
-      if (revRes.ok) {
-        const page = revText ? JSON.parse(revText) : {}
-        const raw = page?.content
-        setReviews(Array.isArray(raw) ? raw : [])
-      } else {
-        setReviews([])
-      }
     } catch (e) {
       if (!silent) {
         setError(e instanceof Error ? e.message : '오류')
@@ -204,12 +194,6 @@ export function GuideMatchOptionsPage() {
   const previewFirstSpot = previewSpots[0] ?? ''
   const previewLockedSpots = previewSpots.slice(1)
   const hasLockedPreview = previewLockedSpots.length > 0 || !!previewHint
-
-  useEffect(() => {
-    if (!payFocus) return
-    const timer = setTimeout(() => setPayFocus(false), 1400)
-    return () => clearTimeout(timer)
-  }, [payFocus])
 
   useEffect(() => {
     if (!proposalArrivedNotice) return
@@ -255,11 +239,6 @@ export function GuideMatchOptionsPage() {
     }
   }
 
-  const moveToPaymentOptions = () => {
-    matchingOptionsRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
-    setPayFocus(true)
-  }
-
   useEffect(() => {
     if (!previewMapRef.current) return
     let cancelled = false
@@ -297,14 +276,18 @@ export function GuideMatchOptionsPage() {
       setPayErr('가이드가 코스를 작성한 뒤 결제를 진행할 수 있어요.')
       return
     }
+    if (accompanyPackageWon <= 0) {
+      setPayErr('가이드가 종일 패키지 요금을 설정해야 결제할 수 있어요. 가이드 마이페이지에서 비용을 저장한 뒤 다시 시도해 주세요.')
+      return
+    }
     setPaying(true)
     try {
       const res = await apiRequest('/matching/payments', {
         method: 'POST',
         json: {
           matchRequestId: requestId,
-          amount,
-          paymentType,
+          amount: accompanyPackageWon,
+          paymentType: 'ACCOMPANY',
         },
       })
       const t = await res.text()
@@ -387,7 +370,40 @@ export function GuideMatchOptionsPage() {
         </div>
       </header>
 
-      <div className="gmo-grid">
+      <div className="gmo-main-flow">
+        <section className="gmo-price-panel" aria-labelledby="gmo-price-title">
+          <h2 id="gmo-price-title">직접 만나기 (동행)</h2>
+          <p className="gmo-price-lead">
+            가이드가 마이페이지에서 설정한 <strong>종일 패키지</strong> 요금입니다. (시간당 요금 × {FULL_DAY_HOURS}시간)
+          </p>
+          <div className="gmo-price-highlight">
+            <span className="gmo-price-label">동행 패키지</span>
+            <strong className="gmo-price-value">
+              {accompanyPackageWon > 0 ? formatKrw(accompanyPackageWon) : '요금 미설정'}
+            </strong>
+          </div>
+          <div className="gmo-total gmo-total--single">
+            <span>결제 금액</span>
+            <strong>{accompanyPackageWon > 0 ? formatKrw(accompanyPackageWon) : '—'}</strong>
+          </div>
+
+          <button
+            type="button"
+            className="gmo-pay"
+            disabled={paying || requestId == null || !courseReadyForPayment || accompanyPackageWon <= 0}
+            onClick={() => void onPay()}
+          >
+            {paying ? '처리 중…' : !courseReadyForPayment ? '가이드 코스 작성 대기중' : accompanyPackageWon <= 0 ? '요금 설정 대기' : '결제하고 코스 열기'}
+          </button>
+          {!courseReadyForPayment && (
+            <p className="gmo-course-gate">가이드가 코스를 작성하면 결제 버튼이 활성화됩니다.</p>
+          )}
+          {courseReadyForPayment && accompanyPackageWon <= 0 && (
+            <p className="gmo-course-gate">가이드가 가이드 비용(종일 패키지)을 저장해야 결제할 수 있어요.</p>
+          )}
+          {payErr && <p className="gmo-err">{payErr}</p>}
+        </section>
+
         <section className="gmo-preview" aria-labelledby="gmo-preview-title">
           <h2 id="gmo-preview-title">추천 코스 미리보기</h2>
           <div className="gmo-map">
@@ -401,64 +417,6 @@ export function GuideMatchOptionsPage() {
             </div>
           </div>
         </section>
-
-        <aside
-          ref={matchingOptionsRef}
-          className={`gmo-side${payFocus ? ' gmo-side--focus' : ''}`}
-          aria-labelledby="gmo-side-title"
-        >
-          <h2 id="gmo-side-title">가이드 매칭 옵션</h2>
-
-          <label className="gmo-opt">
-            <input
-              type="radio"
-              name="payType"
-              checked={paymentType === 'CHAT'}
-              onChange={() => setPaymentType('CHAT')}
-            />
-            <span className="gmo-opt-inner">
-              <span className="gmo-opt-text">
-                <span className="gmo-opt-title">정보만 받기 (채팅)</span>
-                <span className="gmo-opt-desc">채팅으로 코스·팁을 받아요</span>
-              </span>
-              <span className="gmo-opt-price">{formatKrw(PRICE_CHAT)}</span>
-            </span>
-          </label>
-
-          <label className="gmo-opt">
-            <input
-              type="radio"
-              name="payType"
-              checked={paymentType === 'ACCOMPANY'}
-              onChange={() => setPaymentType('ACCOMPANY')}
-            />
-            <span className="gmo-opt-inner">
-              <span className="gmo-opt-text">
-                <span className="gmo-opt-title">직접 만나기 (동행)</span>
-                <span className="gmo-opt-desc">현지에서 함께 동행해요</span>
-              </span>
-              <span className="gmo-opt-price">{formatKrw(PRICE_ACCOMPANY)}</span>
-            </span>
-          </label>
-
-          <div className="gmo-total">
-            <span>Total</span>
-            <strong>{formatKrw(amount)}</strong>
-          </div>
-
-          <button
-            type="button"
-            className="gmo-pay"
-            disabled={paying || requestId == null || !courseReadyForPayment}
-            onClick={() => void onPay()}
-          >
-            {paying ? '처리 중…' : !courseReadyForPayment ? '가이드 코스 작성 대기중' : '결제하고 코스 열기'}
-          </button>
-          {!courseReadyForPayment && (
-            <p className="gmo-course-gate">가이드가 코스를 작성하면 결제 버튼이 활성화됩니다.</p>
-          )}
-          {payErr && <p className="gmo-err">{payErr}</p>}
-        </aside>
       </div>
 
       {previewSpots.length > 0 && (
@@ -488,9 +446,9 @@ export function GuideMatchOptionsPage() {
               <div className="gmo-locked-overlay">
                 <div className="gmo-pay-hint-card">
                   <p className="gmo-pay-hint-title">아직 공개되지 않은 코스가 있어요</p>
-                  <p className="gmo-pay-hint-sub">결제하기를 누르면 위 매칭 옵션에서 바로 진행할 수 있어요.</p>
-                  <button type="button" className="gmo-pay-hint-btn" onClick={moveToPaymentOptions}>
-                    결제하기로 이동
+                  <p className="gmo-pay-hint-sub">아래 버튼을 누르면 바로 결제 단계로 이동합니다.</p>
+                  <button type="button" className="gmo-pay-hint-btn" onClick={() => void onPay()}>
+                    결제 진행하기
                   </button>
                 </div>
               </div>
@@ -503,8 +461,8 @@ export function GuideMatchOptionsPage() {
           )}
           {!hasLockedPreview && (
             <div className="gmo-pay-hint-inline">
-              <button type="button" className="gmo-pay-hint-btn" onClick={moveToPaymentOptions}>
-                결제하기로 이동
+              <button type="button" className="gmo-pay-hint-btn" onClick={() => void onPay()}>
+                결제 진행하기
               </button>
             </div>
           )}
@@ -517,32 +475,6 @@ export function GuideMatchOptionsPage() {
           <p className="gmo-course-pending-sub">조금만 기다려 주세요. 작성이 완료되면 일부 코스가 여기에 먼저 공개됩니다.</p>
         </section>
       )}
-
-      <section className="gmo-reviews" aria-labelledby="gmo-rev-title">
-        <h2 id="gmo-rev-title">여행자들의 후기 ({rc})</h2>
-        <p className="gmo-reviews-readonly">후기는 투어가 완료된 뒤 작성할 수 있어요. 지금은 기존 후기만 확인할 수 있습니다.</p>
-        <ul className="gmo-review-list">
-          {reviews.length === 0 ? (
-            <li className="gmo-review-item">
-              <div className="gmo-review-av" />
-              <div>
-                <p className="gmo-review-name">LocalGuest</p>
-                <p className="gmo-review-text">아직 등록된 후기가 없어요. 매칭 후 첫 후기를 남겨 보세요!</p>
-              </div>
-            </li>
-          ) : (
-            reviews.slice(0, 6).map((r) => (
-              <li key={r.id} className="gmo-review-item">
-                <div className="gmo-review-av" />
-                <div>
-                  <p className="gmo-review-name">{r.writeNickname ?? '여행자'}</p>
-                  <p className="gmo-review-text">{r.content}</p>
-                </div>
-              </li>
-            ))
-          )}
-        </ul>
-      </section>
     </div>
   )
 }


### PR DESCRIPTION
## 🔗 이슈 번호

Closes #333

## 💡 주요 변경 사항

- `GuideMatchOptionsPage`: **정보만 받기(채팅)** 옵션 및 고정 금액 제거. **동행(ACCOMPANY)** 만 `POST /matching/payments`로 요청.
- 결제 금액은 가이드 마이페이지 **종일 패키지**와 동일하게 `profile.pricePerHour × 8` 계산 (`GuideFeesPage`와 동일 규칙). 미설정 시 결제 비활성 + 안내 문구.
- 레이아웃: **가이드 히어로 → 가격 패널 → 지도(미리보기) → 코스 일부** 세로 배치 (지도/가격 2분할 제거).
- 페이지 하단 **후기 섹션** 및 관련 API 호출 제거.
- 코스 잠금 카드의 CTA는 **`onPay` 직접 호출**로 변경 (매칭 옵션 스크롤 강조 제거). 버튼 문구 **「결제 진행하기」**.

## ⚠️ 주의 사항 / 질문

- DB `payment_type`은 여전히 `CHAT`을 허용하나, **이 UI에서는 생성하지 않음**. 기존 CHAT 결제 데이터는 `PaymentKakaoStubPage` 등에서 그대로 표시 가능.
- 가이드가 요금을 0으로 두면 게스트는 결제할 수 없음 — 운영 정책상 의도된 경우 알려 주세요.

## ✅ 체크리스트

- [x] 빌드가 정상적으로 되는가? (`npm run build`)
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [x] `.gitignore`에 설정 파일이 잘 포함되었는가? (본 PR에서 설정 파일 **미변경**)

Made with [Cursor](https://cursor.com)