### PR TITLE
[Feat/fe#345] AI 요약 숨김 전송 + 요청자 정보 구조화

### DIFF
--- a/frontend/src/pages/AiQuickSearchPage.jsx
+++ b/frontend/src/pages/AiQuickSearchPage.jsx
@@ -7,6 +7,7 @@ import './AiQuickSearchPage.css'
 
 const PLACEHOLDER = '제주도에서 조용히 사진 찍기 좋은 오름 추천해줘'
 const LS_AI_SEARCH_SNAPSHOT = 'localguest_ai_search_snapshot_v1'
+const LS_AI_MATCH_DRAFT = 'localguest_ai_match_draft_v1'
 const AI_GUIDE_DEFAULT_SHOW = 3
 const AI_GUIDE_EXPANDED_SHOW = 5
 
@@ -241,6 +242,34 @@ export function AiQuickSearchPage() {
     }
   }, [expandedGuides, fallbackGuides, hasSearched, prompt, result])
 
+  const persistMatchDraftForGuide = useCallback(
+    (guideId) => {
+      try {
+        const draft = result?.matchRequestDraft ?? null
+        if (!draft || !guideId) return
+        sessionStorage.setItem(
+          LS_AI_MATCH_DRAFT,
+          JSON.stringify({
+            guideId: String(guideId),
+            savedAt: Date.now(),
+            matchRequestDraft: draft,
+          }),
+        )
+      } catch {
+        /* ignore */
+      }
+    },
+    [result],
+  )
+
+  const onClickGuideDetail = useCallback(
+    (guideId) => {
+      persistMatchDraftForGuide(guideId)
+      persistSnapshotForBack()
+    },
+    [persistMatchDraftForGuide, persistSnapshotForBack],
+  )
+
   useEffect(() => {
     const recs = result?.recommendations
     if (!Array.isArray(recs) || recs.length === 0) {
@@ -474,7 +503,7 @@ export function AiQuickSearchPage() {
                                     to={`/guides/${g.guideId}#match-request`}
                                     className="ais-feed-thumb"
                                     title={f.content ? String(f.content).slice(0, 80) : '가이드 상세보기'}
-                                    onClick={persistSnapshotForBack}
+                                    onClick={() => onClickGuideDetail(g.guideId)}
                                   >
                                     <span
                                       className="ais-feed-thumb-img"
@@ -488,7 +517,7 @@ export function AiQuickSearchPage() {
                                   to={`/guides/${g.guideId}#match-request`}
                                   className="ais-feed-empty"
                                   title="가이드 상세보기"
-                                  onClick={persistSnapshotForBack}
+                                  onClick={() => onClickGuideDetail(g.guideId)}
                                 >
                                   <span
                                     className="ais-feed-thumb-img"
@@ -521,7 +550,7 @@ export function AiQuickSearchPage() {
                               <Link
                                 to={`/guides/${g.guideId}#match-request`}
                                 className="ais-profile-btn ais-profile-btn--primary"
-                                onClick={persistSnapshotForBack}
+                                onClick={() => onClickGuideDetail(g.guideId)}
                               >
                                 가이드 상세보기
                               </Link>

--- a/frontend/src/pages/GuideCourseEditorPage.css
+++ b/frontend/src/pages/GuideCourseEditorPage.css
@@ -134,20 +134,38 @@
 }
 
 .gce-concept {
-  margin: 0.65rem 0 0;
-  padding-top: 0.65rem;
-  border-top: 1px solid #eef0f3;
+  margin: 0;
   font-size: 0.8125rem;
   line-height: 1.5;
   color: #3c434d;
 }
 
 .gce-concept-detail {
-  margin: 0.5rem 0 0;
+  margin: 0;
   font-size: 0.78rem;
   line-height: 1.55;
   color: #6b7280;
   white-space: pre-wrap;
+}
+
+.gce-concept-box {
+  margin: 0.65rem 0 0;
+  padding-top: 0.65rem;
+  border-top: 1px solid #eef0f3;
+  display: grid;
+  gap: 0.55rem;
+}
+
+.gce-concept-block {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.gce-concept-title {
+  margin: 0;
+  font-size: 0.7rem;
+  font-weight: 800;
+  color: #111827;
 }
 
 .gce-editor {

--- a/frontend/src/pages/GuideCourseEditorPage.jsx
+++ b/frontend/src/pages/GuideCourseEditorPage.jsx
@@ -287,13 +287,23 @@ export function GuideCourseEditorPage() {
               <span className="gce-value">{formatRequestedAt(matchRow.createdAt)}</span>
             </div>
           </div>
-          {matchRow.conceptSummary?.trim() && (
-            <p className="gce-concept">{matchRow.conceptSummary.trim()}</p>
+          {(matchRow.conceptSummary?.trim() || matchRow.concept?.trim()) && (
+            <div className="gce-concept-box" aria-label="여행 컨셉">
+              {matchRow.conceptSummary?.trim() && (
+                <div className="gce-concept-block">
+                  <p className="gce-concept-title">요약</p>
+                  <p className="gce-concept">{matchRow.conceptSummary.trim()}</p>
+                </div>
+              )}
+              {matchRow.concept?.trim() &&
+                matchRow.concept.trim() !== String(matchRow.conceptSummary ?? '').trim() && (
+                  <div className="gce-concept-block">
+                    <p className="gce-concept-title">상세</p>
+                    <p className="gce-concept-detail">{matchRow.concept.trim()}</p>
+                  </div>
+                )}
+            </div>
           )}
-          {matchRow.concept?.trim() &&
-            matchRow.concept.trim() !== String(matchRow.conceptSummary ?? '').trim() && (
-              <p className="gce-concept-detail">{matchRow.concept.trim()}</p>
-            )}
         </section>
       )}
 

--- a/frontend/src/pages/GuideDetailPage.jsx
+++ b/frontend/src/pages/GuideDetailPage.jsx
@@ -176,6 +176,10 @@ export function GuideDetailPage() {
   const navigate = useNavigate()
   const { isAuthenticated, isGuide } = useAuth()
 
+  const [aiConceptSummary, setAiConceptSummary] = useState(null)
+  const [aiDesiredBudget, setAiDesiredBudget] = useState(null)
+  const [aiHiddenConcept, setAiHiddenConcept] = useState(null)
+
   const [detail, setDetail] = useState(null)
   const [schedules, setSchedules] = useState([])
   const [reviews, setReviews] = useState([])
@@ -192,6 +196,31 @@ export function GuideDetailPage() {
   const [concept, setConcept] = useState('')
   const [submitErr, setSubmitErr] = useState('')
   const [submitting, setSubmitting] = useState(false)
+
+  useEffect(() => {
+    // AI 검색 결과에서 넘어온 matchRequestDraft는 게스트에게 노출하지 않고, 전송 시에만 활용한다.
+    try {
+      const raw = sessionStorage.getItem('localguest_ai_match_draft_v1')
+      if (!raw) return
+      const snap = JSON.parse(raw)
+      const snapGuideId = snap?.guideId != null ? String(snap.guideId) : ''
+      if (!snapGuideId || snapGuideId !== String(guideId)) return
+      const draft = snap?.matchRequestDraft ?? null
+      if (!draft || typeof draft !== 'object') return
+
+      if (draft?.conceptSummary) setAiConceptSummary(String(draft.conceptSummary))
+      if (draft?.desiredBudget != null && draft.desiredBudget !== '') setAiDesiredBudget(Number(draft.desiredBudget))
+      if (draft?.concept) setAiHiddenConcept(String(draft.concept))
+
+      // 목적지는 사용자가 비워둔 경우에만 보조로 채운다.
+      if (!destination.trim() && draft?.destination) setDestination(String(draft.destination).trim())
+
+      sessionStorage.removeItem('localguest_ai_match_draft_v1')
+    } catch {
+      /* ignore */
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [guideId])
 
   useEffect(() => {
     let cancelled = false
@@ -388,6 +417,8 @@ export function GuideDetailPage() {
       : schedules.find((s) => Number(s.scheduleId) === Number(selectedScheduleId))
     const desiredDate = selectedDateKey || (sch?.availableDate != null ? formatScheduleDate(sch.availableDate) : undefined)
 
+    const conceptText = concept.trim() || (aiHiddenConcept ? String(aiHiddenConcept).trim() : '')
+
     setSubmitting(true)
     try {
       const res = await apiRequest('/matching/requests', {
@@ -396,7 +427,10 @@ export function GuideDetailPage() {
           guideId: Number(guideId),
           scheduleId: selectedScheduleId != null ? Number(selectedScheduleId) : undefined,
           destination: dest,
-          concept: concept.trim() || undefined,
+          concept: conceptText || undefined,
+          conceptSummary: aiConceptSummary ? String(aiConceptSummary).trim() : undefined,
+          desiredBudget:
+            aiDesiredBudget != null && !Number.isNaN(Number(aiDesiredBudget)) ? Number(aiDesiredBudget) : undefined,
           desiredDate: desiredDate || undefined,
         },
       })


### PR DESCRIPTION
## 🔗 이슈 번호

- Closes #345

## 💡 주요 변경 사항

- **게스트(GuideDetailPage)**
  - AI 추천 `matchRequestDraft`로부터 받은 컨셉/요약/예산을 **입력칸(하고 싶은 일)에 미리 채우지 않음**
  - 사용자가 내용을 비워도 서버에는 AI draft를 **숨겨서 함께 전송**하여 가이드가 요청자 정보를 볼 수 있게 함
- **AI 검색(AiQuickSearchPage)**
  - 가이드 상세 이동 전 `matchRequestDraft`를 sessionStorage로 전달
- **가이드(GuideCourseEditorPage)**
  - 요청자 정보에서 컨셉을 **요약/상세로 구분**해 가독성 개선

## ⚠️ 주의 사항 / 질문

- 게스트가 textarea에 직접 입력하면, 그 입력이 `concept`로 우선 전송됩니다.
- `.ai/mcp/*` 는 로컬 설정으로 커밋하지 않았습니다.

## ✅ 체크리스트

- [x] `npm run build` (frontend)

Made with [Cursor](https://cursor.com)