### PR TITLE
Feat/be#337 AI 지역 매칭 유연화 (상세 지역 표기 허용)

### DIFF
--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/RegionCandidateExpansion.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/RegionCandidateExpansion.java
@@ -89,6 +89,17 @@ public final class RegionCandidateExpansion {
         if (left == null || right == null) {
             return false;
         }
-        return left.trim().equalsIgnoreCase(right.trim());
+        String l = left.trim().toLowerCase();
+        String r = right.trim().toLowerCase();
+        if (l.isEmpty() || r.isEmpty()) {
+            return false;
+        }
+        if (l.equals(r)) {
+            return true;
+        }
+        // 상세 표기(예: "제주특별자치도 제주시")와 canonical(예: "제주")를 같은 지역으로 취급한다.
+        // - DB/폼 입력값이 상이해도, 프롬프트 파서의 canonical 지역과 매칭 후보 풀이 과도하게 축소되지 않도록 완화한다.
+        // - 단순 부분 포함이므로, 지역명이 겹치는 케이스는 추후 alias/정규화로 확장 가능하다.
+        return l.contains(r) || r.contains(l);
     }
 }

--- a/backend/module-ai/src/test/java/com/team6/module/ai/support/RegionCandidateExpansionTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/support/RegionCandidateExpansionTest.java
@@ -21,6 +21,18 @@ class RegionCandidateExpansionTest {
     }
 
     @Test
+    void apply_should_treat_detailed_region_as_exact_match() {
+        List<GuideRecommendRequest.GuideCandidateDto> pool = List.of(
+                g(1L, "제주특별자치도 제주시"),
+                g(2L, "제주")
+        );
+        RegionCandidateExpansion.Result r = RegionCandidateExpansion.apply(pool, "제주");
+        assertThat(r.candidates()).hasSize(2);
+        assertThat(r.expansionUsed()).isFalse();
+        assertThat(r.exactCount()).isEqualTo(2);
+    }
+
+    @Test
     void apply_should_expand_to_adjacent_when_exact_sparse() {
         List<GuideRecommendRequest.GuideCandidateDto> pool = List.of(
                 g(1L, "강릉"),


### PR DESCRIPTION
## 🔗 이슈 번호

Closes #337

## 💡 주요 변경 사항

- `RegionCandidateExpansion`의 지역 동일성 비교를 유연화: trim/lowercase 후 **동일 문자열**뿐 아니라 **부분 포함(contains)**도 동일 지역으로 인정.
  - 예: `제주` ↔ `제주특별자치도 제주시`
- `RegionCandidateExpansionTest`에 상세 표기 케이스 회귀 테스트 추가.

## ⚠️ 주의 사항 / 질문

- contains 기반 완화는 간단하고 효과적이지만, 지역명이 겹치는 특이 케이스는 추후 alias/정규화로 고도화 여지가 있습니다.

## ✅ 체크리스트

- [x] 빌드가 정상적으로 되는가? (`./gradlew :module-ai:test`, `./gradlew :api-server:compileJava`)
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [x] `.gitignore`에 설정 파일이 잘 포함되었는가? (본 PR에서 설정 파일 **미변경**)

Made with [Cursor](https://cursor.com)