### PR TITLE
Feat/fe#339: 가이드 매칭/스케줄 UX 개선 및 코스 작성 전용 페이지 도입

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,10 +5,18 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="84d1b3de-8103-452e-83cf-38ecd34993e7" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/backend/module-domain/src/main/java/com/team6/domain/matching/dto/request/MatchRequestCreateRequest.java" beforeDir="false" afterPath="$PROJECT_DIR$/backend/module-domain/src/main/java/com/team6/domain/matching/dto/request/MatchRequestCreateRequest.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/backend/module-domain/src/main/java/com/team6/domain/matching/service/MatchRequestService.java" beforeDir="false" afterPath="$PROJECT_DIR$/backend/module-domain/src/main/java/com/team6/domain/matching/service/MatchRequestService.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideCoursePanel.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideCoursePanel.css" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideCoursePanel.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideCoursePanel.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideDetailPage.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideDetailPage.css" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideDetailPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideDetailPage.jsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideFeedSchedulePage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideFeedSchedulePage.jsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideMatchedCoursePage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideMatchedCoursePage.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideInboxPage.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideInboxPage.css" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideInboxPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideInboxPage.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideScheduleSection.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideScheduleSection.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/routes/guideRoutes.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/routes/guideRoutes.jsx" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/backend/api-server/src/main/resources/application-secret.yml
+++ b/backend/api-server/src/main/resources/application-secret.yml
@@ -1,0 +1,21 @@
+spring:
+  config:
+    activate:
+      on-profile: secret-local
+
+  mail:
+    username: localGuideMatching@gmail.com
+    password: "frhw yvik bzuw mybv"
+
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: "973764371870-fr2vkfsnnm69vov0nl61fi5r1d82qp0t.apps.googleusercontent.com"
+            client-secret: "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"
+
+# ⚠️ 로컬 전용 시크릿. 커밋 금지 (.gitignore 처리됨)
+# Google OAuth (spring.security.oauth2.client.registration.google.*)에서 참조
+GOOGLE_CLIENT_ID: 973764371870-fr2vkfsnnm69vov0nl61fi5r1d82qp0t.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET: 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

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/dto/request/MatchRequestCreateRequest.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/dto/request/MatchRequestCreateRequest.java
@@ -26,7 +26,6 @@ public class MatchRequestCreateRequest {
      * 매칭 생성 시 해당 슬롯을 PENDING으로 잠그기 위해 전달한다.
      * JSON: {@code scheduleId} (가이드 API와 동일). {@code guideScheduleId}도 수신 호환.
      */
-    @NotNull
     @Positive
     @JsonProperty("scheduleId")
     @JsonAlias("guideScheduleId")

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/service/MatchRequestService.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/service/MatchRequestService.java
@@ -1,6 +1,10 @@
 package com.team6.domain.matching.service;
 
 import com.team6.domain.guide.repository.GuideProfileRepository;
+import com.team6.domain.guide.repository.GuideScheduleRepository;
+import com.team6.domain.guide.entity.GuideProfile;
+import com.team6.domain.guide.entity.GuideSchedule;
+import com.team6.domain.guide.entity.enums.GuideScheduleStatus;
 import com.team6.domain.matching.client.GuideScheduleSyncClient;
 import com.team6.domain.matching.dto.request.MatchRequestCreateRequest;
 import com.team6.domain.matching.dto.request.MatchRequestDeclineRequest;
@@ -17,9 +21,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.text.NumberFormat;
 import java.util.List;
 import java.util.Locale;
+import java.util.Comparator;
 
 @Slf4j
 @Service
@@ -30,17 +36,19 @@ public class MatchRequestService {
     private final MatchRequestRepository matchRequestRepository;
     private final GuideScheduleSyncClient guideScheduleSyncClient;
     private final GuideProfileRepository guideProfileRepository;
+    private final GuideScheduleRepository guideScheduleRepository;
 
     // 매칭 요청 생성
     public MatchRequestCreateResponse createMatchRequest(Long guestId, MatchRequestCreateRequest request) {
         Long guideMemberId = resolveGuideMemberId(request.getGuideId());
         validateCreateRequest(guestId, guideMemberId);
+        Long guideScheduleId = resolveOrCreateScheduleId(request.getGuideId(), request);
 
         String conceptSummary = resolveConceptSummary(request);
         MatchRequest matchRequest = MatchRequest.create(
                 guestId,
                 request.getGuideId(),
-                request.getGuideScheduleId(),
+                guideScheduleId,
                 request.getDestination(),
                 request.getConcept(),
                 conceptSummary,
@@ -229,6 +237,57 @@ public class MatchRequestService {
         return guideProfileRepository.findById(guideProfileId)
                 .map(guideProfile -> guideProfile.getMemberId())
                 .orElseThrow(() -> new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED));
+    }
+
+    /**
+     * 기본 정책: 가이드가 날짜를 별도로 막지 않았다면 요청 가능.
+     * - scheduleId가 오면 그대로 사용
+     * - scheduleId가 없고 desiredDate가 오면
+     *   1) BLOCKED면 거부
+     *   2) AVAILABLE 슬롯이 있으면 그 슬롯 사용
+     *   3) 슬롯이 없으면 종일 AVAILABLE(00:00~23:59) 슬롯을 생성해 사용
+     */
+    private Long resolveOrCreateScheduleId(Long guideId, MatchRequestCreateRequest request) {
+        if (request.getGuideScheduleId() != null) {
+            return request.getGuideScheduleId();
+        }
+
+        LocalDate desiredDate = request.getDesiredDate();
+        if (desiredDate == null) {
+            throw new MatchingException(MatchingErrorCode.INVALID_REQUEST);
+        }
+
+        List<GuideSchedule> daySchedules = guideScheduleRepository.findByGuideProfile_IdAndAvailableDate(guideId, desiredDate);
+        boolean blocked = daySchedules.stream()
+                .anyMatch(s -> s.getStatus() == GuideScheduleStatus.BLOCKED);
+        if (blocked) {
+            throw new MatchingException(MatchingErrorCode.MATCH_REQUEST_INVALID_STATUS);
+        }
+
+        GuideSchedule available = daySchedules.stream()
+                .filter(s -> s.getStatus() == GuideScheduleStatus.AVAILABLE)
+                .min(Comparator.comparing(GuideSchedule::getStartTime))
+                .orElse(null);
+        if (available != null) {
+            return available.getId();
+        }
+
+        boolean pendingOrBooked = daySchedules.stream()
+                .anyMatch(s -> s.getStatus() == GuideScheduleStatus.PENDING || s.getStatus() == GuideScheduleStatus.BOOKED);
+        if (pendingOrBooked) {
+            throw new MatchingException(MatchingErrorCode.MATCH_REQUEST_INVALID_STATUS);
+        }
+
+        GuideProfile profile = guideProfileRepository.findById(guideId)
+                .orElseThrow(() -> new MatchingException(MatchingErrorCode.INVALID_REQUEST));
+        GuideSchedule generated = GuideSchedule.builder()
+                .guideProfile(profile)
+                .availableDate(desiredDate)
+                .startTime(LocalTime.of(0, 0))
+                .endTime(LocalTime.of(23, 59))
+                .status(GuideScheduleStatus.AVAILABLE)
+                .build();
+        return guideScheduleRepository.save(generated).getId();
     }
 
     private void syncTourProgress(MatchRequest request, LocalDate today) {

--- a/frontend/src/pages/GuideCourseEditorPage.css
+++ b/frontend/src/pages/GuideCourseEditorPage.css
@@ -1,0 +1,155 @@
+/* 코스 작성 — 가이드 대시보드(g-panel)와 동일한 흰 배경·카드 톤, 컴팩트 */
+
+.gce-page {
+  width: 100%;
+  max-width: min(760px, 100%);
+  margin: 0 auto;
+  box-sizing: border-box;
+}
+
+.gce-header {
+  margin-bottom: 0.85rem;
+  padding: 0.75rem 0.9rem;
+  background: #fff;
+  border: 1px solid #e8eaed;
+  border-radius: 16px;
+  box-shadow: 0 6px 24px rgba(31, 35, 40, 0.05);
+}
+
+.gce-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin: 0 0 0.65rem;
+  padding: 0.25rem 0;
+  border: none;
+  background: none;
+  color: #3c434d;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.gce-back:hover {
+  color: #1f2328;
+}
+
+.gce-kicker {
+  margin: 0 0 0.2rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #7a828d;
+}
+
+.gce-title-num {
+  margin: 0 0 0.35rem;
+  font-size: 1.2rem;
+  font-weight: 800;
+  line-height: 1.25;
+  letter-spacing: -0.02em;
+  color: #1f2328;
+}
+
+.gce-hero-sub {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: #5c6370;
+  line-height: 1.4;
+}
+
+.gce-banner {
+  margin: 0.65rem 0 0;
+  padding: 0.5rem 0.65rem;
+  border-radius: 8px;
+  background: #f4f6f8;
+  border: 1px solid #e8eaed;
+  color: #3c434d;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.gce-alert {
+  margin: 0 0 0.75rem;
+  padding: 0.55rem 0.75rem;
+  border-radius: 8px;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  color: #991b1b;
+  font-size: 0.8125rem;
+}
+
+.gce-busy {
+  margin: 0 0 0.75rem;
+  font-size: 0.75rem;
+  color: #7a828d;
+}
+
+.gce-guest {
+  margin-bottom: 0.85rem;
+  padding: 0.75rem 0.9rem;
+  background: #fff;
+  border: 1px solid #e8eaed;
+  border-radius: 16px;
+  box-shadow: 0 6px 24px rgba(31, 35, 40, 0.05);
+}
+
+.gce-guest-title {
+  margin: 0 0 0.65rem;
+  font-size: 0.9rem;
+  font-weight: 800;
+  color: #1f2328;
+}
+
+.gce-guest-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 0.55rem 1rem;
+}
+
+.gce-guest-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.gce-label {
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #9ca3af;
+}
+
+.gce-value {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: #1f2328;
+  word-break: break-word;
+}
+
+.gce-concept {
+  margin: 0.65rem 0 0;
+  padding-top: 0.65rem;
+  border-top: 1px solid #eef0f3;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: #3c434d;
+}
+
+.gce-concept-detail {
+  margin: 0.5rem 0 0;
+  font-size: 0.78rem;
+  line-height: 1.55;
+  color: #6b7280;
+  white-space: pre-wrap;
+}
+
+.gce-editor {
+  width: 100%;
+}

--- a/frontend/src/pages/GuideCourseEditorPage.jsx
+++ b/frontend/src/pages/GuideCourseEditorPage.jsx
@@ -1,0 +1,316 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Link, useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom'
+
+import { PageError, PageLoading } from '../components/PageStates.jsx'
+import { apiRequest } from '../api/client.js'
+import { useResolvedGuideId } from '../hooks/useResolvedGuideId.js'
+import { fetchGuideMatchRequests } from '../lib/matchingGuest.js'
+
+import { GuideCoursePanel, parseCourseDetail } from './GuideCoursePanel.jsx'
+
+import './GuideCourseEditorPage.css'
+
+const MATCH_STATUS_KO = {
+  PENDING: '대기 중',
+  ACCEPTED: '수락됨',
+  PAID: '결제 완료',
+  IN_PROGRESS: '진행 중',
+  COMPLETED: '완료',
+  CANCELLED: '취소됨',
+  REJECTED: '거절됨',
+}
+
+function formatMatchStatus(status) {
+  if (status == null || status === '') return '—'
+  return MATCH_STATUS_KO[status] ?? String(status)
+}
+
+function formatBudgetKrw(n) {
+  if (n == null || n === '' || Number.isNaN(Number(n))) return '—'
+  return `${Number(n).toLocaleString('ko-KR')}원`
+}
+
+function formatDesiredDate(d) {
+  if (d == null || d === '') return '—'
+  return String(d)
+}
+
+function formatRequestedAt(iso) {
+  if (iso == null || iso === '') return '—'
+  try {
+    const t = new Date(iso)
+    if (Number.isNaN(t.getTime())) return String(iso)
+    return t.toLocaleString('ko-KR', { dateStyle: 'medium', timeStyle: 'short' })
+  } catch {
+    return String(iso)
+  }
+}
+
+async function readJsonError(res, text) {
+  try {
+    const j = JSON.parse(text)
+    return (j.message ?? text) || '요청 실패'
+  } catch {
+    return text || '요청 실패'
+  }
+}
+
+function buildProposedSchedule(courseDetail) {
+  const spots = parseCourseDetail(courseDetail ?? '').filter((spot) => String(spot.name ?? '').trim())
+  if (spots.length === 0) return ''
+  return spots.map((spot) => spot.name.trim()).join(' -> ')
+}
+
+function formatTime(t) {
+  if (t == null) return ''
+  if (typeof t === 'string') return t.length >= 5 ? t.slice(0, 5) : t
+  return String(t)
+}
+
+function fromStateSchedule(stateSchedule) {
+  if (!stateSchedule || stateSchedule.scheduleId == null) return null
+  return {
+    scheduleId: Number(stateSchedule.scheduleId),
+    availableDate: stateSchedule.availableDate ?? '',
+    startTime: formatTime(stateSchedule.startTime),
+    endTime: formatTime(stateSchedule.endTime),
+    destination: stateSchedule.destination ?? '로컬 투어',
+  }
+}
+
+export function GuideCourseEditorPage() {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const { requestId, scheduleId: scheduleIdParam } = useParams()
+  const [searchParams] = useSearchParams()
+  const { guideId, loading: guideIdLoading, error: guideIdError } = useResolvedGuideId()
+
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [schedule, setSchedule] = useState(() => fromStateSchedule(location.state?.schedule))
+  const [initialForm, setInitialForm] = useState(location.state?.initialForm ?? null)
+  const [proposalErr, setProposalErr] = useState('')
+  const [proposalBusy, setProposalBusy] = useState(false)
+  const [matchRow, setMatchRow] = useState(null)
+
+  const proposeAfterSave =
+    searchParams.get('propose') === '1' || Boolean(location.state?.proposeAfterSave)
+
+  const scheduleIdFromQuery = Number(searchParams.get('scheduleId'))
+  const scheduleIdFromPath = Number(scheduleIdParam)
+  const targetScheduleId = Number.isFinite(scheduleIdFromQuery)
+    ? scheduleIdFromQuery
+    : (Number.isFinite(scheduleIdFromPath) ? scheduleIdFromPath : null)
+
+  const loadSchedule = useCallback(async () => {
+    if (!guideId || guideIdLoading) return
+    if (schedule) {
+      setLoading(false)
+      return
+    }
+    setLoading(true)
+    setError('')
+    try {
+      const schedulesRes = await apiRequest(`/guides/${guideId}/schedules`, { method: 'GET', skipAuth: true })
+      const schedulesText = await schedulesRes.text()
+      if (!schedulesRes.ok) throw new Error(schedulesText || '스케줄을 불러오지 못했습니다.')
+      const schedules = schedulesText ? JSON.parse(schedulesText) : []
+      const list = Array.isArray(schedules) ? schedules : []
+
+      let pick = null
+      if (targetScheduleId != null) {
+        pick = list.find((s) => Number(s.scheduleId) === targetScheduleId) ?? null
+      }
+
+      let destination = '로컬 투어'
+      if (pick?.scheduleId != null) {
+        try {
+          const reqs = await fetchGuideMatchRequests(apiRequest)
+          const req = Array.isArray(reqs)
+            ? reqs.find((r) => Number(r.scheduleId) === Number(pick.scheduleId))
+            : null
+          destination = req?.destination ?? destination
+        } catch {
+          destination = '로컬 투어'
+        }
+      }
+
+      if (!pick) {
+        throw new Error('편집할 스케줄을 찾을 수 없습니다. 스케줄 관리에서 다시 들어와 주세요.')
+      }
+
+      setSchedule({
+        scheduleId: Number(pick.scheduleId),
+        availableDate: pick.availableDate ?? searchParams.get('date') ?? '',
+        startTime: formatTime(pick.startTime ?? searchParams.get('startTime') ?? ''),
+        endTime: formatTime(pick.endTime ?? searchParams.get('endTime') ?? ''),
+        destination: searchParams.get('destination') ?? destination,
+      })
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '코스 편집 페이지를 열지 못했습니다.')
+    } finally {
+      setLoading(false)
+    }
+  }, [guideId, guideIdLoading, schedule, searchParams, targetScheduleId])
+
+  useEffect(() => {
+    void loadSchedule()
+  }, [loadSchedule])
+
+  useEffect(() => {
+    if (!guideId || guideIdLoading) return
+    let cancelled = false
+    void (async () => {
+      try {
+        const list = await fetchGuideMatchRequests(apiRequest)
+        if (cancelled || !Array.isArray(list)) return
+        const rid = requestId != null ? Number(requestId) : NaN
+        const sid = schedule?.scheduleId
+        let row = null
+        if (!Number.isNaN(rid)) {
+          row = list.find((r) => Number(r.requestId) === rid) ?? null
+        }
+        if (!row && sid != null) {
+          row = list.find((r) => Number(r.scheduleId) === Number(sid)) ?? null
+        }
+        if (!cancelled) setMatchRow(row)
+      } catch {
+        if (!cancelled) setMatchRow(null)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [guideId, guideIdLoading, requestId, schedule?.scheduleId])
+
+  const backTo = useMemo(
+    () => (proposeAfterSave ? '/guide/inbox' : '/guide/mypage/feed-schedule?tab=schedule'),
+    [proposeAfterSave],
+  )
+
+  if (guideIdLoading || loading) {
+    return <PageLoading />
+  }
+
+  if (guideIdError || error || !schedule) {
+    return (
+      <PageError message={guideIdError || error || '코스 편집 정보를 찾을 수 없습니다.'}>
+        <Link to={backTo}>{proposeAfterSave ? '매칭 요청으로 돌아가기' : '스케줄 관리로 돌아가기'}</Link>
+      </PageError>
+    )
+  }
+
+  const numericRequestId = requestId != null ? Number(requestId) : null
+
+  const handleSaved = async (savedForm) => {
+    setInitialForm(savedForm ?? null)
+    setProposalErr('')
+    if (!proposeAfterSave || numericRequestId == null || Number.isNaN(numericRequestId)) {
+      return
+    }
+    const proposedSchedule = buildProposedSchedule(savedForm?.courseDetail ?? '')
+    const proposeMessage = String(savedForm?.guideMessage ?? '').trim()
+    if (!proposedSchedule) {
+      setProposalErr('코스 스팟을 1개 이상 작성해야 제시안을 보낼 수 있습니다.')
+      return
+    }
+    setProposalBusy(true)
+    try {
+      const res = await apiRequest(`/matching/requests/${numericRequestId}/propose`, {
+        method: 'PATCH',
+        json: {
+          proposedSchedule,
+          proposeMessage: proposeMessage || undefined,
+        },
+      })
+      const text = await res.text()
+      if (!res.ok) {
+        setProposalErr(await readJsonError(res, text))
+        return
+      }
+      navigate('/guide/inbox', { replace: true })
+    } catch {
+      setProposalErr('제시안 전송에 실패했습니다.')
+    } finally {
+      setProposalBusy(false)
+    }
+  }
+
+  const showRequestHero = numericRequestId != null && !Number.isNaN(numericRequestId)
+
+  return (
+    <div className="gce-page">
+      <header className="gce-header">
+        <button type="button" className="gce-back" onClick={() => navigate(backTo)}>
+          ← {proposeAfterSave ? '매칭 요청' : '스케줄 관리'}
+        </button>
+        <p className="gce-kicker">코스 작성</p>
+        {showRequestHero ? (
+          <h1 className="gce-title-num">요청 #{numericRequestId}</h1>
+        ) : (
+          <h1 className="gce-title-num">스케줄 #{schedule.scheduleId}</h1>
+        )}
+        <p className="gce-hero-sub">
+          {schedule.availableDate}
+          {schedule.startTime && schedule.endTime ? ` · ${schedule.startTime}–${schedule.endTime}` : ''}
+          {schedule.destination ? ` · ${schedule.destination}` : ''}
+        </p>
+        {proposeAfterSave && <p className="gce-banner">저장하면 제시안이 게스트에게 함께 전송됩니다.</p>}
+      </header>
+
+      {matchRow && (
+        <section className="gce-guest" aria-label="요청자 정보">
+          <h2 className="gce-guest-title">요청자 정보</h2>
+          <div className="gce-guest-grid">
+            <div className="gce-guest-item">
+              <span className="gce-label">게스트</span>
+              <span className="gce-value">게스트 #{matchRow.guestId}</span>
+            </div>
+            <div className="gce-guest-item">
+              <span className="gce-label">희망 일정</span>
+              <span className="gce-value">{formatDesiredDate(matchRow.desiredDate)}</span>
+            </div>
+            <div className="gce-guest-item">
+              <span className="gce-label">목적지</span>
+              <span className="gce-value">{matchRow.destination?.trim() || '—'}</span>
+            </div>
+            <div className="gce-guest-item">
+              <span className="gce-label">예산</span>
+              <span className="gce-value">{formatBudgetKrw(matchRow.desiredBudget)}</span>
+            </div>
+            <div className="gce-guest-item">
+              <span className="gce-label">요청 상태</span>
+              <span className="gce-value">{formatMatchStatus(matchRow.status)}</span>
+            </div>
+            <div className="gce-guest-item">
+              <span className="gce-label">요청일</span>
+              <span className="gce-value">{formatRequestedAt(matchRow.createdAt)}</span>
+            </div>
+          </div>
+          {matchRow.conceptSummary?.trim() && (
+            <p className="gce-concept">{matchRow.conceptSummary.trim()}</p>
+          )}
+          {matchRow.concept?.trim() &&
+            matchRow.concept.trim() !== String(matchRow.conceptSummary ?? '').trim() && (
+              <p className="gce-concept-detail">{matchRow.concept.trim()}</p>
+            )}
+        </section>
+      )}
+
+      {proposalErr && <p className="gce-alert">{proposalErr}</p>}
+      {proposalBusy && <p className="gce-busy">제시안 전송 중…</p>}
+
+      <div className="gce-editor">
+        <GuideCoursePanel
+          guideId={guideId}
+          schedule={schedule}
+          initialForm={initialForm}
+          standalone
+          hideHeader
+          onClose={() => navigate(backTo)}
+          onSaved={(savedForm) => void handleSaved(savedForm)}
+        />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/GuideCoursePanel.css
+++ b/frontend/src/pages/GuideCoursePanel.css
@@ -21,6 +21,30 @@
   animation: gcp-slide-in 0.22s ease;
 }
 
+.gcp-page-wrap {
+  width: 100%;
+}
+
+.gcp-panel--page {
+  width: 100%;
+  max-width: min(760px, 100%);
+  height: auto;
+  min-height: min(520px, 70dvh);
+  margin: 0 auto;
+  border-radius: 16px;
+  border: 1px solid #e8eaed;
+  box-shadow: 0 6px 24px rgba(31, 35, 40, 0.05);
+  animation: none;
+}
+
+.gcp-panel--page.gcp-panel--no-header {
+  border-radius: 18px;
+}
+
+.gcp-panel--no-header .gcp-body {
+  padding-top: 1.25rem;
+}
+
 @keyframes gcp-slide-in {
   from { transform: translateX(100%); }
   to   { transform: translateX(0); }

--- a/frontend/src/pages/GuideCoursePanel.jsx
+++ b/frontend/src/pages/GuideCoursePanel.jsx
@@ -63,11 +63,21 @@ export function parseCourseDetail(text) {
  *   guideId: number,
  *   schedule: { scheduleId: number, availableDate: string, startTime: string, endTime: string, destination?: string },
  *   initialForm?: { meetingPoint?: string, guideMessage?: string, courseDetail?: string, isPaid?: boolean } | null,
+ *   standalone?: boolean,
+ *   hideHeader?: boolean,
  *   onClose: () => void,
  *   onSaved: (savedForm?: { meetingPoint?: string, guideMessage?: string, courseDetail?: string, isPaid?: boolean }) => void,
  * }} props
  */
-export function GuideCoursePanel({ guideId, schedule, initialForm = null, onClose, onSaved }) {
+export function GuideCoursePanel({
+  guideId,
+  schedule,
+  initialForm = null,
+  standalone = false,
+  hideHeader = false,
+  onClose,
+  onSaved,
+}) {
   const mapRef = useRef(null)
   const mapInstanceRef = useRef(null)
   const overlaysRef = useRef([])
@@ -383,23 +393,31 @@ export function GuideCoursePanel({ guideId, schedule, initialForm = null, onClos
     }
   }
 
-  return (
-    <div className="gcp-backdrop" onClick={(e) => e.target === e.currentTarget && onClose()}>
-      <aside className="gcp-panel" role="dialog" aria-modal="true" aria-label="코스 작성">
-        {/* 헤더 */}
-        <header className="gcp-header">
-          <div className="gcp-header-left">
-            <span className="gcp-header-label">코스 작성</span>
-            <h2 className="gcp-header-title">
-              {schedule.availableDate}
-              {schedule.destination ? ` · ${schedule.destination}` : ''}
-            </h2>
-            <p className="gcp-header-meta">
-              {schedule.startTime} ~ {schedule.endTime}
-            </p>
-          </div>
-          <button type="button" className="gcp-close" onClick={onClose} aria-label="닫기">✕</button>
-        </header>
+  const panel = (
+    <aside
+      className={`gcp-panel${standalone ? ' gcp-panel--page' : ''}${standalone && hideHeader ? ' gcp-panel--no-header' : ''}`}
+      role={standalone ? undefined : 'dialog'}
+      aria-modal={standalone ? undefined : 'true'}
+      aria-label="코스 작성"
+    >
+        {/* 헤더 — 전용 페이지에서는 상단 히어로로 대체 가능 */}
+        {!hideHeader && (
+          <header className="gcp-header">
+            <div className="gcp-header-left">
+              <span className="gcp-header-label">코스 작성</span>
+              <h2 className="gcp-header-title">
+                {schedule.availableDate}
+                {schedule.destination ? ` · ${schedule.destination}` : ''}
+              </h2>
+              <p className="gcp-header-meta">
+                {schedule.startTime} ~ {schedule.endTime}
+              </p>
+            </div>
+            <button type="button" className="gcp-close" onClick={onClose} aria-label={standalone ? '목록으로' : '닫기'}>
+              {standalone ? '←' : '✕'}
+            </button>
+          </header>
+        )}
 
         {loading ? (
           <div className="gcp-loading">불러오는 중…</div>
@@ -546,6 +564,15 @@ export function GuideCoursePanel({ guideId, schedule, initialForm = null, onClos
           </div>
         )}
       </aside>
+  )
+
+  if (standalone) {
+    return <div className="gcp-page-wrap">{panel}</div>
+  }
+
+  return (
+    <div className="gcp-backdrop" onClick={(e) => e.target === e.currentTarget && onClose()}>
+      {panel}
     </div>
   )
 }

--- a/frontend/src/pages/GuideDetailPage.css
+++ b/frontend/src/pages/GuideDetailPage.css
@@ -293,3 +293,134 @@
   margin-top: 0;
   font-size: 1.15rem;
 }
+
+.gdp-match-cal {
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  background: #fff;
+  padding: 0.75rem;
+}
+
+.gdp-match-cal-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.55rem;
+}
+
+.gdp-match-nav {
+  border: 1px solid #d1d5db;
+  background: #fff;
+  border-radius: 8px;
+  width: 1.9rem;
+  height: 1.9rem;
+  cursor: pointer;
+}
+
+.gdp-match-week {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 0.25rem;
+  margin-bottom: 0.3rem;
+}
+
+.gdp-match-week span {
+  font-size: 0.66rem;
+  color: #9ca3af;
+  text-align: center;
+}
+
+.gdp-match-days {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 0.3rem;
+}
+
+.gdp-match-day {
+  position: relative;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  height: 2rem;
+  background: #f9fafb;
+  font-size: 0.82rem;
+  color: #6b7280;
+}
+
+.gdp-match-day.is-on {
+  background: #eff6ff;
+  border-color: #bfdbfe;
+  color: #1d4ed8;
+  cursor: pointer;
+}
+
+.gdp-match-day.is-blocked {
+  background: #f8fafc;
+  border-color: #e5e7eb;
+  color: #9ca3af;
+}
+
+.gdp-match-day.is-selected {
+  background: #2563eb;
+  border-color: #2563eb;
+  color: #fff;
+  font-weight: 700;
+}
+
+.gdp-match-day.is-out,
+.gdp-match-day.is-past {
+  opacity: 0.45;
+}
+
+.gdp-match-cal-hint {
+  margin: 0.55rem 0 0;
+  font-size: 0.74rem;
+  color: #6b7280;
+}
+
+.gdp-match-x {
+  position: absolute;
+  right: 0.35rem;
+  top: 0.15rem;
+  font-size: 0.72rem;
+  color: #9ca3af;
+}
+
+.gdp-match-dot {
+  position: absolute;
+  left: 50%;
+  bottom: 0.2rem;
+  width: 4px;
+  height: 4px;
+  margin-left: -2px;
+  border-radius: 999px;
+  background: #2563eb;
+}
+
+.gdp-match-times {
+  margin-top: 0.65rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.gdp-match-time {
+  border: 1px solid #d1d5db;
+  border-radius: 999px;
+  background: #fff;
+  color: #374151;
+  font-size: 0.76rem;
+  padding: 0.25rem 0.65rem;
+  cursor: pointer;
+}
+
+.gdp-match-time.is-selected {
+  border-color: #1f2937;
+  background: #1f2937;
+  color: #fff;
+}
+
+.gdp-match-default-slot {
+  margin: 0.55rem 0 0;
+  font-size: 0.78rem;
+  color: #4b5563;
+}

--- a/frontend/src/pages/GuideDetailPage.jsx
+++ b/frontend/src/pages/GuideDetailPage.jsx
@@ -7,6 +7,8 @@ import { useAuth } from '../context/useAuth.js'
 
 import './GuideDetailPage.css'
 
+const WEEKDAYS_SHORT = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT']
+
 /**
  * @param {unknown} raw
  * @returns {string}
@@ -15,6 +17,28 @@ function formatScheduleDate(raw) {
   if (raw == null) return ''
   const s = String(raw)
   return s.length >= 10 ? s.slice(0, 10) : s
+}
+
+function parseDateOnly(raw) {
+  const key = formatScheduleDate(raw)
+  if (!key) return null
+  const d = new Date(`${key}T00:00:00`)
+  return Number.isNaN(d.getTime()) ? null : d
+}
+
+function ymd(date) {
+  const y = date.getFullYear()
+  const m = String(date.getMonth() + 1).padStart(2, '0')
+  const d = String(date.getDate()).padStart(2, '0')
+  return `${y}-${m}-${d}`
+}
+
+function isPastDateKey(dateKey) {
+  const d = parseDateOnly(dateKey)
+  if (!d) return true
+  const now = new Date()
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  return d < today
 }
 
 /**
@@ -76,6 +100,12 @@ function normalizeSchedule(schedule) {
     ...schedule,
     scheduleId,
   }
+}
+
+function compareScheduleTime(a, b) {
+  const ad = `${formatScheduleDate(a?.availableDate)} ${formatLocalTime(a?.startTime)}`
+  const bd = `${formatScheduleDate(b?.availableDate)} ${formatLocalTime(b?.startTime)}`
+  return ad.localeCompare(bd)
 }
 
 /**
@@ -153,6 +183,11 @@ export function GuideDetailPage() {
   const [loading, setLoading] = useState(true)
 
   const [selectedScheduleId, setSelectedScheduleId] = useState(null)
+  const [selectedDateKey, setSelectedDateKey] = useState(null)
+  const [calendarMonth, setCalendarMonth] = useState(() => {
+    const now = new Date()
+    return new Date(now.getFullYear(), now.getMonth(), 1)
+  })
   const [destination, setDestination] = useState('')
   const [concept, setConcept] = useState('')
   const [submitErr, setSubmitErr] = useState('')
@@ -184,15 +219,24 @@ export function GuideDetailPage() {
         if (schRes.ok) {
           const parsed = schText ? JSON.parse(schText) : []
           const list = toScheduleList(parsed)
-          const avail = list.filter((s) => isBookableSchedule(s)).map((s) => normalizeSchedule(s))
+          const avail = list
+            .map((s) => normalizeSchedule(s))
+            .filter((s) => {
+              const key = formatScheduleDate(s.availableDate)
+              return key && !isPastDateKey(key)
+            })
+            .sort(compareScheduleTime)
           if (!cancelled) {
             setSchedules(avail)
-            if (avail.length > 0 && avail[0]?.scheduleId != null) {
-              setSelectedScheduleId(Number(avail[0].scheduleId))
-            }
+            const today = ymd(new Date())
+            setSelectedDateKey(today)
+            setSelectedScheduleId(null)
+            setCalendarMonth(new Date(new Date().getFullYear(), new Date().getMonth(), 1))
           }
         } else if (!cancelled) {
           setSchedules([])
+          setSelectedScheduleId(null)
+          setSelectedDateKey(ymd(new Date()))
         }
 
         let revList = []
@@ -245,6 +289,71 @@ export function GuideDetailPage() {
     )
   }, [detail])
 
+  const blockedDateSet = useMemo(() => {
+    const set = new Set()
+    for (const schedule of schedules) {
+      const key = formatScheduleDate(schedule?.availableDate)
+      const status = String(schedule?.status ?? '').toUpperCase()
+      if (key && status === 'BLOCKED') set.add(key)
+    }
+    return set
+  }, [schedules])
+
+  const availableByDate = useMemo(() => {
+    /** @type {Map<string, any[]>} */
+    const map = new Map()
+    for (const schedule of schedules) {
+      const key = formatScheduleDate(schedule?.availableDate)
+      if (!key || isPastDateKey(key)) continue
+      if (!isBookableSchedule(schedule)) continue
+      if (!map.has(key)) map.set(key, [])
+      map.get(key).push(schedule)
+    }
+    for (const [key, list] of map.entries()) {
+      list.sort(compareScheduleTime)
+      map.set(key, list)
+    }
+    return map
+  }, [schedules])
+
+  const selectedDateSchedules = useMemo(() => {
+    if (!selectedDateKey) return []
+    return availableByDate.get(selectedDateKey) ?? []
+  }, [availableByDate, selectedDateKey])
+
+  useEffect(() => {
+    if (!selectedDateKey) return
+    if (selectedDateSchedules.length === 0) {
+      if (selectedScheduleId != null) setSelectedScheduleId(null)
+      return
+    }
+    const hasSelected = selectedDateSchedules.some((s) => Number(s.scheduleId) === Number(selectedScheduleId))
+    if (!hasSelected) {
+      setSelectedScheduleId(Number(selectedDateSchedules[0].scheduleId))
+    }
+  }, [selectedDateSchedules, selectedDateKey, selectedScheduleId])
+
+  const calendarCells = useMemo(() => {
+    const y = calendarMonth.getFullYear()
+    const m = calendarMonth.getMonth()
+    const first = new Date(y, m, 1).getDay()
+    const daysInMonth = new Date(y, m + 1, 0).getDate()
+    const prevDays = new Date(y, m, 0).getDate()
+    const cells = []
+    for (let i = 0; i < first; i += 1) {
+      const day = prevDays - first + i + 1
+      cells.push({ date: new Date(y, m - 1, day), inMonth: false, key: `p-${y}-${m}-${day}` })
+    }
+    for (let day = 1; day <= daysInMonth; day += 1) {
+      cells.push({ date: new Date(y, m, day), inMonth: true, key: `c-${y}-${m + 1}-${day}` })
+    }
+    while (cells.length < 42) {
+      const day = cells.length - (first + daysInMonth) + 1
+      cells.push({ date: new Date(y, m + 1, day), inMonth: false, key: `n-${y}-${m + 2}-${day}` })
+    }
+    return cells
+  }, [calendarMonth])
+
   const onSubmitMatch = async (e) => {
     e.preventDefault()
     setSubmitErr('')
@@ -256,8 +365,16 @@ export function GuideDetailPage() {
       setSubmitErr('여행자(GUEST) 계정으로 로그인한 뒤 요청해 주세요.')
       return
     }
-    if (selectedScheduleId == null || Number.isNaN(Number(selectedScheduleId))) {
-      setSubmitErr('예약 가능한 일정을 선택해 주세요. (가이드가 일정을 등록해야 합니다.)')
+    if (!selectedDateKey) {
+      setSubmitErr('예약 날짜를 선택해 주세요.')
+      return
+    }
+    if (isPastDateKey(selectedDateKey)) {
+      setSubmitErr('지난 날짜에는 요청할 수 없습니다.')
+      return
+    }
+    if (blockedDateSet.has(selectedDateKey)) {
+      setSubmitErr('해당 날짜는 가이드가 예약을 받지 않습니다. 다른 날짜를 선택해 주세요.')
       return
     }
     const dest = destination.trim()
@@ -266,8 +383,10 @@ export function GuideDetailPage() {
       return
     }
 
-    const sch = schedules.find((s) => Number(s.scheduleId) === Number(selectedScheduleId))
-    const desiredDate = sch?.availableDate != null ? formatScheduleDate(sch.availableDate) : undefined
+    const sch = selectedScheduleId == null
+      ? null
+      : schedules.find((s) => Number(s.scheduleId) === Number(selectedScheduleId))
+    const desiredDate = selectedDateKey || (sch?.availableDate != null ? formatScheduleDate(sch.availableDate) : undefined)
 
     setSubmitting(true)
     try {
@@ -275,7 +394,7 @@ export function GuideDetailPage() {
         method: 'POST',
         json: {
           guideId: Number(guideId),
-          scheduleId: Number(selectedScheduleId),
+          scheduleId: selectedScheduleId != null ? Number(selectedScheduleId) : undefined,
           destination: dest,
           concept: concept.trim() || undefined,
           desiredDate: desiredDate || undefined,
@@ -502,8 +621,7 @@ export function GuideDetailPage() {
       <section className="gdp-match" id="match-request">
         <h2>매칭 요청하기</h2>
         <p style={{ color: '#4b5563', fontSize: '0.95rem', lineHeight: 1.5 }}>
-          예약 가능한 일정을 고르고 목적지를 적으면 가이드에게 매칭 요청이 전달됩니다. (가이드가 일정을 아직 등록하지 않았다면
-          요청할 수 없어요.)
+          날짜를 고르고 목적지를 적으면 가이드에게 매칭 요청이 전달됩니다. 기본은 모든 날짜 요청 가능이며, 가이드가 막은 날짜만 선택할 수 없어요.
         </p>
 
         {!isAuthenticated && (
@@ -527,22 +645,86 @@ export function GuideDetailPage() {
         {isAuthenticated && !isGuide && (
           <form onSubmit={(e) => void onSubmitMatch(e)} style={{ display: 'grid', gap: '0.85rem', maxWidth: 480 }}>
             <label style={{ display: 'grid', gap: 6 }}>
-              <span>예약 가능 일정</span>
-              {schedules.length === 0 ? (
-                <span style={{ color: '#6b7280' }}>등록된 예약 가능 일정이 없습니다. 가이드에게 일정 등록을 요청해 주세요.</span>
-              ) : (
-                <select
-                  value={selectedScheduleId ?? ''}
-                  onChange={(ev) => setSelectedScheduleId(ev.target.value ? Number(ev.target.value) : null)}
-                  required
-                >
-                  {schedules.map((s) => (
-                    <option key={s.scheduleId} value={s.scheduleId}>
-                      {formatScheduleDate(s.availableDate)} {formatLocalTime(s.startTime)} ~ {formatLocalTime(s.endTime)}
-                    </option>
+              <span>예약 날짜 선택</span>
+              <div className="gdp-match-cal">
+                <div className="gdp-match-cal-head">
+                  <button
+                    type="button"
+                    className="gdp-match-nav"
+                    onClick={() => setCalendarMonth((p) => new Date(p.getFullYear(), p.getMonth() - 1, 1))}
+                    aria-label="이전 달"
+                  >
+                    ‹
+                  </button>
+                  <strong>
+                    {calendarMonth.getFullYear()}년 {calendarMonth.getMonth() + 1}월
+                  </strong>
+                  <button
+                    type="button"
+                    className="gdp-match-nav"
+                    onClick={() => setCalendarMonth((p) => new Date(p.getFullYear(), p.getMonth() + 1, 1))}
+                    aria-label="다음 달"
+                  >
+                    ›
+                  </button>
+                </div>
+                <div className="gdp-match-week">
+                  {WEEKDAYS_SHORT.map((w) => (
+                    <span key={w}>{w}</span>
                   ))}
-                </select>
-              )}
+                </div>
+                <div className="gdp-match-days">
+                  {calendarCells.map((cell) => {
+                    const key = ymd(cell.date)
+                    const inMonth = cell.inMonth
+                    const isPast = isPastDateKey(key)
+                    const isBlocked = blockedDateSet.has(key)
+                    const hasSchedule = availableByDate.has(key)
+                    const selectable = inMonth && !isPast && !isBlocked
+                    const selected = selectable && key === selectedDateKey
+                    return (
+                      <button
+                        key={cell.key}
+                        type="button"
+                        className={`gdp-match-day${!inMonth ? ' is-out' : ''}${isPast ? ' is-past' : ''}${selectable ? ' is-on' : ''}${isBlocked ? ' is-blocked' : ''}${selected ? ' is-selected' : ''}`}
+                        disabled={!selectable}
+                        onClick={() => {
+                          setSelectedDateKey(key)
+                          const picks = availableByDate.get(key) ?? []
+                          if (picks.length > 0) setSelectedScheduleId(Number(picks[0].scheduleId))
+                          else setSelectedScheduleId(null)
+                        }}
+                      >
+                        {cell.date.getDate()}
+                        {isBlocked && <span className="gdp-match-x">×</span>}
+                        {hasSchedule && <span className="gdp-match-dot" />}
+                      </button>
+                    )
+                  })}
+                </div>
+                <p className="gdp-match-cal-hint">지난 날짜는 선택할 수 없어요. 기본은 예약 가능이며, 가이드가 막은 날짜만 선택할 수 없습니다.</p>
+
+                {selectedDateSchedules.length > 0 ? (
+                  <div className="gdp-match-times" role="radiogroup" aria-label="시간 선택">
+                    {selectedDateSchedules.map((s) => {
+                      const sid = Number(s.scheduleId)
+                      const on = sid === Number(selectedScheduleId)
+                      return (
+                        <button
+                          key={sid}
+                          type="button"
+                          className={`gdp-match-time${on ? ' is-selected' : ''}`}
+                          onClick={() => setSelectedScheduleId(sid)}
+                        >
+                          {formatLocalTime(s.startTime)} ~ {formatLocalTime(s.endTime)}
+                        </button>
+                      )
+                    })}
+                  </div>
+                ) : (
+                  <p className="gdp-match-default-slot">기본 예약 모드로 요청됩니다. (가이드가 이 날짜를 차단하지 않았다면 요청 가능)</p>
+                )}
+              </div>
             </label>
             <label style={{ display: 'grid', gap: 6 }}>
               <span>여행 목적지 · 지역</span>
@@ -567,7 +749,7 @@ export function GuideDetailPage() {
             <div>
               <button
                 type="submit"
-                disabled={submitting || schedules.length === 0}
+                disabled={submitting || !selectedDateKey || blockedDateSet.has(selectedDateKey)}
                 style={{
                   padding: '0.6rem 1.2rem',
                   borderRadius: 8,

--- a/frontend/src/pages/GuideFeedSchedulePage.jsx
+++ b/frontend/src/pages/GuideFeedSchedulePage.jsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useSearchParams } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 
 import { apiRequest } from '../api/client.js'
 import { useResolvedGuideId } from '../hooks/useResolvedGuideId.js'
@@ -7,7 +7,6 @@ import { fetchGuideMatchRequests } from '../lib/matchingGuest.js'
 
 import '../layouts/GuideDashboardLayout.css'
 import './GuideMypagePages.css'
-import { GuideCoursePanel } from './GuideCoursePanel.jsx'
 import { GuideScheduleSection } from './GuideScheduleSection.jsx'
 
 function parseFeedHeading(content) {
@@ -93,6 +92,7 @@ function hasWholeDayAvailableSlot(list, dateStr) {
 }
 
 export function GuideFeedSchedulePage() {
+  const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
   const { guideId, loading: idLoading, error: idError, reload: reloadId } = useResolvedGuideId()
   const [feeds, setFeeds] = useState([])
@@ -108,8 +108,6 @@ export function GuideFeedSchedulePage() {
   const [feedLocationTags, setFeedLocationTags] = useState([])
   const [showLocationInput, setShowLocationInput] = useState(false)
   const [locationInput, setLocationInput] = useState('')
-  const [courseTarget, setCourseTarget] = useState(null)
-  const [savedCourseForms, setSavedCourseForms] = useState({})
   const { toasts, addToast } = useToast()
   const [blockedDates, setBlockedDates] = useState(() => new Set())
   const [busy, setBusy] = useState(false)
@@ -358,36 +356,6 @@ export function GuideFeedSchedulePage() {
     }
   }
 
-  /** 종일(00:00~23:59) 예약 받기 슬롯만 삭제 → 중립. 시간대별 일정은 유지 */
-  const clearOpenDay = async (dateStr) => {
-    if (!guideId || scheduleOpLockRef.current || busy) return
-    const markers = schedules.filter((s) => s.availableDate === dateStr && isWholeDayOpenSlot(s))
-    if (markers.length === 0) {
-      addToast('종일로 켠 "예약 받기"만 여기서 끌 수 있어요. 다른 시간대는 목록에서 삭제해 주세요.', 'error')
-      return
-    }
-    if (!window.confirm('이 날짜의 종일 예약 받기 설정을 지울까요? (예약을 막지는 않아요)')) return
-    scheduleOpLockRef.current = true
-    setBusy(true)
-    try {
-      for (const s of markers) {
-        const res = await apiRequest(`/guides/${guideId}/schedules/${s.scheduleId}`, { method: 'DELETE' })
-        if (!res.ok) {
-          const t = await res.text()
-          addToast(await readJsonError(res, t), 'error')
-          return
-        }
-      }
-      addToast('이 날을 비었습니다.')
-      await reloadScheduleData(guideId)
-    } catch {
-      addToast('삭제에 실패했어요', 'error')
-    } finally {
-      scheduleOpLockRef.current = false
-      setBusy(false)
-    }
-  }
-
   const onPickFiles = async (e) => {
     const files = Array.from(e.target.files ?? [])
     e.target.value = ''
@@ -436,6 +404,28 @@ export function GuideFeedSchedulePage() {
   const removeLocationTag = (tag) => {
     setFeedLocationTags((prev) => prev.filter((t) => t !== tag))
   }
+
+  const moveToCourseEditor = useCallback((tour) => {
+    const sid = Number(tour?.scheduleId)
+    if (!Number.isFinite(sid)) return
+    const rid = Number(tour?.requestId)
+    const hasRid = Number.isFinite(rid) && rid > 0
+    const path = hasRid
+      ? `/guide/requests/${rid}/course-editor`
+      : `/guide/schedules/${sid}/course-editor`
+    const params = new URLSearchParams()
+    params.set('scheduleId', String(sid))
+    if (tour?.availableDate) params.set('date', String(tour.availableDate))
+    if (tour?.startTime) params.set('startTime', String(tour.startTime))
+    if (tour?.endTime) params.set('endTime', String(tour.endTime))
+    if (tour?.destination) params.set('destination', String(tour.destination))
+    navigate(`${path}?${params.toString()}`, {
+      state: {
+        schedule: tour,
+        initialForm: null,
+      },
+    })
+  }, [navigate])
 
   if (idLoading) {
     return (
@@ -664,7 +654,7 @@ export function GuideFeedSchedulePage() {
           <div className="gss-banner gss-banner--schedule">
             <span className="gss-banner__icon" aria-hidden="true">💡</span>
             <span>
-              달력은 기본이 <strong>비어 있음</strong>이에요. 예약 요청을 받을 날만 날짜를 눌러 <strong>예약 받기</strong>를 켜 주세요. (월을 바꿔도 자동으로 켜지지 않아요.)
+              달력은 기본이 <strong>예약 가능</strong>이에요. 요청을 받지 않을 날짜만 눌러 <strong>예약 안 받기</strong>로 바꿔 주세요.
             </span>
           </div>
           <GuideScheduleSection
@@ -674,40 +664,10 @@ export function GuideFeedSchedulePage() {
             busy={busy}
             onActivateReceiving={activateReceiving}
             onSetBlocked={setDayBlocked}
-            onClearOpenDay={clearOpenDay}
-            onOpenCourse={(tour) => setCourseTarget(tour)}
+            onOpenCourse={moveToCourseEditor}
             requestsByScheduleId={requestsByScheduleId}
           />
         </>
-      )}
-      {courseTarget && (
-        <GuideCoursePanel
-          guideId={guideId}
-          schedule={courseTarget}
-          initialForm={savedCourseForms[courseTarget.scheduleId] ?? null}
-          onClose={() => setCourseTarget(null)}
-          onSaved={(savedForm) => {
-            if (courseTarget?.scheduleId != null && savedForm) {
-              const sid = courseTarget.scheduleId
-              setSavedCourseForms((prev) => ({
-                ...prev,
-                [sid]: {
-                  ...prev[sid],
-                  ...savedForm,
-                },
-              }))
-              setSchedules((prev) =>
-                prev.map((row) => (
-                  row.scheduleId === sid
-                    ? { ...row, hasCourse: true }
-                    : row
-                )),
-              )
-            }
-            setCourseTarget(null)
-            void reloadScheduleData(guideId)
-          }}
-        />
       )}
     </div>
   )

--- a/frontend/src/pages/GuideInboxPage.css
+++ b/frontend/src/pages/GuideInboxPage.css
@@ -29,9 +29,53 @@
   margin-top: 0.5rem;
 }
 
+.inbox-status-sections {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.inbox-status-section {
+  border: 1px solid #e8eaed;
+  border-radius: 14px;
+  background: #fff;
+  box-shadow: 0 2px 10px rgba(31, 35, 40, 0.04);
+  padding: 0.75rem;
+}
+
+.inbox-status-section--inprogress {
+  border-color: #bfdbfe;
+  background: #f8fbff;
+}
+
+.inbox-status-section--pending {
+  border-color: #fde68a;
+  background: #fffcf2;
+}
+
+.inbox-status-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.35rem;
+}
+
+.inbox-status-count {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #4b5563;
+  background: #f3f4f6;
+  border: 1px solid #e5e7eb;
+  border-radius: 999px;
+  padding: 0.2rem 0.55rem;
+  white-space: nowrap;
+}
+
 .inbox-table-wrap {
   overflow-x: auto;
-  margin-top: 1rem;
+  margin-top: 0.45rem;
   -webkit-overflow-scrolling: touch;
 }
 
@@ -242,7 +286,7 @@
   font-size: 0.95rem;
   font-weight: 800;
   color: #1f2328;
-  margin: 1.25rem 0 0.6rem;
+  margin: 0;
 }
 
 .inbox-card {

--- a/frontend/src/pages/GuideInboxPage.jsx
+++ b/frontend/src/pages/GuideInboxPage.jsx
@@ -1,12 +1,11 @@
-import { useCallback, useEffect, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
 
 import { apiRequest } from '../api/client.js'
 import { useGuidePendingRequests } from '../context/GuidePendingRequestsProvider.jsx'
 import { useAuth } from '../context/useAuth.js'
 import { useResolvedGuideId } from '../hooks/useResolvedGuideId.js'
 import { fetchGuideMatchRequests } from '../lib/matchingGuest.js'
-import { GuideCoursePanel, parseCourseDetail } from './GuideCoursePanel.jsx'
 
 import './GuideInboxPage.css'
 
@@ -37,7 +36,26 @@ function statusLabel(status) {
   )
 }
 
+function formatScheduleTime(t) {
+  if (t == null) return '00:00'
+  if (typeof t === 'string') return t.length >= 5 ? t.slice(0, 5) : t
+  return String(t)
+}
+
+function formatBudget(value) {
+  return value ? `₩${Number(value).toLocaleString('ko-KR')}` : '—'
+}
+
+const STATUS_SECTIONS = [
+  { key: 'PENDING', label: '대기중', statuses: ['PENDING'] },
+  { key: 'IN_PROGRESS', label: '투어 진행중', statuses: ['IN_PROGRESS'] },
+  { key: 'ACCEPTED', label: '제시안 전송', statuses: ['ACCEPTED'] },
+  { key: 'PAID', label: '결제완료', statuses: ['PAID'] },
+  { key: 'REJECTED', label: '거절', statuses: ['REJECTED', 'CANCELLED'] },
+]
+
 export function GuideInboxPage() {
+  const navigate = useNavigate()
   const { isGuide } = useAuth()
   const { refresh: refreshPendingBadge } = useGuidePendingRequests()
   const { guideId } = useResolvedGuideId()
@@ -47,7 +65,6 @@ export function GuideInboxPage() {
   const [loading, setLoading] = useState(true)
   const [busyId, setBusyId] = useState(null)
   const [toast, setToast] = useState('')
-  const [courseTarget, setCourseTarget] = useState(null)
 
   const fetchList = useCallback(async () => {
     setError('')
@@ -128,6 +145,20 @@ export function GuideInboxPage() {
     void loadSchedules()
   }, [loadSchedules])
 
+  const groupedRows = useMemo(() => {
+    const sections = STATUS_SECTIONS.map((section) => ({
+      ...section,
+      rows: rows.filter((row) => section.statuses.includes(String(row.status ?? ''))),
+    }))
+    const included = new Set(STATUS_SECTIONS.flatMap((section) => section.statuses))
+    const others = rows.filter((row) => !included.has(String(row.status ?? '')))
+    const rejectedSection = sections.find((section) => section.key === 'REJECTED')
+    const mainSections = sections.filter((section) => section.key !== 'REJECTED' && section.rows.length > 0)
+    if (others.length > 0) mainSections.push({ key: 'OTHER', label: '기타', statuses: [], rows: others })
+    if (rejectedSection?.rows.length) mainSections.push(rejectedSection)
+    return mainSections
+  }, [rows])
+
   const openCourseWriter = async (r) => {
     if (guideId == null) {
       setToast('가이드 프로필 정보를 불러오는 중입니다. 잠시 후 다시 시도해 주세요.')
@@ -158,50 +189,23 @@ export function GuideInboxPage() {
         setBusyId(null)
       }
     }
-    setCourseTarget({
-      requestId: r.requestId,
+    const schedulePayload = {
       scheduleId: sid,
       availableDate: linkedSchedule?.availableDate ?? r.desiredDate ?? '',
-      startTime: linkedSchedule?.startTime ?? '00:00',
-      endTime: linkedSchedule?.endTime ?? '23:59',
+      startTime: formatScheduleTime(linkedSchedule?.startTime ?? '00:00'),
+      endTime: formatScheduleTime(linkedSchedule?.endTime ?? '23:59'),
       destination: r.destination ?? '',
+    }
+    const params = new URLSearchParams()
+    params.set('scheduleId', String(sid))
+    params.set('propose', '1')
+    if (schedulePayload.availableDate) params.set('date', String(schedulePayload.availableDate))
+    params.set('startTime', schedulePayload.startTime)
+    params.set('endTime', schedulePayload.endTime)
+    if (schedulePayload.destination) params.set('destination', String(schedulePayload.destination))
+    navigate(`/guide/requests/${r.requestId}/course-editor?${params.toString()}`, {
+      state: { schedule: schedulePayload, proposeAfterSave: true },
     })
-  }
-
-  const buildProposedSchedule = (courseDetail) => {
-    const spots = parseCourseDetail(courseDetail).filter((spot) => String(spot.name ?? '').trim())
-    if (spots.length === 0) return ''
-    return spots.map((spot) => spot.name.trim()).join(' -> ')
-  }
-
-  const submitProposalFromForm = async (requestId, savedForm) => {
-    const proposedSchedule = buildProposedSchedule(savedForm?.courseDetail ?? '')
-    const proposeMessage = String(savedForm?.guideMessage ?? '').trim()
-    const body = {
-      proposedSchedule,
-      proposeMessage: proposeMessage || undefined,
-    }
-    if (!proposedSchedule) {
-      setToast('코스 스팟을 1개 이상 작성해야 제시안을 보낼 수 있습니다.')
-      return
-    }
-    setBusyId(requestId)
-    setToast('')
-    try {
-      const res = await apiRequest(`/matching/requests/${requestId}/propose`, { method: 'PATCH', json: body })
-      const text = await res.text()
-      if (!res.ok) {
-        setToast(await readJsonError(res, text))
-        return
-      }
-      await fetchList()
-      await loadSchedules()
-      setCourseTarget(null)
-    } catch {
-      setToast('제시안 전송 실패')
-    } finally {
-      setBusyId(null)
-    }
   }
 
   if (!isGuide) {
@@ -236,103 +240,108 @@ export function GuideInboxPage() {
       )}
 
       {!loading && !error && rows.length > 0 && (
-        <>
-          <div className="inbox-table-wrap">
-            <table className="inbox-table">
-              <thead>
-                <tr>
-                  <th>상태</th>
-                  <th>게스트</th>
-                  <th>목적지</th>
-                  <th>희망일</th>
-                  <th>예산</th>
-                  <th>동작</th>
-                </tr>
-              </thead>
-              <tbody>
-                {rows.map((r) => (
-                  <tr key={r.requestId}>
-                    <td>{statusLabel(r.status)}</td>
-                    <td>{`게스트 #${r.guestId}`}</td>
-                    <td>{r.destination}</td>
-                    <td>{r.desiredDate ?? '—'}</td>
-                    <td>{r.desiredBudget ? '₩' + Number(r.desiredBudget).toLocaleString('ko-KR') : '—'}</td>
-                    <td className="inbox-actions">
-                      {r.status === 'PENDING' && (
-                        <>
-                          <button type="button" className="inbox-btn" onClick={() => openCourseWriter(r)} disabled={busyId != null}>
-                            코스 작성하기
-                          </button>
-                          <button
-                            type="button"
-                            className="inbox-btn inbox-btn--danger"
-                            onClick={() => void reject(r.requestId)}
-                            disabled={busyId != null}
-                          >
-                            거절
-                          </button>
-                        </>
-                      )}
-                    </td>
-                  </tr>
+        <div className="inbox-status-sections">
+          {groupedRows.map((section) => (
+            <section
+              key={section.key}
+              className={`inbox-status-section${section.key === 'IN_PROGRESS' ? ' inbox-status-section--inprogress' : ''}${section.key === 'PENDING' ? ' inbox-status-section--pending' : ''}`}
+              aria-label={`${section.label} 요청`}
+            >
+              <header className="inbox-status-head">
+                <h2 className="inbox-section-title">{section.label}</h2>
+                <span className="inbox-status-count">{section.rows.length}건</span>
+              </header>
+
+              <div className="inbox-table-wrap">
+                <table className="inbox-table">
+                  <thead>
+                    <tr>
+                      <th>상태</th>
+                      <th>게스트</th>
+                      <th>목적지</th>
+                      <th>희망일</th>
+                      <th>예산</th>
+                      <th>동작</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {section.rows.map((r) => (
+                      <tr key={r.requestId}>
+                        <td>{statusLabel(r.status)}</td>
+                        <td>{`게스트 #${r.guestId}`}</td>
+                        <td>{r.destination ?? '—'}</td>
+                        <td>{r.desiredDate ?? '—'}</td>
+                        <td>{formatBudget(r.desiredBudget)}</td>
+                        <td className="inbox-actions">
+                          {r.status === 'PENDING' && (
+                            <>
+                              <button type="button" className="inbox-btn" onClick={() => openCourseWriter(r)} disabled={busyId != null}>
+                                코스 작성하기
+                              </button>
+                              <button
+                                type="button"
+                                className="inbox-btn inbox-btn--danger"
+                                onClick={() => void reject(r.requestId)}
+                                disabled={busyId != null}
+                              >
+                                거절
+                              </button>
+                            </>
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              <div className="inbox-cards" aria-label={`${section.label} 카드 목록`}>
+                {section.rows.map((r) => (
+                  <article
+                    key={`card-${r.requestId}`}
+                    className="inbox-card"
+                    style={['REJECTED', 'CANCELLED', 'COMPLETED'].includes(r.status) ? { opacity: 0.55 } : undefined}
+                  >
+                    <header className="inbox-card-head">
+                      <span className="inbox-card-id">#{r.requestId}</span>
+                      {statusLabel(r.status)}
+                    </header>
+                    <p className="inbox-card-line">👤 <strong>게스트</strong> {`게스트 #${r.guestId}`}</p>
+                    <p className="inbox-card-line">📍 <strong>목적지</strong> {r.destination ?? '—'}</p>
+                    <p className="inbox-card-line">📅 <strong>희망일</strong> {r.desiredDate ?? '—'}</p>
+                    <p className="inbox-card-line">💰 <strong>예산</strong> {formatBudget(r.desiredBudget)}</p>
+                    {r.conceptSummary && (
+                      <p className="inbox-card-line">🗺️ <strong>여행 컨셉</strong> {r.conceptSummary}</p>
+                    )}
+                    {r.createdAt && (
+                      <p className="inbox-card-line">🕐 <strong>요청일</strong> {new Date(r.createdAt).toLocaleDateString('ko-KR')}</p>
+                    )}
+                    {r.status === 'ACCEPTED' && (
+                      <p className="inbox-proposed-hint">✉️ 제시안을 전송했습니다. 게스트가 수락하면 결제로 진행됩니다.</p>
+                    )}
+                    {r.status === 'PENDING' && (
+                      <div className="inbox-card-actions">
+                        <button type="button" className="inbox-btn" onClick={() => openCourseWriter(r)} disabled={busyId != null}>
+                          코스 작성하기
+                        </button>
+                        <button
+                          type="button"
+                          className="inbox-btn inbox-btn--danger"
+                          onClick={() => void reject(r.requestId)}
+                          disabled={busyId != null}
+                        >
+                          거절
+                        </button>
+                      </div>
+                    )}
+                  </article>
                 ))}
-              </tbody>
-            </table>
-          </div>
-
-          <div className="inbox-cards" aria-label="예약 요청 카드 목록">
-            {rows.map((r) => (
-              <article
-                key={`card-${r.requestId}`}
-                className="inbox-card"
-                style={['REJECTED', 'CANCELLED', 'COMPLETED'].includes(r.status) ? { opacity: 0.55 } : undefined}
-              >
-                <header className="inbox-card-head">
-                  <span className="inbox-card-id">#{r.requestId}</span>
-                  {statusLabel(r.status)}
-                </header>
-                <p className="inbox-card-line">👤 <strong>게스트</strong> {`게스트 #${r.guestId}`}</p>
-                <p className="inbox-card-line">📍 <strong>목적지</strong> {r.destination ?? '—'}</p>
-                <p className="inbox-card-line">📅 <strong>희망일</strong> {r.desiredDate ?? '—'}</p>
-                <p className="inbox-card-line">💰 <strong>예산</strong> {r.desiredBudget ? '₩' + Number(r.desiredBudget).toLocaleString('ko-KR') : '—'}</p>
-                {r.conceptSummary && (
-                  <p className="inbox-card-line">🗺️ <strong>여행 컨셉</strong> {r.conceptSummary}</p>
-                )}
-                {r.createdAt && (
-                  <p className="inbox-card-line">🕐 <strong>요청일</strong> {new Date(r.createdAt).toLocaleDateString('ko-KR')}</p>
-                )}
-                {r.status === 'ACCEPTED' && (
-                  <p className="inbox-proposed-hint">✉️ 제시안을 전송했습니다. 게스트가 수락하면 결제로 진행됩니다.</p>
-                )}
-                {r.status === 'PENDING' && (
-                  <div className="inbox-card-actions">
-                    <button type="button" className="inbox-btn" onClick={() => openCourseWriter(r)} disabled={busyId != null}>
-                      코스 작성하기
-                    </button>
-                    <button
-                      type="button"
-                      className="inbox-btn inbox-btn--danger"
-                      onClick={() => void reject(r.requestId)}
-                      disabled={busyId != null}
-                    >
-                      거절
-                    </button>
-                  </div>
-                )}
-              </article>
-            ))}
-          </div>
-        </>
+              </div>
+            </section>
+          ))}
+        </div>
       )}
 
-      {courseTarget && guideId != null && (
-        <GuideCoursePanel
-          guideId={guideId}
-          schedule={courseTarget}
-          onClose={() => setCourseTarget(null)}
-          onSaved={(savedForm) => void submitProposalFromForm(courseTarget.requestId, savedForm)}
-        />
-      )}
     </div>
   )
 }

--- a/frontend/src/pages/GuideScheduleSection.jsx
+++ b/frontend/src/pages/GuideScheduleSection.jsx
@@ -39,7 +39,7 @@ function getDayStatus(dayKey, scheduleByDate, blockedDates) {
   if (daySchedules.some((s) => s.status === 'BOOKED')) return 'booked'
   if (daySchedules.some((s) => s.status === 'PENDING')) return 'pending'
   if (daySchedules.some((s) => s.status === 'AVAILABLE')) return 'receiving'
-  return 'neutral'
+  return 'receiving'
 }
 
 function mergeSchedules(schedules, pendingSchedules) {
@@ -61,7 +61,6 @@ function ScheduleDrawer({
   requestsByScheduleId,
   onActivateReceiving,
   onSetBlocked,
-  onClearOpenDay,
   onOpenCourse,
   busy,
 }) {
@@ -69,7 +68,7 @@ function ScheduleDrawer({
   /** 'receive' | 'block' — 적용 전 선택만 반영 */
   const [pick, setPick] = useState('receive')
 
-  const status = selectedKey ? getDayStatus(selectedKey, scheduleByDate, blockedDates) : 'neutral'
+  const status = selectedKey ? getDayStatus(selectedKey, scheduleByDate, blockedDates) : 'receiving'
   const daySchedules = selectedKey ? (scheduleByDate.get(selectedKey) ?? []) : []
 
   useEffect(() => {
@@ -86,7 +85,6 @@ function ScheduleDrawer({
     : selectedKey
 
   const badgeClass = {
-    neutral: 'gss3-badge--neutral',
     receiving: 'gss3-badge--available',
     booked: 'gss3-badge--booked',
     pending: 'gss3-badge--pending',
@@ -94,7 +92,6 @@ function ScheduleDrawer({
   }[status]
 
   const badgeLabel = {
-    neutral: '설정 없음',
     receiving: '예약 받는 중',
     booked: '예약 확정',
     pending: '수락 대기',
@@ -115,13 +112,11 @@ function ScheduleDrawer({
       <p className="gss3-drawer-date">{dateLabel}</p>
       <span className={`gss3-badge ${badgeClass}`}>{badgeLabel}</span>
 
-      {(status === 'neutral' || status === 'receiving' || status === 'blocked') && (
+      {(status === 'receiving' || status === 'blocked') && (
         <div className="gss3-drawer-avail">
           <p className="gss3-drawer-desc">
-            {status === 'neutral' &&
-              '원하는 옵션을 고른 뒤 하단의 적용하기를 누르세요. (월을 넘겨도 자동으로 켜지지 않아요.)'}
             {status === 'receiving' &&
-              '이 날에는 예약 가능 일정이 있어 게스트가 요청할 수 있어요. 막거나, 종일 받기만 끄려면 아래 링크를 사용하세요.'}
+              '기본값으로 이 날은 예약을 받는 상태예요. 필요하면 아래에서 이 날짜만 예약 안 받기로 바꿀 수 있어요.'}
             {status === 'blocked' && '이 날은 요청이 막혀 있어요. 다시 받으려면 옵션을 바꾼 뒤 적용하기를 눌러 주세요.'}
           </p>
 
@@ -146,17 +141,6 @@ function ScheduleDrawer({
             {busy ? '적용 중…' : '적용하기'}
           </button>
 
-          {status === 'receiving' && (
-            <div className="gss3-clear-slot">
-              <div className="gss3-clear-slot__copy">
-                <span className="gss3-clear-slot__title">종일 예약 받기 끄기</span>
-                <span className="gss3-clear-slot__sub">00:00~23:59 슬롯만 삭제 · &quot;예약 안 받기&quot;와는 달라요</span>
-              </div>
-              <button type="button" className="gss3-clear-slot__btn" disabled={busy} onClick={() => onClearOpenDay(selectedKey)}>
-                예약 받기 취소
-              </button>
-            </div>
-          )}
           <p className="gss3-drawer-footnote">
             &quot;예약 받기&quot;는 종일(00:00~23:59) 예약 가능 슬롯을 만들어요. 매일 투어가 있는 뜻은 아니에요.
           </p>
@@ -219,6 +203,7 @@ function ScheduleDrawer({
                       className={`gss3-dact ${s.hasCourse ? 'gss3-dact--primary' : 'gss3-dact--warn'}`}
                       onClick={() =>
                         onOpenCourse({
+                          requestId: s.matchRequestId ?? req?.requestId ?? null,
                           scheduleId: s.scheduleId,
                           availableDate: s.availableDate,
                           startTime: formatTime(s.startTime),
@@ -293,6 +278,7 @@ function BookingCard({ dateKey, info, req, isSelected, onClickCard, onOpenCourse
               className={`gss3-bact ${hasCourse ? 'gss3-bact--primary' : 'gss3-bact--warn'}`}
               onClick={() =>
                 onOpenCourse({
+                  requestId: info.matchRequestId ?? req?.requestId ?? null,
                   scheduleId: info.scheduleId,
                   availableDate: info.availableDate,
                   startTime: formatTime(info.startTime),
@@ -322,7 +308,6 @@ export function GuideScheduleSection({
   busy = false,
   onActivateReceiving,
   onSetBlocked,
-  onClearOpenDay,
   onOpenCourse,
   requestsByScheduleId = new Map(),
 }) {
@@ -475,7 +460,7 @@ export function GuideScheduleSection({
             const key = cell.inMonth ? ymd(cell.date) : null
             const past = isPast(cell.date)
             const isToday = key === todayKey
-            const status = key ? getDayStatus(key, scheduleByDate, blockedDates) : 'neutral'
+            const status = key ? getDayStatus(key, scheduleByDate, blockedDates) : 'receiving'
             const isSelected = key === selectedKey
             const daySchedules = key ? (scheduleByDate.get(key) ?? []) : []
             const hasUnwrittenCourse = daySchedules.some((s) => s.status === 'BOOKED' && !s.hasCourse)
@@ -537,10 +522,6 @@ export function GuideScheduleSection({
             오늘
           </span>
           <span className="gss3-leg">
-            <span className="gss3-leg-neutral" />
-            설정 없음
-          </span>
-          <span className="gss3-leg">
             <span className="gss3-leg-open" />
             예약 받는 날
           </span>
@@ -561,7 +542,7 @@ export function GuideScheduleSection({
             코스 미작성
           </span>
         </div>
-        <p className="gss3-cal-hint">지난 날짜는 선택할 수 없어요 · 비어 있는 날은 직접 &quot;예약 받기&quot;를 켜야 해요</p>
+        <p className="gss3-cal-hint">지난 날짜는 선택할 수 없어요 · 기본은 예약 가능이며, 원하지 않는 날짜만 &quot;예약 안 받기&quot;로 바꾸면 됩니다</p>
 
         <div className={`gss3-drawer-wrap${selectedKey ? ' gss3-drawer-wrap--open' : ''}`}>
           {selectedKey && (
@@ -572,7 +553,6 @@ export function GuideScheduleSection({
               requestsByScheduleId={requestsByScheduleId}
               onActivateReceiving={onActivateReceiving}
               onSetBlocked={onSetBlocked}
-              onClearOpenDay={onClearOpenDay}
               onOpenCourse={onOpenCourse}
               busy={busy}
             />

--- a/frontend/src/routes/guideRoutes.jsx
+++ b/frontend/src/routes/guideRoutes.jsx
@@ -3,6 +3,7 @@ import { Navigate } from 'react-router-dom'
 import { ProtectedRoute } from '../components/ProtectedRoute'
 import { GuideDashboardLayout } from '../layouts/GuideDashboardLayout'
 import { GuideApplyPage } from '../pages/GuideApplyPage'
+import { GuideCourseEditorPage } from '../pages/GuideCourseEditorPage'
 import { GuideFeedSchedulePage } from '../pages/GuideFeedSchedulePage'
 import { GuideFeesPage } from '../pages/GuideFeesPage'
 import { GuideInboxPage } from '../pages/GuideInboxPage'
@@ -35,6 +36,22 @@ export const guideRoutes = [
     element: (
       <ProtectedRoute>
         <GuideInboxPage />
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: 'guide/requests/:requestId/course-editor',
+    element: (
+      <ProtectedRoute>
+        <GuideCourseEditorPage />
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: 'guide/schedules/:scheduleId/course-editor',
+    element: (
+      <ProtectedRoute>
+        <GuideCourseEditorPage />
       </ProtectedRoute>
     ),
   },


### PR DESCRIPTION
# 🔗 이슈 번호
- Closes #339 

---

## 💡 주요 변경 사항
- 코스 작성 전용 페이지 신규 추가 (`GuideCourseEditorPage.jsx`, `GuideCourseEditorPage.css`)
- 코스 작성 진입 흐름 통일:
  - 매칭 요청/스케줄 관리 모두 전용 페이지로 이동
  - `GuideCoursePanel` standalone 동작 및 헤더 처리 개선
- 매칭 요청 페이지 UX 개선:
  - 상태별 섹션 분리 및 정렬 (`대기중` 우선, `거절` 마지막)
  - `투어 진행중`, `대기중` 섹션 강조
- 스케줄 관리 정책/문구 정리:
  - 기본은 예약 가능, 필요한 날짜만 `예약 안 받기`
  - 중복 기능이던 `예약 받기 취소` 제거
- 게스트 매칭 요청 날짜 선택 개선:
  - `GuideDetailPage`에서 select 목록 제거
  - 캘린더 기반 선택 + 과거 날짜 차단 + 차단일 비활성
- 백엔드 매칭 생성 로직 확장:
  - `MatchRequestCreateRequest`에서 `scheduleId` 선택 입력 허용
  - `MatchRequestService`에서 `desiredDate` 기반 schedule resolve/create 처리

---

## ⚠️ 주의 사항 / 질문
- 현재 정책은 “기본 예약 가능, 차단 날짜만 비허용” UX에 맞춘 구현입니다.
- `scheduleId` 자동 생성/선택 로직은 실사용에 맞게 동작하지만, 추후 슬롯 정책(종일/시간대 분리) 세분화 여지가 있습니다.
- 커밋/PR에 `application-secret.yml`, `.idea/workspace.xml` 등 로컬 파일 포함되지 않도록 확인 필요.

---

## ✅ 체크리스트
- [x] 빌드가 정상적으로 되는가?
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [x] .gitignore에 설정 파일이 잘 포함되었는가? (application-local.yml 등)