### PR TITLE
Feat/be#347 프롬프트 예산 범위(min/max) 저장 및 가이드 노출

### DIFF
--- a/backend/module-ai/src/main/java/com/team6/module/ai/dto/response/GuideRecommendResponse.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/dto/response/GuideRecommendResponse.java
@@ -81,6 +81,10 @@ public class GuideRecommendResponse {
         private String conceptSummary;
         @Schema(description = "희망 예산(원). 프롬프트 예산 범위가 있으면 평균값으로 채운다(선택)")
         private Integer desiredBudget;
+        @Schema(description = "희망 예산 하한(원). 프롬프트 예산 범위가 있으면 채운다(선택)")
+        private Integer budgetMinWon;
+        @Schema(description = "희망 예산 상한(원). 프롬프트 예산 범위가 있으면 채운다(선택)")
+        private Integer budgetMaxWon;
         @Schema(description = "예산 힌트(낮음/중간/높음)")
         private String budgetHint;
         private Integer headcount;

--- a/backend/module-ai/src/main/java/com/team6/module/ai/parser/PromptParser.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/parser/PromptParser.java
@@ -200,6 +200,12 @@ public class PromptParser {
                 return null;
             }
         }
+
+        // "예산 하루 10만원" 같이 단일 금액 표현도 범위(min=max)로 보존한다.
+        Integer single = extractBudgetAmount(prompt);
+        if (single != null && single >= 0) {
+            return new BudgetRange(single, single);
+        }
         return null;
     }
 

--- a/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
@@ -379,6 +379,8 @@ public class PromptRecommendationService {
                 .concept(ConceptSummaryGenerator.generateMatchRequestConcept(request))
                 .conceptSummary(ConceptSummaryGenerator.generate(request))
                 .desiredBudget(desiredBudget)
+                .budgetMinWon(min)
+                .budgetMaxWon(max)
                 .budgetHint(request.getBudgetLevel())
                 .headcount(request.getHeadcount())
                 .durationDays(request.getDurationDays())

--- a/backend/module-ai/src/test/java/com/team6/module/ai/parser/PromptParserTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/parser/PromptParserTest.java
@@ -34,7 +34,21 @@ class PromptParserTest {
 
         assertThat(request.getRegion()).isEqualTo("제주");
         assertThat(request.getBudgetLevel()).isEqualTo("중간");
+        assertThat(request.getBudgetMinWon()).isEqualTo(200_000);
+        assertThat(request.getBudgetMaxWon()).isEqualTo(200_000);
         assertThat(request.getActivityTags()).contains("카페");
+    }
+
+    @Test
+    void parse_should_preserve_single_budget_amount_as_range() {
+        GuideRecommendRequest request = promptParser.parse(
+                "제주도 맛집 투어랑 야경이 예쁜곳에 가고싶어요 예산은 하루 10만원",
+                3,
+                List.of()
+        );
+        assertThat(request.getRegion()).isEqualTo("제주");
+        assertThat(request.getBudgetMinWon()).isEqualTo(100_000);
+        assertThat(request.getBudgetMaxWon()).isEqualTo(100_000);
     }
 
     @Test

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/dto/request/MatchRequestCreateRequest.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/dto/request/MatchRequestCreateRequest.java
@@ -45,4 +45,10 @@ public class MatchRequestCreateRequest {
     private LocalDate desiredDate;
 
     private Integer desiredBudget;
+
+    /**
+     * 희망 예산 범위(원). 프롬프트/입력에서 범위를 받는 경우 그대로 저장한다(선택).
+     */
+    private Integer budgetMinWon;
+    private Integer budgetMaxWon;
 }

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/dto/response/MatchRequestCreateResponse.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/dto/response/MatchRequestCreateResponse.java
@@ -23,6 +23,8 @@ public class MatchRequestCreateResponse {
     private String conceptSummary;
     private LocalDate desiredDate;
     private Integer desiredBudget;
+    private Integer budgetMinWon;
+    private Integer budgetMaxWon;
     private String proposedSchedule;
     private String proposeMessage;
     private String status;
@@ -44,6 +46,8 @@ public class MatchRequestCreateResponse {
                 .conceptSummary(entity.getConceptSummary())
                 .desiredDate(entity.getDesiredDate())
                 .desiredBudget(entity.getDesiredBudget())
+                .budgetMinWon(entity.getBudgetMinWon())
+                .budgetMaxWon(entity.getBudgetMaxWon())
                 .proposedSchedule(entity.getProposedSchedule())
                 .proposeMessage(entity.getProposeMessage())
                 .status(entity.getStatus().name())

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/entity/MatchRequest.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/entity/MatchRequest.java
@@ -61,6 +61,22 @@ public class MatchRequest extends BaseTimeEntity {
     @Column(name = "desired_budget")
     private Integer desiredBudget;      // 희망 예산(원)
 
+    /**
+     * 희망 예산 범위(원). 가이드가 “N~M원” 형태로 더 디테일하게 계획을 잡을 수 있도록 보존한다.
+     *
+     * DDL 적용 방법: Flyway/Liquibase 마이그레이션 또는 DBA가 직접 아래 DDL 실행
+     * <pre>
+     * ALTER TABLE match_request
+     *   ADD COLUMN budget_min_won INT NULL AFTER desired_budget,
+     *   ADD COLUMN budget_max_won INT NULL AFTER budget_min_won;
+     * </pre>
+     */
+    @Column(name = "budget_min_won")
+    private Integer budgetMinWon;
+
+    @Column(name = "budget_max_won")
+    private Integer budgetMaxWon;
+
     @Column(name = "proposed_schedule", columnDefinition = "TEXT")
     private String proposedSchedule;    // 가이드 제시 일정(간략)
 
@@ -93,7 +109,9 @@ public class MatchRequest extends BaseTimeEntity {
             String concept,
             String conceptSummary,
             LocalDate desiredDate,
-            Integer desiredBudget
+            Integer desiredBudget,
+            Integer budgetMinWon,
+            Integer budgetMaxWon
     ) {
         return MatchRequest.builder()
                 .guestId(guestId)
@@ -104,6 +122,8 @@ public class MatchRequest extends BaseTimeEntity {
                 .conceptSummary(conceptSummary)
                 .desiredDate(desiredDate)
                 .desiredBudget(desiredBudget)
+                .budgetMinWon(budgetMinWon)
+                .budgetMaxWon(budgetMaxWon)
                 .build();
     }
 

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/service/MatchRequestService.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/service/MatchRequestService.java
@@ -53,7 +53,9 @@ public class MatchRequestService {
                 request.getConcept(),
                 conceptSummary,
                 request.getDesiredDate(),
-                request.getDesiredBudget()
+                request.getDesiredBudget(),
+                request.getBudgetMinWon(),
+                request.getBudgetMaxWon()
         );
 
         MatchRequest saved = matchRequestRepository.save(matchRequest);

--- a/backend/module-domain/src/test/java/com/team6/domain/matching/service/MatchRequestServiceTest.java
+++ b/backend/module-domain/src/test/java/com/team6/domain/matching/service/MatchRequestServiceTest.java
@@ -97,6 +97,8 @@ class MatchRequestServiceTest {
         setField(request, "concept", "food");
         setField(request, "desiredDate", LocalDate.of(2026, 4, 20));
         setField(request, "desiredBudget", 50000);
+        setField(request, "budgetMinWon", 40000);
+        setField(request, "budgetMaxWon", 60000);
         return request;
     }
 

--- a/frontend/src/pages/GuideCourseEditorPage.jsx
+++ b/frontend/src/pages/GuideCourseEditorPage.jsx
@@ -30,6 +30,17 @@ function formatBudgetKrw(n) {
   return `${Number(n).toLocaleString('ko-KR')}원`
 }
 
+function formatBudgetRange(minWon, maxWon) {
+  const min = minWon != null && minWon !== '' && !Number.isNaN(Number(minWon)) ? Number(minWon) : null
+  const max = maxWon != null && maxWon !== '' && !Number.isNaN(Number(maxWon)) ? Number(maxWon) : null
+  if (min == null && max == null) return null
+  if (min != null && max != null) {
+    return `${min.toLocaleString('ko-KR')}~${max.toLocaleString('ko-KR')}원`
+  }
+  const only = min ?? max
+  return `${Number(only).toLocaleString('ko-KR')}원`
+}
+
 function formatDesiredDate(d) {
   if (d == null || d === '') return '—'
   return String(d)
@@ -276,7 +287,9 @@ export function GuideCourseEditorPage() {
             </div>
             <div className="gce-guest-item">
               <span className="gce-label">예산</span>
-              <span className="gce-value">{formatBudgetKrw(matchRow.desiredBudget)}</span>
+              <span className="gce-value">
+                {formatBudgetRange(matchRow.budgetMinWon, matchRow.budgetMaxWon) ?? formatBudgetKrw(matchRow.desiredBudget)}
+              </span>
             </div>
             <div className="gce-guest-item">
               <span className="gce-label">요청 상태</span>

--- a/frontend/src/pages/GuideDetailPage.jsx
+++ b/frontend/src/pages/GuideDetailPage.jsx
@@ -178,6 +178,8 @@ export function GuideDetailPage() {
 
   const [aiConceptSummary, setAiConceptSummary] = useState(null)
   const [aiDesiredBudget, setAiDesiredBudget] = useState(null)
+  const [aiBudgetMinWon, setAiBudgetMinWon] = useState(null)
+  const [aiBudgetMaxWon, setAiBudgetMaxWon] = useState(null)
   const [aiHiddenConcept, setAiHiddenConcept] = useState(null)
 
   const [detail, setDetail] = useState(null)
@@ -210,6 +212,8 @@ export function GuideDetailPage() {
 
       if (draft?.conceptSummary) setAiConceptSummary(String(draft.conceptSummary))
       if (draft?.desiredBudget != null && draft.desiredBudget !== '') setAiDesiredBudget(Number(draft.desiredBudget))
+      if (draft?.budgetMinWon != null && draft.budgetMinWon !== '') setAiBudgetMinWon(Number(draft.budgetMinWon))
+      if (draft?.budgetMaxWon != null && draft.budgetMaxWon !== '') setAiBudgetMaxWon(Number(draft.budgetMaxWon))
       if (draft?.concept) setAiHiddenConcept(String(draft.concept))
 
       // 목적지는 사용자가 비워둔 경우에만 보조로 채운다.
@@ -431,6 +435,10 @@ export function GuideDetailPage() {
           conceptSummary: aiConceptSummary ? String(aiConceptSummary).trim() : undefined,
           desiredBudget:
             aiDesiredBudget != null && !Number.isNaN(Number(aiDesiredBudget)) ? Number(aiDesiredBudget) : undefined,
+          budgetMinWon:
+            aiBudgetMinWon != null && !Number.isNaN(Number(aiBudgetMinWon)) ? Number(aiBudgetMinWon) : undefined,
+          budgetMaxWon:
+            aiBudgetMaxWon != null && !Number.isNaN(Number(aiBudgetMaxWon)) ? Number(aiBudgetMaxWon) : undefined,
           desiredDate: desiredDate || undefined,
         },
       })


### PR DESCRIPTION
## 🔗 이슈 번호

- Closes #347

## 💡 주요 변경 사항

- **AI(module-ai)**: `matchRequestDraft`에 `budgetMinWon/budgetMaxWon`(원) 포함
  - 추가 보강: "하루 10만원" 같은 **단일 금액 표현도 범위(min=max)** 로 보존
- **매칭(module-domain)**
  - `MatchRequest`에 `budget_min_won`, `budget_max_won` 컬럼(Nullable) 추가
  - `POST /matching/requests`, `GET /matching/requests/*/list` 응답 DTO에 범위 필드 포함
- **프론트**
  - 가이드 상세에서 매칭 요청 생성 시 AI draft의 범위 예산을 함께 전송
  - 가이드 요청자 정보에서 범위가 있으면 `min~max` 형태로 우선 표시

## ⚠️ 주의 사항 / 질문

- 이 레포에는 DB 마이그레이션 툴(Flyway/Liquibase) 설정이 없어, 엔티티에 **DDL(ALTER TABLE)** 을 함께 남겼습니다.
  - 운영/공용 DB에는 아래 DDL 반영 후 `ddl-auto: validate`를 유지해야 합니다.

## ✅ 체크리스트

- [x] `./gradlew :module-ai:test`
- [x] `./gradlew :api-server:compileJava`
- [x] `./gradlew :module-domain:test --tests com.team6.domain.matching.service.MatchRequestServiceTest`
- [x] `npm run build` (frontend)