### PR TITLE
Feat/fe#340 AI 추천 카드 CTA 통일 + 순위 표시 + 뒤로가기 복원

### DIFF
--- a/frontend/src/pages/AiQuickSearchPage.css
+++ b/frontend/src/pages/AiQuickSearchPage.css
@@ -301,6 +301,33 @@
   border: 1px solid #e8eaed;
   border-radius: 14px;
   box-shadow: 0 4px 16px rgba(31, 35, 40, 0.04);
+  position: relative;
+}
+
+.ais-rank {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.ais-rank-badge {
+  width: 1.65rem;
+  height: 1.65rem;
+  border-radius: 999px;
+  background: #1f2328;
+  color: #fff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.82rem;
+  font-weight: 900;
+  letter-spacing: -0.02em;
+}
+
+.ais-rank-text {
+  font-size: 0.76rem;
+  font-weight: 800;
+  color: #111827;
 }
 
 .ais-guide-feeds {

--- a/frontend/src/pages/AiQuickSearchPage.css
+++ b/frontend/src/pages/AiQuickSearchPage.css
@@ -475,6 +475,23 @@
   border-color: #1f2328;
 }
 
+.ais-more {
+  margin-top: 0.75rem;
+  width: 100%;
+  padding: 0.6rem 1rem;
+  border-radius: 999px;
+  border: 1px solid #d1d5db;
+  background: #fff;
+  color: #111827;
+  font-size: 0.82rem;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.ais-more:hover {
+  background: #f9fafb;
+}
+
 .ais-spot-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));

--- a/frontend/src/pages/AiQuickSearchPage.jsx
+++ b/frontend/src/pages/AiQuickSearchPage.jsx
@@ -208,15 +208,20 @@ export function AiQuickSearchPage() {
       setFallbackGuides(restoredFallback)
       setExpandedGuides(Boolean(snap.expandedGuides))
       setHasSearched(Boolean(snap.hasSearched))
-      setPanelOpen(Boolean(snap.panelOpen))
-      // narrative는 result 기반으로 다시 생성해 타이핑 효과를 복원한다.
+      // 뒤로가기 복원에서는 로딩/타이핑 없이 즉시 결과를 보여준다.
+      setPanelOpen(false)
       const narrative = buildNarrative(restoredResult)
-      startTypewriter(narrative)
+      setStreamText(narrative)
+      setShowGuides(true)
+      setShowSpots(true)
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => setPanelOpen(true))
+      })
       sessionStorage.removeItem(LS_AI_SEARCH_SNAPSHOT)
     } catch {
       /* ignore */
     }
-  }, [startTypewriter])
+  }, [])
 
   const persistSnapshotForBack = useCallback(() => {
     try {

--- a/frontend/src/pages/AiQuickSearchPage.jsx
+++ b/frontend/src/pages/AiQuickSearchPage.jsx
@@ -7,7 +7,8 @@ import './AiQuickSearchPage.css'
 
 const PLACEHOLDER = '제주도에서 조용히 사진 찍기 좋은 오름 추천해줘'
 const LS_AI_SEARCH_SNAPSHOT = 'localguest_ai_search_snapshot_v1'
-const AI_GUIDE_SHOW_MAX = 5
+const AI_GUIDE_DEFAULT_SHOW = 3
+const AI_GUIDE_EXPANDED_SHOW = 5
 
 const JEJU_OREUM_SPOTS = [
   { title: '아부오름', caption: '완만한 능선, 소풍 명소', tape: 'g' },
@@ -131,6 +132,7 @@ export function AiQuickSearchPage() {
   const [showGuides, setShowGuides] = useState(false)
   const [showSpots, setShowSpots] = useState(false)
   const [fallbackGuides, setFallbackGuides] = useState([])
+  const [expandedGuides, setExpandedGuides] = useState(false)
   /** @type {Record<string, Array<{ feedId: number, imageUrl?: string, content?: string }>>} */
   const [guideFeedsById, setGuideFeedsById] = useState({})
   const typeTimerRef = useRef(null)
@@ -204,6 +206,7 @@ export function AiQuickSearchPage() {
       setPrompt(restoredPrompt)
       setResult(restoredResult)
       setFallbackGuides(restoredFallback)
+      setExpandedGuides(Boolean(snap.expandedGuides))
       setHasSearched(Boolean(snap.hasSearched))
       setPanelOpen(Boolean(snap.panelOpen))
       // narrative는 result 기반으로 다시 생성해 타이핑 효과를 복원한다.
@@ -225,12 +228,13 @@ export function AiQuickSearchPage() {
           panelOpen: true,
           result,
           fallbackGuides,
+          expandedGuides,
         }),
       )
     } catch {
       /* ignore */
     }
-  }, [fallbackGuides, hasSearched, prompt, result])
+  }, [expandedGuides, fallbackGuides, hasSearched, prompt, result])
 
   useEffect(() => {
     const recs = result?.recommendations
@@ -238,7 +242,8 @@ export function AiQuickSearchPage() {
       setGuideFeedsById({})
       return
     }
-    const ids = [...new Set(recs.slice(0, AI_GUIDE_SHOW_MAX).map((r) => r?.guideId).filter((id) => id != null))].map(String)
+    const showMax = expandedGuides ? AI_GUIDE_EXPANDED_SHOW : AI_GUIDE_DEFAULT_SHOW
+    const ids = [...new Set(recs.slice(0, showMax).map((r) => r?.guideId).filter((id) => id != null))].map(String)
     if (ids.length === 0) return
 
     let cancelled = false
@@ -266,22 +271,24 @@ export function AiQuickSearchPage() {
     }
   }, [result])
 
-  const runSearch = async (e) => {
+  const runSearch = async (e, options = {}) => {
     e?.preventDefault()
     const q = prompt.trim()
     if (!q || loading) return
+    const topN = Number(options?.topN ?? AI_GUIDE_DEFAULT_SHOW)
 
     setError('')
     setResult(null)
     setFallbackGuides([])
     setHasSearched(true)
+    setExpandedGuides(topN > AI_GUIDE_DEFAULT_SHOW)
     setLoading(true)
     openPanelSoon()
 
     try {
       const res = await apiRequest('/ai/recommend', {
         method: 'POST',
-        json: { prompt: q, topN: 5 },
+        json: { prompt: q, topN },
       })
       const text = await res.text()
       if (res.status === 401 || res.status === 403 || res.status === 302) {
@@ -311,7 +318,7 @@ export function AiQuickSearchPage() {
           if (guideRes.ok) {
             const all = guideText ? JSON.parse(guideText) : []
             const picked = pickFallbackGuides(q, data?.keywords, Array.isArray(all) ? all : [])
-            setFallbackGuides(picked.slice(0, AI_GUIDE_SHOW_MAX))
+            setFallbackGuides(picked.slice(0, topN))
           }
         } catch {
           setFallbackGuides([])
@@ -337,7 +344,8 @@ export function AiQuickSearchPage() {
   }
 
   const recs = result?.recommendations && Array.isArray(result.recommendations) ? result.recommendations : []
-  const topGuides = recs.length > 0 ? recs.slice(0, AI_GUIDE_SHOW_MAX) : fallbackGuides.slice(0, AI_GUIDE_SHOW_MAX)
+  const showMax = expandedGuides ? AI_GUIDE_EXPANDED_SHOW : AI_GUIDE_DEFAULT_SHOW
+  const topGuides = recs.length > 0 ? recs.slice(0, showMax) : fallbackGuides.slice(0, showMax)
   const keywords = result?.keywords
   const spots = pickSpots(prompt, keywords)
   const activityHint =
@@ -517,6 +525,15 @@ export function AiQuickSearchPage() {
                         )
                       })}
                     </ul>
+                  )}
+                  {!loading && !expandedGuides && recs.length > AI_GUIDE_DEFAULT_SHOW && (
+                    <button
+                      type="button"
+                      className="ais-more"
+                      onClick={() => void runSearch(null, { topN: AI_GUIDE_EXPANDED_SHOW })}
+                    >
+                      추천 가이드 더 보기
+                    </button>
                   )}
                 </section>
 

--- a/frontend/src/pages/AiQuickSearchPage.jsx
+++ b/frontend/src/pages/AiQuickSearchPage.jsx
@@ -6,6 +6,7 @@ import { apiRequest } from '../api/client'
 import './AiQuickSearchPage.css'
 
 const PLACEHOLDER = '제주도에서 조용히 사진 찍기 좋은 오름 추천해줘'
+const LS_AI_SEARCH_SNAPSHOT = 'localguest_ai_search_snapshot_v1'
 
 const JEJU_OREUM_SPOTS = [
   { title: '아부오름', caption: '완만한 능선, 소풍 명소', tape: 'g' },
@@ -188,6 +189,47 @@ export function AiQuickSearchPage() {
     },
     [stopTypewriter],
   )
+
+  useEffect(() => {
+    // 상세 화면으로 이동했다가 돌아왔을 때, 직전 AI 검색 패널을 복원한다.
+    try {
+      const raw = sessionStorage.getItem(LS_AI_SEARCH_SNAPSHOT)
+      if (!raw) return
+      const snap = JSON.parse(raw)
+      if (!snap || typeof snap !== 'object') return
+      const restoredPrompt = typeof snap.prompt === 'string' ? snap.prompt : ''
+      const restoredResult = snap.result ?? null
+      const restoredFallback = Array.isArray(snap.fallbackGuides) ? snap.fallbackGuides : []
+      setPrompt(restoredPrompt)
+      setResult(restoredResult)
+      setFallbackGuides(restoredFallback)
+      setHasSearched(Boolean(snap.hasSearched))
+      setPanelOpen(Boolean(snap.panelOpen))
+      // narrative는 result 기반으로 다시 생성해 타이핑 효과를 복원한다.
+      const narrative = buildNarrative(restoredResult)
+      startTypewriter(narrative)
+      sessionStorage.removeItem(LS_AI_SEARCH_SNAPSHOT)
+    } catch {
+      /* ignore */
+    }
+  }, [startTypewriter])
+
+  const persistSnapshotForBack = useCallback(() => {
+    try {
+      sessionStorage.setItem(
+        LS_AI_SEARCH_SNAPSHOT,
+        JSON.stringify({
+          prompt,
+          hasSearched,
+          panelOpen: true,
+          result,
+          fallbackGuides,
+        }),
+      )
+    } catch {
+      /* ignore */
+    }
+  }, [fallbackGuides, hasSearched, prompt, result])
 
   useEffect(() => {
     const recs = result?.recommendations
@@ -406,6 +448,10 @@ export function AiQuickSearchPage() {
                         const tags = tagsForGuide(g, keywords)
                         return (
                           <li key={g.guideId ?? idx} className="ais-guide-card">
+                            <div className="ais-rank" aria-label={`추천 순위 ${idx + 1}위`}>
+                              <span className="ais-rank-badge">{idx + 1}</span>
+                              <span className="ais-rank-text">추천 {idx + 1}위</span>
+                            </div>
                             <div className="ais-guide-feeds" aria-label="가이드 피드">
                               {feeds.length > 0 ? (
                                 feeds.slice(0, 6).map((f) => (
@@ -413,7 +459,8 @@ export function AiQuickSearchPage() {
                                     key={f.feedId}
                                     to={`/guides/${g.guideId}#match-request`}
                                     className="ais-feed-thumb"
-                                    title={f.content ? String(f.content).slice(0, 80) : 'AI 추천 코스 상세보기'}
+                                    title={f.content ? String(f.content).slice(0, 80) : '가이드 상세보기'}
+                                    onClick={persistSnapshotForBack}
                                   >
                                     <span
                                       className="ais-feed-thumb-img"
@@ -426,7 +473,8 @@ export function AiQuickSearchPage() {
                                 <Link
                                   to={`/guides/${g.guideId}#match-request`}
                                   className="ais-feed-empty"
-                                  title="AI 추천 코스 상세보기"
+                                  title="가이드 상세보기"
+                                  onClick={persistSnapshotForBack}
                                 >
                                   <span
                                     className="ais-feed-thumb-img"
@@ -458,9 +506,10 @@ export function AiQuickSearchPage() {
                               </div>
                               <Link
                                 to={`/guides/${g.guideId}#match-request`}
-                                className={`ais-profile-btn ${idx === 0 ? 'ais-profile-btn--primary' : ''}`}
+                                className="ais-profile-btn ais-profile-btn--primary"
+                                onClick={persistSnapshotForBack}
                               >
-                                AI 추천 코스 상세보기
+                                가이드 상세보기
                               </Link>
                             </div>
                           </li>

--- a/frontend/src/pages/AiQuickSearchPage.jsx
+++ b/frontend/src/pages/AiQuickSearchPage.jsx
@@ -7,6 +7,7 @@ import './AiQuickSearchPage.css'
 
 const PLACEHOLDER = '제주도에서 조용히 사진 찍기 좋은 오름 추천해줘'
 const LS_AI_SEARCH_SNAPSHOT = 'localguest_ai_search_snapshot_v1'
+const AI_GUIDE_SHOW_MAX = 5
 
 const JEJU_OREUM_SPOTS = [
   { title: '아부오름', caption: '완만한 능선, 소풍 명소', tape: 'g' },
@@ -237,7 +238,7 @@ export function AiQuickSearchPage() {
       setGuideFeedsById({})
       return
     }
-    const ids = [...new Set(recs.slice(0, 3).map((r) => r?.guideId).filter((id) => id != null))].map(String)
+    const ids = [...new Set(recs.slice(0, AI_GUIDE_SHOW_MAX).map((r) => r?.guideId).filter((id) => id != null))].map(String)
     if (ids.length === 0) return
 
     let cancelled = false
@@ -310,7 +311,7 @@ export function AiQuickSearchPage() {
           if (guideRes.ok) {
             const all = guideText ? JSON.parse(guideText) : []
             const picked = pickFallbackGuides(q, data?.keywords, Array.isArray(all) ? all : [])
-            setFallbackGuides(picked.slice(0, 2))
+            setFallbackGuides(picked.slice(0, AI_GUIDE_SHOW_MAX))
           }
         } catch {
           setFallbackGuides([])
@@ -336,7 +337,7 @@ export function AiQuickSearchPage() {
   }
 
   const recs = result?.recommendations && Array.isArray(result.recommendations) ? result.recommendations : []
-  const topGuides = recs.length > 0 ? recs.slice(0, 2) : fallbackGuides.slice(0, 2)
+  const topGuides = recs.length > 0 ? recs.slice(0, AI_GUIDE_SHOW_MAX) : fallbackGuides.slice(0, AI_GUIDE_SHOW_MAX)
   const keywords = result?.keywords
   const spots = pickSpots(prompt, keywords)
   const activityHint =


### PR DESCRIPTION
## 🔗 이슈 번호

Closes #340

## 💡 주요 변경 사항

- AI 검색 추천 카드 CTA 버튼을 전부 **검정(Primary) 버튼**으로 통일.
- 추천 카드 상단에 **순위 배지(추천 1위/2위/…)** 표시.
- 버튼 문구를 `AI 추천 코스 상세보기` → **`가이드 상세보기`**로 변경.
- 가이드 상세로 이동 시 AI 검색 페이지의 **프롬프트/결과 패널 상태를 sessionStorage에 스냅샷 저장**하고, 뒤로가기 복귀 시 자동 복원.
- 추천 가이드는 **기본 3명** 노출, 사용자가 **「추천 가이드 더 보기」**를 누르면 **최대 5명**까지 확장(버튼 스타일은 동일 유지).

## ⚠️ 주의 사항 / 질문

- 복원은 sessionStorage 1회성 스냅샷(복원 후 즉시 삭제) 방식입니다.

## ✅ 체크리스트

- [x] 빌드가 정상적으로 되는가? (`npm run build`)
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [x] `.gitignore`에 설정 파일이 잘 포함되었는가? (본 PR에서 설정 파일 **미변경**)