### PR TITLE
[Feat/be#343] AI 예산 평균 → 매칭 요청 desiredBudget 연결

### DIFF
--- a/backend/module-ai/src/main/java/com/team6/module/ai/dto/response/GuideRecommendResponse.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/dto/response/GuideRecommendResponse.java
@@ -79,6 +79,8 @@ public class GuideRecommendResponse {
         private String concept;
         @Schema(description = "가이드에게 보여줄 요약 문장")
         private String conceptSummary;
+        @Schema(description = "희망 예산(원). 프롬프트 예산 범위가 있으면 평균값으로 채운다(선택)")
+        private Integer desiredBudget;
         @Schema(description = "예산 힌트(낮음/중간/높음)")
         private String budgetHint;
         private Integer headcount;

--- a/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
@@ -367,10 +367,18 @@ public class PromptRecommendationService {
     private static GuideRecommendResponse.MatchRequestDraft matchRequestDraftFrom(GuideRecommendRequest request) {
         // AI 추천 응답을 바로 매칭 요청 생성 화면으로 연결하기 위한 초안 데이터다.
         // matching 모듈을 직접 호출하는 건 아니고, 프론트가 이 draft를 읽어 요청 폼 기본값으로 쓴다.
+        Integer desiredBudget = null;
+        Integer min = request.getBudgetMinWon();
+        Integer max = request.getBudgetMaxWon();
+        if (min != null && max != null && min >= 0 && max >= 0) {
+            long sum = (long) min + (long) max;
+            desiredBudget = (int) Math.round(sum / 2.0d);
+        }
         return GuideRecommendResponse.MatchRequestDraft.builder()
                 .destination(request.getRegion())
                 .concept(ConceptSummaryGenerator.generateMatchRequestConcept(request))
                 .conceptSummary(ConceptSummaryGenerator.generate(request))
+                .desiredBudget(desiredBudget)
                 .budgetHint(request.getBudgetLevel())
                 .headcount(request.getHeadcount())
                 .durationDays(request.getDurationDays())

--- a/backend/module-ai/src/test/java/com/team6/module/ai/service/PromptRecommendationServiceTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/service/PromptRecommendationServiceTest.java
@@ -65,7 +65,7 @@ class PromptRecommendationServiceTest {
         PromptRecommendationService service = createService();
 
         GuideRecommendResponse response = service.recommendByPrompt(
-                "제주 2박3일 4명 여행인데 오션뷰랑 맛집 위주로 추천해줘. 술집은 빼고!",
+                "제주 2박3일 4명 여행인데 오션뷰랑 맛집 위주로 추천해줘. 예산은 10~20만원 정도. 술집은 빼고!",
                 3,
                 List.of(
                         GuideRecommendRequest.GuideCandidateDto.builder()
@@ -94,6 +94,7 @@ class PromptRecommendationServiceTest {
         assertThat(response.getMatchRequestDraft().getConcept()).contains("희망 활동");
         assertThat(response.getMatchRequestDraft().getConcept()).contains("맛집");
         assertThat(response.getMatchRequestDraft().getConcept()).contains("바다");
+        assertThat(response.getMatchRequestDraft().getDesiredBudget()).isEqualTo(150_000);
         assertThat(response.getPolicyVersion()).isEqualTo(AiRecommendationTuning.POLICY_VERSION);
         assertThat(response.getNotice()).contains("한 분뿐");
         assertThat(response.getNoticeCodes()).contains(

--- a/frontend/src/pages/AiQuickSearchPage.jsx
+++ b/frontend/src/pages/AiQuickSearchPage.jsx
@@ -7,6 +7,7 @@ import './AiQuickSearchPage.css'
 
 const PLACEHOLDER = '제주도에서 조용히 사진 찍기 좋은 오름 추천해줘'
 const LS_AI_SEARCH_SNAPSHOT = 'localguest_ai_search_snapshot_v1'
+const LS_AI_MATCH_DRAFT = 'localguest_ai_match_draft_v1'
 const AI_GUIDE_DEFAULT_SHOW = 3
 const AI_GUIDE_EXPANDED_SHOW = 5
 
@@ -241,6 +242,34 @@ export function AiQuickSearchPage() {
     }
   }, [expandedGuides, fallbackGuides, hasSearched, prompt, result])
 
+  const persistMatchDraftForGuide = useCallback(
+    (guideId) => {
+      try {
+        const draft = result?.matchRequestDraft ?? null
+        if (!draft || !guideId) return
+        sessionStorage.setItem(
+          LS_AI_MATCH_DRAFT,
+          JSON.stringify({
+            guideId: String(guideId),
+            savedAt: Date.now(),
+            matchRequestDraft: draft,
+          }),
+        )
+      } catch {
+        /* ignore */
+      }
+    },
+    [result],
+  )
+
+  const onClickGuideDetail = useCallback(
+    (guideId) => {
+      persistMatchDraftForGuide(guideId)
+      persistSnapshotForBack()
+    },
+    [persistMatchDraftForGuide, persistSnapshotForBack],
+  )
+
   useEffect(() => {
     const recs = result?.recommendations
     if (!Array.isArray(recs) || recs.length === 0) {
@@ -474,7 +503,7 @@ export function AiQuickSearchPage() {
                                     to={`/guides/${g.guideId}#match-request`}
                                     className="ais-feed-thumb"
                                     title={f.content ? String(f.content).slice(0, 80) : '가이드 상세보기'}
-                                    onClick={persistSnapshotForBack}
+                                    onClick={() => onClickGuideDetail(g.guideId)}
                                   >
                                     <span
                                       className="ais-feed-thumb-img"
@@ -488,7 +517,7 @@ export function AiQuickSearchPage() {
                                   to={`/guides/${g.guideId}#match-request`}
                                   className="ais-feed-empty"
                                   title="가이드 상세보기"
-                                  onClick={persistSnapshotForBack}
+                                  onClick={() => onClickGuideDetail(g.guideId)}
                                 >
                                   <span
                                     className="ais-feed-thumb-img"
@@ -521,7 +550,7 @@ export function AiQuickSearchPage() {
                               <Link
                                 to={`/guides/${g.guideId}#match-request`}
                                 className="ais-profile-btn ais-profile-btn--primary"
-                                onClick={persistSnapshotForBack}
+                                onClick={() => onClickGuideDetail(g.guideId)}
                               >
                                 가이드 상세보기
                               </Link>

--- a/frontend/src/pages/GuideDetailPage.jsx
+++ b/frontend/src/pages/GuideDetailPage.jsx
@@ -176,6 +176,9 @@ export function GuideDetailPage() {
   const navigate = useNavigate()
   const { isAuthenticated, isGuide } = useAuth()
 
+  const [aiConceptSummary, setAiConceptSummary] = useState(null)
+  const [aiDesiredBudget, setAiDesiredBudget] = useState(null)
+
   const [detail, setDetail] = useState(null)
   const [schedules, setSchedules] = useState([])
   const [reviews, setReviews] = useState([])
@@ -192,6 +195,31 @@ export function GuideDetailPage() {
   const [concept, setConcept] = useState('')
   const [submitErr, setSubmitErr] = useState('')
   const [submitting, setSubmitting] = useState(false)
+
+  useEffect(() => {
+    // AI 검색 결과에서 넘어온 matchRequestDraft를 읽어, 매칭 요청 생성 시 함께 전달한다.
+    try {
+      const raw = sessionStorage.getItem('localguest_ai_match_draft_v1')
+      if (!raw) return
+      const snap = JSON.parse(raw)
+      const snapGuideId = snap?.guideId != null ? String(snap.guideId) : ''
+      if (!snapGuideId || snapGuideId !== String(guideId)) return
+      const draft = snap?.matchRequestDraft ?? null
+      if (!draft || typeof draft !== 'object') return
+
+      if (draft?.conceptSummary) setAiConceptSummary(String(draft.conceptSummary))
+      if (draft?.desiredBudget != null && draft.desiredBudget !== '') setAiDesiredBudget(Number(draft.desiredBudget))
+
+      // 폼 기본값은 사용자가 이미 입력/수정했다면 덮어쓰지 않는다.
+      if (!destination.trim() && draft?.destination) setDestination(String(draft.destination).trim())
+      if (!concept.trim() && draft?.concept) setConcept(String(draft.concept).trim())
+
+      sessionStorage.removeItem('localguest_ai_match_draft_v1')
+    } catch {
+      /* ignore */
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [guideId])
 
   useEffect(() => {
     let cancelled = false
@@ -397,6 +425,9 @@ export function GuideDetailPage() {
           scheduleId: selectedScheduleId != null ? Number(selectedScheduleId) : undefined,
           destination: dest,
           concept: concept.trim() || undefined,
+          conceptSummary: aiConceptSummary ? String(aiConceptSummary).trim() : undefined,
+          desiredBudget:
+            aiDesiredBudget != null && !Number.isNaN(Number(aiDesiredBudget)) ? Number(aiDesiredBudget) : undefined,
           desiredDate: desiredDate || undefined,
         },
       })


### PR DESCRIPTION
## 🔗 이슈 번호

- Closes #343

## 💡 주요 변경 사항

- **백엔드(module-ai)**: AI 추천 응답 `matchRequestDraft`에 `desiredBudget`(원) 필드 추가
  - 프롬프트에서 예산 범위(min/max)가 추출된 경우 **평균값**으로 계산해 내려줍니다.
- **프론트**: AI 검색에서 가이드 상세로 이동할 때 draft를 sessionStorage로 전달
  - `GuideDetailPage`에서 매칭 요청 생성(`POST /matching/requests`) 시 `conceptSummary`, `desiredBudget`를 함께 전송합니다.

## ⚠️ 주의 사항 / 질문

- 예산 범위가 없는 경우 `desiredBudget`은 전송되지 않습니다(null).
- `.ai/mcp/*` 는 로컬 설정으로 커밋하지 않았습니다.

## ✅ 체크리스트

- [x] `./gradlew :module-ai:test`
- [x] `./gradlew :api-server:compileJava`
- [x] `npm run build` (frontend)

Made with [Cursor](https://cursor.com)