### PR TITLE
Feat/fe#349: 매칭 요청 UX 개선 및 가이드 일정/위치 입력 안정화

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,17 +6,21 @@
   <component name="ChangeListManager">
     <list default="true" id="84d1b3de-8103-452e-83cf-38ecd34993e7" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/backend/module-domain/src/main/java/com/team6/domain/matching/dto/request/MatchRequestCreateRequest.java" beforeDir="false" afterPath="$PROJECT_DIR$/backend/module-domain/src/main/java/com/team6/domain/matching/dto/request/MatchRequestCreateRequest.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/backend/api-server/src/main/resources/application.yml" beforeDir="false" afterPath="$PROJECT_DIR$/backend/api-server/src/main/resources/application.yml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/backend/module-domain/src/main/java/com/team6/domain/matching/service/MatchRequestService.java" beforeDir="false" afterPath="$PROJECT_DIR$/backend/module-domain/src/main/java/com/team6/domain/matching/service/MatchRequestService.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideCoursePanel.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideCoursePanel.css" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideCoursePanel.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideCoursePanel.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/api/client.js" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/api/client.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/layouts/AppLayout.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/layouts/AppLayout.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/layouts/DashboardLayout.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/layouts/DashboardLayout.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/layouts/GuideDashboardLayout.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/layouts/GuideDashboardLayout.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/layouts/MypageShell.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/layouts/MypageShell.jsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideDetailPage.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideDetailPage.css" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideDetailPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideDetailPage.jsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideFeedSchedulePage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideFeedSchedulePage.jsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideInboxPage.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideInboxPage.css" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideInboxPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideInboxPage.jsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideScheduleSection.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideScheduleSection.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideMypagePages.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideMypagePages.css" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideProfileEditPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideProfileEditPage.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideSettingsPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideSettingsPage.jsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/frontend/src/routes/guideRoutes.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/routes/guideRoutes.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/routes/mypageRoutes.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/routes/mypageRoutes.jsx" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/backend/api-server/src/main/resources/application.yml
+++ b/backend/api-server/src/main/resources/application.yml
@@ -2,6 +2,11 @@ spring:
   profiles:
     active: local
 
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+
 ---
 spring:
   config:

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/service/MatchRequestService.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/service/MatchRequestService.java
@@ -42,13 +42,13 @@ public class MatchRequestService {
     public MatchRequestCreateResponse createMatchRequest(Long guestId, MatchRequestCreateRequest request) {
         Long guideMemberId = resolveGuideMemberId(request.getGuideId());
         validateCreateRequest(guestId, guideMemberId);
-        Long guideScheduleId = resolveOrCreateScheduleId(request.getGuideId(), request);
+        ScheduleResolution scheduleResolution = resolveOrCreateSchedule(request.getGuideId(), request);
 
         String conceptSummary = resolveConceptSummary(request);
         MatchRequest matchRequest = MatchRequest.create(
                 guestId,
                 request.getGuideId(),
-                guideScheduleId,
+                scheduleResolution.scheduleId(),
                 request.getDestination(),
                 request.getConcept(),
                 conceptSummary,
@@ -59,7 +59,15 @@ public class MatchRequestService {
         );
 
         MatchRequest saved = matchRequestRepository.save(matchRequest);
-        guideScheduleSyncClient.markPending(saved.getGuideId(), saved.getGuideScheduleId(), saved.getId(), guideMemberId);
+        if (scheduleResolution.createdSchedule() != null) {
+            // 같은 트랜잭션에서 만든 슬롯은 HTTP sync 전에 직접 PENDING 반영해야 조회 불가 타이밍 문제가 없다.
+            scheduleResolution.createdSchedule().changeStatus(GuideScheduleStatus.PENDING);
+            scheduleResolution.createdSchedule().linkMatchRequest(saved.getId());
+            log.info("[F03-04] 자동 생성 슬롯 PENDING 반영 — guideId={}, scheduleId={}, requestId={}",
+                    saved.getGuideId(), saved.getGuideScheduleId(), saved.getId());
+        } else {
+            guideScheduleSyncClient.markPending(saved.getGuideId(), saved.getGuideScheduleId(), saved.getId(), guideMemberId);
+        }
         log.info("[F03-04] 매칭 요청 생성 — guestId={}, guideId={}", guestId, request.getGuideId());
         return MatchRequestCreateResponse.from(saved);
     }
@@ -249,9 +257,9 @@ public class MatchRequestService {
      *   2) AVAILABLE 슬롯이 있으면 그 슬롯 사용
      *   3) 슬롯이 없으면 종일 AVAILABLE(00:00~23:59) 슬롯을 생성해 사용
      */
-    private Long resolveOrCreateScheduleId(Long guideId, MatchRequestCreateRequest request) {
+    private ScheduleResolution resolveOrCreateSchedule(Long guideId, MatchRequestCreateRequest request) {
         if (request.getGuideScheduleId() != null) {
-            return request.getGuideScheduleId();
+            return new ScheduleResolution(request.getGuideScheduleId(), null);
         }
 
         LocalDate desiredDate = request.getDesiredDate();
@@ -271,7 +279,7 @@ public class MatchRequestService {
                 .min(Comparator.comparing(GuideSchedule::getStartTime))
                 .orElse(null);
         if (available != null) {
-            return available.getId();
+            return new ScheduleResolution(available.getId(), null);
         }
 
         boolean pendingOrBooked = daySchedules.stream()
@@ -289,8 +297,11 @@ public class MatchRequestService {
                 .endTime(LocalTime.of(23, 59))
                 .status(GuideScheduleStatus.AVAILABLE)
                 .build();
-        return guideScheduleRepository.save(generated).getId();
+        GuideSchedule saved = guideScheduleRepository.save(generated);
+        return new ScheduleResolution(saved.getId(), saved);
     }
+
+    private record ScheduleResolution(Long scheduleId, GuideSchedule createdSchedule) {}
 
     private void syncTourProgress(MatchRequest request, LocalDate today) {
         request.markInProgressIfTourDay(today);

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -99,7 +99,7 @@ export async function apiRequest(path, options = {}) {
   const normalizedPath = path.startsWith('/') ? path : `/${path}`
   if (res.ok && method === 'POST' && normalizedPath === '/guides') {
     try {
-      sessionStorage.setItem('localguest_login_return_override', '/guide/mypage/fees')
+      sessionStorage.setItem('localguest_login_return_override', '/guide/mypage/profile')
     } catch {
       /* ignore */
     }

--- a/frontend/src/layouts/AppLayout.jsx
+++ b/frontend/src/layouts/AppLayout.jsx
@@ -26,6 +26,7 @@ function AppLayoutInner() {
   const { isAuthenticated, email, isGuide, logout } = useAuth()
   const { pendingCount } = useGuidePendingRequests()
   const guideMypageActive = isGuide && pathname.startsWith('/guide/mypage')
+  const guestItineraryActive = !isGuide && (pathname.startsWith('/mypage/itinerary') || pathname.startsWith('/upcoming-trips'))
   const matchComplete = isGuidesMatchCompletePath(pathname)
   const baseTitleRef = useRef(typeof document !== 'undefined' ? document.title : 'LocalGuest')
 
@@ -71,9 +72,11 @@ function AppLayoutInner() {
             메시지
           </NavLink>
           <NavLink
-            to={isGuide ? '/guide/mypage/fees' : '/mypage'}
+            to={isGuide ? '/guide/mypage/profile' : '/mypage'}
             className={({ isActive }) => {
-              const on = isGuide ? guideMypageActive || matchComplete : isActive || matchComplete
+              const on = isGuide
+                ? guideMypageActive || matchComplete
+                : (isActive || matchComplete) && !guestItineraryActive
               const parts = ['shell-pill-link', 'shell-pill-link--cta']
               if (on) {
                 parts.push('is-on')
@@ -83,6 +86,11 @@ function AppLayoutInner() {
           >
             {isGuide ? '가이드 마이페이지' : '마이페이지'}
           </NavLink>
+          {!isGuide && (
+            <NavLink to="/upcoming-trips" className={pillClass('shell-pill-link--cta')}>
+              앞으로의 여행 일정
+            </NavLink>
+          )}
           {isGuide && (
             <NavLink
               to="/guide/inbox"

--- a/frontend/src/layouts/DashboardLayout.jsx
+++ b/frontend/src/layouts/DashboardLayout.jsx
@@ -8,7 +8,7 @@ import './DashboardLayout.css'
 
 const guestItems = [
   { to: '/mypage/scrapbook', label: '📒 나의 여행 기록(스크랩북)' },
-  { to: '/mypage/itinerary', label: '📆 앞으로의 여행 일정' },
+  { to: '/upcoming-trips', label: '📆 앞으로의 여행 일정' },
   { to: '/mypage/payments', label: '💳 결제 내역' },
   { to: '/mypage/privacy', label: '⚙️ 개인정보 설정' },
   { to: '/mypage/tour', label: '🔁 투어 연장/환불 관리' },

--- a/frontend/src/layouts/GuideDashboardLayout.jsx
+++ b/frontend/src/layouts/GuideDashboardLayout.jsx
@@ -1,4 +1,4 @@
-import { Link, Navigate, NavLink, Outlet, useLocation, useNavigate } from 'react-router-dom'
+import { Link, Navigate, NavLink, Outlet, useLocation } from 'react-router-dom'
 
 import { useGuidePendingRequests } from '../context/GuidePendingRequestsProvider.jsx'
 import { useAuth } from '../context/useAuth.js'
@@ -19,7 +19,6 @@ const NAV = [
 export function GuideDashboardLayout() {
   const { email, logout, isGuide } = useAuth()
   const { pendingCount } = useGuidePendingRequests()
-  const navigate = useNavigate()
   const { pathname, search } = useLocation()
   const displayName = email ? email.split('@')[0] : '홍길동'
 
@@ -34,9 +33,6 @@ export function GuideDashboardLayout() {
           <div className="g-dash-avatar" aria-hidden />
           <strong className="g-dash-name">{displayName}</strong>
           <span className="g-dash-email">{email ?? ''}</span>
-          <button type="button" className="g-dash-profile-btn" onClick={() => navigate('/guide/mypage/profile')}>
-            프로필 수정
-          </button>
         </div>
         <nav className="g-dash-nav" aria-label="가이드 메뉴">
           {NAV.map((item) => {

--- a/frontend/src/layouts/MypageShell.jsx
+++ b/frontend/src/layouts/MypageShell.jsx
@@ -10,7 +10,7 @@ import { DashboardLayout } from './DashboardLayout.jsx'
 export function MypageShell() {
   const { isGuide } = useAuth()
   if (isGuide) {
-    return <Navigate to="/guide/mypage/fees" replace />
+    return <Navigate to="/guide/mypage/profile" replace />
   }
   return (
     <DashboardLayout>

--- a/frontend/src/pages/GuestUpcomingTripsPage.css
+++ b/frontend/src/pages/GuestUpcomingTripsPage.css
@@ -1,0 +1,119 @@
+.gut-page {
+  width: 100%;
+  max-width: min(1080px, 100%);
+  margin: 0 auto;
+}
+
+.gut-hero {
+  margin-bottom: 1rem;
+}
+
+.gut-hero h1 {
+  margin: 0 0 0.3rem;
+  font-size: clamp(1.2rem, 4vw, 1.6rem);
+  color: #111827;
+}
+
+.gut-hero p {
+  margin: 0;
+  color: #4b5563;
+  font-size: 0.9rem;
+}
+
+.gut-sections {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.gut-section {
+  border: 1px solid #e5e7eb;
+  border-radius: 14px;
+  background: #fff;
+  padding: 0.85rem;
+}
+
+.gut-section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.65rem;
+}
+
+.gut-section-head h2 {
+  margin: 0;
+  font-size: 0.98rem;
+  color: #111827;
+}
+
+.gut-section-head span {
+  font-size: 0.76rem;
+  color: #374151;
+  background: #f3f4f6;
+  border: 1px solid #e5e7eb;
+  border-radius: 999px;
+  padding: 0.18rem 0.55rem;
+}
+
+.gut-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 0.65rem;
+}
+
+.gut-card {
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  background: #fafafa;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.gut-meta h3 {
+  margin: 0.35rem 0 0.35rem;
+  font-size: 0.95rem;
+  color: #111827;
+}
+
+.gut-meta p {
+  margin: 0.2rem 0 0;
+  font-size: 0.82rem;
+  color: #4b5563;
+  line-height: 1.45;
+}
+
+.gut-dday {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  font-size: 0.74rem;
+  font-weight: 800;
+  padding: 0.2rem 0.55rem;
+  color: #1d4ed8;
+  background: #dbeafe;
+}
+
+.gut-dday.is-today {
+  color: #b91c1c;
+  background: #fee2e2;
+}
+
+.gut-dday.is-soon {
+  color: #92400e;
+  background: #fef3c7;
+}
+
+.gut-open {
+  border: 1px solid #111827;
+  border-radius: 999px;
+  background: #111827;
+  color: #fff;
+  font-size: 0.78rem;
+  font-weight: 700;
+  padding: 0.4rem 0.7rem;
+  cursor: pointer;
+  font-family: inherit;
+}
+

--- a/frontend/src/pages/GuestUpcomingTripsPage.jsx
+++ b/frontend/src/pages/GuestUpcomingTripsPage.jsx
@@ -1,0 +1,177 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import { PageEmpty, PageError, PageLoading } from '../components/PageStates.jsx'
+import { apiRequest } from '../api/client.js'
+import {
+  daysUntil,
+  fetchGuestMatchRequests,
+  fetchGuestPayments,
+  loadGuideNicknames,
+  pickLatestCompletedPaymentIdForRequest,
+} from '../lib/matchingGuest.js'
+
+import './GuestUpcomingTripsPage.css'
+
+const UPCOMING = new Set(['PENDING', 'ACCEPTED', 'PAID', 'IN_PROGRESS'])
+
+function ddayLabel(days, status) {
+  if (status === 'IN_PROGRESS') return '진행중'
+  if (days == null) return '일정 미정'
+  if (days === 0) return 'D-Day'
+  if (days > 0) return `D-${days}`
+  return `${Math.abs(days)}일 지남`
+}
+
+function groupRows(rows) {
+  const paymentPending = []
+  const inProgress = []
+  const dday = []
+  const d1 = []
+  const upcoming = []
+
+  for (const row of rows) {
+    if (row.status === 'ACCEPTED') {
+      paymentPending.push(row)
+      continue
+    }
+    const d = daysUntil(row.desiredDate)
+    if (row.status === 'IN_PROGRESS') inProgress.push(row)
+    else if (d === 0) dday.push(row)
+    else if (d === 1) d1.push(row)
+    else upcoming.push(row)
+  }
+
+  return [
+    { key: 'payment', title: '결제하고 확정 필요', rows: paymentPending },
+    { key: 'inprogress', title: '지금 진행 중', rows: inProgress },
+    { key: 'dday', title: '오늘 출발 (D-Day)', rows: dday },
+    { key: 'd1', title: '내일 출발 (D-1)', rows: d1 },
+    { key: 'upcoming', title: '다가오는 일정', rows: upcoming },
+  ].filter((section) => section.rows.length > 0)
+}
+
+export function GuestUpcomingTripsPage() {
+  const navigate = useNavigate()
+  const [rows, setRows] = useState([])
+  const [names, setNames] = useState({})
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [paymentIdByRequest, setPaymentIdByRequest] = useState(() => ({}))
+
+  const reload = useCallback(async () => {
+    const [all, paysRaw] = await Promise.all([
+      fetchGuestMatchRequests(apiRequest),
+      fetchGuestPayments(apiRequest).catch(() => []),
+    ])
+    const pays = Array.isArray(paysRaw) ? paysRaw : []
+    const list = (Array.isArray(all) ? all : [])
+      .filter((r) => UPCOMING.has(String(r.status ?? '')))
+      .sort((a, b) => {
+        const da = String(a.desiredDate ?? '')
+        const db = String(b.desiredDate ?? '')
+        if (da !== db) return da.localeCompare(db)
+        return (a.requestId ?? 0) - (b.requestId ?? 0)
+      })
+
+    setRows(list)
+    const nm = await loadGuideNicknames(apiRequest, list.map((r) => r.guideId))
+    setNames(nm)
+
+    const payMap = {}
+    for (const r of list) {
+      const pid = pickLatestCompletedPaymentIdForRequest(pays, r.requestId)
+      if (pid != null) payMap[r.requestId] = pid
+    }
+    setPaymentIdByRequest(payMap)
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      setLoading(true)
+      setError('')
+      try {
+        await reload()
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : '불러오기 실패')
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [reload])
+
+  const openMatchScreen = useCallback(
+    (row) => {
+      if (!row?.guideId || !row?.requestId) return
+      const st = String(row.status ?? '')
+      if (st === 'PAID' || st === 'IN_PROGRESS') {
+        const qs = new URLSearchParams()
+        qs.set('requestId', String(row.requestId))
+        const pid = paymentIdByRequest[row.requestId]
+        if (pid != null) qs.set('paymentId', String(pid))
+        navigate(`/guides/${row.guideId}/match/complete?${qs.toString()}`)
+        return
+      }
+      navigate(`/guides/${row.guideId}/match`, { state: { requestId: row.requestId } })
+    },
+    [navigate, paymentIdByRequest],
+  )
+
+  const sections = useMemo(() => groupRows(rows), [rows])
+
+  return (
+    <div className="gut-page">
+      <header className="gut-hero">
+        <h1>📆 앞으로의 여행 일정</h1>
+        <p>다가오는 투어를 D-Day 기준으로 빠르게 확인하고, 바로 매칭 상세로 이동할 수 있어요.</p>
+      </header>
+
+      {loading && <PageLoading />}
+      {!loading && error && <PageError message={error} onRetry={() => void reload()} />}
+
+      {!loading && !error && rows.length === 0 && (
+        <PageEmpty title="예정된 여행이 없습니다">진행 중이거나 예정된 매칭이 생기면 여기에 표시됩니다.</PageEmpty>
+      )}
+
+      {!loading && !error && rows.length > 0 && (
+        <div className="gut-sections">
+          {sections.map((section) => (
+            <section key={section.key} className="gut-section">
+              <div className="gut-section-head">
+                <h2>{section.title}</h2>
+                <span>{section.rows.length}건</span>
+              </div>
+
+              <div className="gut-cards">
+                {section.rows.map((row) => {
+                  const d = daysUntil(row.desiredDate)
+                  const nick = names[row.guideId] ?? `가이드 #${row.guideId}`
+                  return (
+                    <article key={row.requestId} className="gut-card">
+                      <div className="gut-meta">
+                        <span className={`gut-dday${d === 0 ? ' is-today' : d === 1 ? ' is-soon' : ''}`}>
+                          {row.status === 'ACCEPTED' ? '결제 필요' : ddayLabel(d, row.status)}
+                        </span>
+                        <h3>{nick}</h3>
+                        <p>{row.destination ?? '로컬 투어'} · {row.desiredDate ?? '—'}</p>
+                        <p>상태: {row.status} · 예산: {row.desiredBudget != null ? `₩${Number(row.desiredBudget).toLocaleString('ko-KR')}` : '—'}</p>
+                      </div>
+                      <button type="button" className="gut-open" onClick={() => openMatchScreen(row)}>
+                        상세 보기
+                      </button>
+                    </article>
+                  )
+                })}
+              </div>
+            </section>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+

--- a/frontend/src/pages/GuideDetailPage.css
+++ b/frontend/src/pages/GuideDetailPage.css
@@ -359,6 +359,12 @@
   color: #9ca3af;
 }
 
+.gdp-match-day.is-reserved {
+  background: #f3f4f6;
+  border-color: #d1d5db;
+  color: #9ca3af;
+}
+
 .gdp-match-day.is-selected {
   background: #2563eb;
   border-color: #2563eb;
@@ -383,17 +389,6 @@
   top: 0.15rem;
   font-size: 0.72rem;
   color: #9ca3af;
-}
-
-.gdp-match-dot {
-  position: absolute;
-  left: 50%;
-  bottom: 0.2rem;
-  width: 4px;
-  height: 4px;
-  margin-left: -2px;
-  border-radius: 999px;
-  background: #2563eb;
 }
 
 .gdp-match-times {
@@ -423,4 +418,117 @@
   margin: 0.55rem 0 0;
   font-size: 0.78rem;
   color: #4b5563;
+}
+
+.gdp-confirm-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 90;
+  background: rgba(2, 6, 23, 0.55);
+  backdrop-filter: blur(2px);
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+}
+
+.gdp-confirm {
+  width: min(100%, 460px);
+  border-radius: 18px;
+  border: 1px solid #e2e8f0;
+  background: linear-gradient(180deg, #ffffff 0%, #f8fbff 100%);
+  box-shadow: 0 24px 50px rgba(15, 23, 42, 0.28);
+  padding: 1.1rem 1.1rem 1rem;
+}
+
+.gdp-confirm-kicker {
+  margin: 0 0 0.35rem;
+  display: inline-block;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #1d4ed8;
+  background: #eff6ff;
+  border: 1px solid #dbeafe;
+  border-radius: 999px;
+  padding: 0.14rem 0.5rem;
+}
+
+.gdp-confirm h3 {
+  margin: 0;
+  font-size: 1.08rem;
+  color: #111827;
+  letter-spacing: -0.01em;
+}
+
+.gdp-confirm-sub {
+  margin: 0.42rem 0 0;
+  color: #475569;
+  font-size: 0.86rem;
+}
+
+.gdp-confirm-list {
+  margin: 1rem 0 0;
+  display: grid;
+  gap: 0.55rem;
+}
+
+.gdp-confirm-list > div {
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 0.62rem 0.75rem;
+  background: #ffffff;
+}
+
+.gdp-confirm-list dt {
+  margin: 0 0 0.22rem;
+  color: #64748b;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.gdp-confirm-list dd {
+  margin: 0;
+  color: #111827;
+  font-size: 0.92rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+}
+
+.gdp-confirm-actions {
+  margin-top: 1.05rem;
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.gdp-confirm-btn {
+  border-radius: 10px;
+  font-size: 0.84rem;
+  font-weight: 600;
+  padding: 0.5rem 0.9rem;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.gdp-confirm-btn--line {
+  border: 1px solid #d1d5db;
+  background: #fff;
+  color: #374151;
+}
+
+.gdp-confirm-btn--line:hover:not(:disabled) {
+  border-color: #94a3b8;
+  color: #0f172a;
+}
+
+.gdp-confirm-btn--solid {
+  border: 1px solid #0f172a;
+  background: linear-gradient(180deg, #1e293b 0%, #0f172a 100%);
+  color: #fff;
+}
+
+.gdp-confirm-btn--solid:hover:not(:disabled) {
+  border-color: #020617;
+  background: linear-gradient(180deg, #111827 0%, #020617 100%);
 }

--- a/frontend/src/pages/GuideDetailPage.jsx
+++ b/frontend/src/pages/GuideDetailPage.jsx
@@ -198,6 +198,7 @@ export function GuideDetailPage() {
   const [concept, setConcept] = useState('')
   const [submitErr, setSubmitErr] = useState('')
   const [submitting, setSubmitting] = useState(false)
+  const [confirmModal, setConfirmModal] = useState(null)
 
   useEffect(() => {
     // AI 검색 결과에서 넘어온 matchRequestDraft는 게스트에게 노출하지 않고, 전송 시에만 활용한다.
@@ -332,6 +333,16 @@ export function GuideDetailPage() {
     return set
   }, [schedules])
 
+  const reservedDateSet = useMemo(() => {
+    const set = new Set()
+    for (const schedule of schedules) {
+      const key = formatScheduleDate(schedule?.availableDate)
+      const status = String(schedule?.status ?? '').toUpperCase()
+      if (key && (status === 'BOOKED' || status === 'PENDING')) set.add(key)
+    }
+    return set
+  }, [schedules])
+
   const availableByDate = useMemo(() => {
     /** @type {Map<string, any[]>} */
     const map = new Map()
@@ -387,60 +398,12 @@ export function GuideDetailPage() {
     return cells
   }, [calendarMonth])
 
-  const onSubmitMatch = async (e) => {
-    e.preventDefault()
-    setSubmitErr('')
-    if (!isAuthenticated) {
-      setSubmitErr('로그인이 필요합니다.')
-      return
-    }
-    if (isGuide) {
-      setSubmitErr('여행자(GUEST) 계정으로 로그인한 뒤 요청해 주세요.')
-      return
-    }
-    if (!selectedDateKey) {
-      setSubmitErr('예약 날짜를 선택해 주세요.')
-      return
-    }
-    if (isPastDateKey(selectedDateKey)) {
-      setSubmitErr('지난 날짜에는 요청할 수 없습니다.')
-      return
-    }
-    if (blockedDateSet.has(selectedDateKey)) {
-      setSubmitErr('해당 날짜는 가이드가 예약을 받지 않습니다. 다른 날짜를 선택해 주세요.')
-      return
-    }
-    const dest = destination.trim()
-    if (!dest) {
-      setSubmitErr('여행 목적지(지역)를 입력해 주세요.')
-      return
-    }
-
-    const sch = selectedScheduleId == null
-      ? null
-      : schedules.find((s) => Number(s.scheduleId) === Number(selectedScheduleId))
-    const desiredDate = selectedDateKey || (sch?.availableDate != null ? formatScheduleDate(sch.availableDate) : undefined)
-
-    const conceptText = concept.trim() || (aiHiddenConcept ? String(aiHiddenConcept).trim() : '')
-
+  const sendMatchRequest = async (payload) => {
     setSubmitting(true)
     try {
       const res = await apiRequest('/matching/requests', {
         method: 'POST',
-        json: {
-          guideId: Number(guideId),
-          scheduleId: selectedScheduleId != null ? Number(selectedScheduleId) : undefined,
-          destination: dest,
-          concept: conceptText || undefined,
-          conceptSummary: aiConceptSummary ? String(aiConceptSummary).trim() : undefined,
-          desiredBudget:
-            aiDesiredBudget != null && !Number.isNaN(Number(aiDesiredBudget)) ? Number(aiDesiredBudget) : undefined,
-          budgetMinWon:
-            aiBudgetMinWon != null && !Number.isNaN(Number(aiBudgetMinWon)) ? Number(aiBudgetMinWon) : undefined,
-          budgetMaxWon:
-            aiBudgetMaxWon != null && !Number.isNaN(Number(aiBudgetMaxWon)) ? Number(aiBudgetMaxWon) : undefined,
-          desiredDate: desiredDate || undefined,
-        },
+        json: payload,
       })
       const t = await res.text()
       if (res.status === 401 || res.status === 403) {
@@ -469,6 +432,67 @@ export function GuideDetailPage() {
     } finally {
       setSubmitting(false)
     }
+  }
+
+  const onSubmitMatch = async (e) => {
+    e.preventDefault()
+    if (submitting) return
+    setSubmitErr('')
+    if (!isAuthenticated) {
+      setSubmitErr('로그인이 필요합니다.')
+      return
+    }
+    if (isGuide) {
+      setSubmitErr('여행자(GUEST) 계정으로 로그인한 뒤 요청해 주세요.')
+      return
+    }
+    if (!selectedDateKey) {
+      setSubmitErr('예약 날짜를 선택해 주세요.')
+      return
+    }
+    if (isPastDateKey(selectedDateKey)) {
+      setSubmitErr('지난 날짜에는 요청할 수 없습니다.')
+      return
+    }
+    if (blockedDateSet.has(selectedDateKey)) {
+      setSubmitErr('해당 날짜는 가이드가 예약을 받지 않습니다. 다른 날짜를 선택해 주세요.')
+      return
+    }
+    if (reservedDateSet.has(selectedDateKey)) {
+      setSubmitErr('해당 날짜는 이미 예약이 잡혀 요청할 수 없습니다. 다른 날짜를 선택해 주세요.')
+      return
+    }
+    const dest = destination.trim()
+    if (!dest) {
+      setSubmitErr('여행 목적지(지역)를 입력해 주세요.')
+      return
+    }
+
+    const sch = selectedScheduleId == null
+      ? null
+      : schedules.find((s) => Number(s.scheduleId) === Number(selectedScheduleId))
+    const desiredDate = selectedDateKey || (sch?.availableDate != null ? formatScheduleDate(sch.availableDate) : undefined)
+    const conceptText = concept.trim() || (aiHiddenConcept ? String(aiHiddenConcept).trim() : '')
+
+    setConfirmModal({
+      destination: dest,
+      desiredDate: desiredDate || '',
+      concept: conceptText,
+      payload: {
+        guideId: Number(guideId),
+        scheduleId: selectedScheduleId != null ? Number(selectedScheduleId) : undefined,
+        destination: dest,
+        concept: conceptText || undefined,
+        conceptSummary: aiConceptSummary ? String(aiConceptSummary).trim() : undefined,
+        desiredBudget:
+          aiDesiredBudget != null && !Number.isNaN(Number(aiDesiredBudget)) ? Number(aiDesiredBudget) : undefined,
+        budgetMinWon:
+          aiBudgetMinWon != null && !Number.isNaN(Number(aiBudgetMinWon)) ? Number(aiBudgetMinWon) : undefined,
+        budgetMaxWon:
+          aiBudgetMaxWon != null && !Number.isNaN(Number(aiBudgetMaxWon)) ? Number(aiBudgetMaxWon) : undefined,
+        desiredDate: desiredDate || undefined,
+      },
+    })
   }
 
   if (loading) {
@@ -721,14 +745,15 @@ export function GuideDetailPage() {
                     const inMonth = cell.inMonth
                     const isPast = isPastDateKey(key)
                     const isBlocked = blockedDateSet.has(key)
+                    const isReserved = reservedDateSet.has(key)
                     const hasSchedule = availableByDate.has(key)
-                    const selectable = inMonth && !isPast && !isBlocked
+                    const selectable = inMonth && !isPast && !isBlocked && !isReserved
                     const selected = selectable && key === selectedDateKey
                     return (
                       <button
                         key={cell.key}
                         type="button"
-                        className={`gdp-match-day${!inMonth ? ' is-out' : ''}${isPast ? ' is-past' : ''}${selectable ? ' is-on' : ''}${isBlocked ? ' is-blocked' : ''}${selected ? ' is-selected' : ''}`}
+                        className={`gdp-match-day${!inMonth ? ' is-out' : ''}${isPast ? ' is-past' : ''}${selectable ? ' is-on' : ''}${isBlocked ? ' is-blocked' : ''}${isReserved ? ' is-reserved' : ''}${selected ? ' is-selected' : ''}`}
                         disabled={!selectable}
                         onClick={() => {
                           setSelectedDateKey(key)
@@ -739,12 +764,12 @@ export function GuideDetailPage() {
                       >
                         {cell.date.getDate()}
                         {isBlocked && <span className="gdp-match-x">×</span>}
-                        {hasSchedule && <span className="gdp-match-dot" />}
+                        {isReserved && <span className="gdp-match-x">×</span>}
                       </button>
                     )
                   })}
                 </div>
-                <p className="gdp-match-cal-hint">지난 날짜는 선택할 수 없어요. 기본은 예약 가능이며, 가이드가 막은 날짜만 선택할 수 없습니다.</p>
+                <p className="gdp-match-cal-hint">지난 날짜와 예약된 날짜는 선택할 수 없어요. 기본은 예약 가능이며, 가이드가 막은 날짜도 비활성화됩니다.</p>
 
                 {selectedDateSchedules.length > 0 ? (
                   <div className="gdp-match-times" role="radiogroup" aria-label="시간 선택">
@@ -791,7 +816,7 @@ export function GuideDetailPage() {
             <div>
               <button
                 type="submit"
-                disabled={submitting || !selectedDateKey || blockedDateSet.has(selectedDateKey)}
+                disabled={submitting || !selectedDateKey || blockedDateSet.has(selectedDateKey) || reservedDateSet.has(selectedDateKey)}
                 style={{
                   padding: '0.6rem 1.2rem',
                   borderRadius: 8,
@@ -807,6 +832,66 @@ export function GuideDetailPage() {
           </form>
         )}
       </section>
+
+      {confirmModal && (
+        <div
+          className="gdp-confirm-overlay"
+          role="dialog"
+          aria-modal="true"
+          aria-label="매칭 요청 확인"
+          onClick={(e) => {
+            if (e.target === e.currentTarget && !submitting) setConfirmModal(null)
+          }}
+        >
+          <div className="gdp-confirm">
+            <p className="gdp-confirm-kicker">Final Check</p>
+            <h3>{p.nickname} 가이드에게 매칭 요청을 보낼까요?</h3>
+            <p className="gdp-confirm-sub">아래 정보가 그대로 전달됩니다. 맞으면 전송해 주세요.</p>
+            <dl className="gdp-confirm-list">
+              <div>
+                <dt>목적지</dt>
+                <dd>{confirmModal.destination}</dd>
+              </div>
+              <div>
+                <dt>날짜</dt>
+                <dd>{confirmModal.desiredDate || '미정'}</dd>
+              </div>
+              <div>
+                <dt>하고 싶은 일</dt>
+                <dd>{confirmModal.concept || '입력 없음'}</dd>
+              </div>
+              {confirmModal.payload?.desiredBudget != null && (
+                <div>
+                  <dt>예산</dt>
+                  <dd>{Number(confirmModal.payload.desiredBudget).toLocaleString('ko-KR')}원</dd>
+                </div>
+              )}
+            </dl>
+            <div className="gdp-confirm-actions">
+              <button
+                type="button"
+                className="gdp-confirm-btn gdp-confirm-btn--line"
+                onClick={() => setConfirmModal(null)}
+                disabled={submitting}
+              >
+                수정할게요
+              </button>
+              <button
+                type="button"
+                className="gdp-confirm-btn gdp-confirm-btn--solid"
+                disabled={submitting}
+                onClick={() => {
+                  const payload = confirmModal.payload
+                  setConfirmModal(null)
+                  void sendMatchRequest(payload)
+                }}
+              >
+                {submitting ? '전송 중…' : '요청 전송'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/GuideFeedSchedulePage.jsx
+++ b/frontend/src/pages/GuideFeedSchedulePage.jsx
@@ -448,23 +448,6 @@ export function GuideFeedSchedulePage() {
 
   return (
     <div className="g-panel">
-      <h1>💼 피드 및 스케줄 관리</h1>
-      <div className="gfs-tabs" role="tablist" aria-label="피드·스케줄 탭">
-        <button
-          type="button"
-          className={`gfs-tab ${currentTab === 'feed' ? 'is-on' : ''}`}
-          onClick={() => setSearchParams({ tab: 'feed' })}
-        >
-          피드 등록
-        </button>
-        <button
-          type="button"
-          className={`gfs-tab ${currentTab === 'schedule' ? 'is-on' : ''}`}
-          onClick={() => setSearchParams({ tab: 'schedule' })}
-        >
-          스케줄 관리
-        </button>
-      </div>
       {loadError && <p className="g-error">{loadError}</p>}
       <Toast toasts={toasts} />
       {currentTab === 'feed' ? (

--- a/frontend/src/pages/GuideMypagePages.css
+++ b/frontend/src/pages/GuideMypagePages.css
@@ -1112,11 +1112,12 @@
   font-size: clamp(1.2rem, 3vw, 1.7rem);
   font-weight: 900;
   letter-spacing: -0.03em;
+  color: #111;
 }
 
 .gpv-head p {
   margin: 0;
-  color: #6b7280;
+  color: #111;
   font-size: 0.86rem;
 }
 
@@ -1147,7 +1148,48 @@
   border-radius: 10px;
   padding: 0.35rem 0.75rem;
   font-size: 0.74rem;
-  color: #4b5563;
+  color: #111;
+  white-space: nowrap;
+  font-weight: 700;
+}
+
+.gpv-region-row {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.gpv-region-row input {
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.gpv-region-btn {
+  flex: 0 0 auto;
+  min-width: 88px;
+  border-color: #93c5fd;
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+
+.gpv-region-btn:hover:not(:disabled) {
+  background: #dbeafe;
+  border-color: #60a5fa;
+}
+
+.gpv-region-btn:disabled {
+  opacity: 0.65;
+}
+
+.gpv-region-hint {
+  margin-top: 0.35rem;
+  display: inline-block;
+  padding: 0.28rem 0.55rem;
+  border-radius: 999px;
+  background: #eff6ff;
+  border: 1px solid #bfdbfe;
+  color: #1e3a8a;
+  font-size: 0.74rem;
 }
 
 .gpv-photo-input {
@@ -1166,7 +1208,7 @@
 
 .gpv-photo-url-box summary {
   font-size: 0.72rem;
-  color: #9ca3af;
+  color: #111;
   cursor: pointer;
   list-style: none;
 }
@@ -1201,7 +1243,88 @@
   padding: 0.6rem 0.7rem;
   font: inherit;
   font-size: 0.86rem;
+  color: #111;
   box-sizing: border-box;
+}
+
+.gpv-field input::placeholder,
+.gpv-photo-input::placeholder {
+  color: #111;
+  opacity: 0.75;
+}
+
+/* intro/schedule text contrast boost */
+.gi-card-title,
+.gi-range-val,
+.gi-chip,
+.gi-tag,
+.gi-tag-input,
+.gi-custom-input,
+.gi-card p,
+.gi-card label,
+.gi-card small {
+  color: #111;
+}
+
+.gi-tag-input::placeholder,
+.gi-custom-input::placeholder {
+  color: #111;
+  opacity: 0.75;
+}
+
+.gss-head h2,
+.gss-head p,
+.gss-banner,
+.gss-banner strong,
+.gss-cal-top strong,
+.gss-week span,
+.gss-legend,
+.gss-day,
+.gss-day small,
+.gss3-sum-label,
+.gss3-cal-title,
+.gss3-weekday,
+.gss3-cal-hint,
+.gss3-leg,
+.gss3-empty,
+.gss3-mgmt-title,
+.gss3-drawer-date,
+.gss3-drawer-desc,
+.gss3-pick__label,
+.gss3-pick__hint,
+.gss3-dk,
+.gss3-dv,
+.gss3-bcard-dest,
+.gss3-bcard-meta {
+  color: #111;
+}
+
+/* intro card hard override (ensure no white text) */
+.gi-card,
+.gi-card label,
+.gi-card p,
+.gi-card .gm-hint,
+.gi-card .gi-card-title,
+.gi-card .gi-range-val,
+.gi-card .gi-chip,
+.gi-card .gi-tag,
+.gi-card .gi-tag-del,
+.gi-card input,
+.gi-card select,
+.gi-card textarea {
+  color: #111 !important;
+}
+
+.gi-card input::placeholder,
+.gi-card textarea::placeholder {
+  color: #111 !important;
+  opacity: 0.75;
+}
+
+.gi-card .gi-chip.is-on {
+  background: #1f2328;
+  border-color: #1f2328;
+  color: #fff !important;
 }
 
 .gpv-tag-list {

--- a/frontend/src/pages/GuideProfileEditPage.jsx
+++ b/frontend/src/pages/GuideProfileEditPage.jsx
@@ -7,6 +7,8 @@ import { buildGuidePutBody } from '../lib/guideProfilePayload.js'
 import '../layouts/GuideDashboardLayout.css'
 import './GuideMypagePages.css'
 
+const KAKAO_APP_KEY = import.meta.env.VITE_KAKAO_MAP_APP_KEY
+
 function useToast() {
   const [toasts, setToasts] = useState([])
   const addToast = useCallback((message, type = 'success') => {
@@ -39,6 +41,52 @@ async function readJsonError(res, text) {
   }
 }
 
+function loadKakaoSdk(appKey) {
+  if (!appKey) return Promise.reject(new Error('카카오맵 앱 키가 없습니다.'))
+  if (window.kakao?.maps?.services) return Promise.resolve(window.kakao)
+  return new Promise((resolve, reject) => {
+    const existing = document.getElementById('kakao-map-sdk')
+    if (existing) {
+      existing.addEventListener('load', () => window.kakao.maps.load(() => resolve(window.kakao)))
+      existing.addEventListener('error', () => reject(new Error('카카오맵 SDK 로드 실패')))
+      return
+    }
+    const script = document.createElement('script')
+    script.id = 'kakao-map-sdk'
+    script.async = true
+    script.src = `https://dapi.kakao.com/v2/maps/sdk.js?appkey=${appKey}&autoload=false&libraries=services`
+    script.onload = () => window.kakao.maps.load(() => resolve(window.kakao))
+    script.onerror = () => reject(new Error('카카오맵 SDK 로드 실패'))
+    document.head.appendChild(script)
+  })
+}
+
+function detectRegionByCurrentLocation(kakao) {
+  return new Promise((resolve, reject) => {
+    if (!navigator.geolocation) {
+      reject(new Error('브라우저 위치 기능을 지원하지 않습니다.'))
+      return
+    }
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        const geocoder = new kakao.maps.services.Geocoder()
+        geocoder.coord2RegionCode(position.coords.longitude, position.coords.latitude, (result, status) => {
+          if (status !== kakao.maps.services.Status.OK || !Array.isArray(result) || result.length === 0) {
+            reject(new Error('현재 위치에서 지역 정보를 찾지 못했습니다.'))
+            return
+          }
+          const hRegion = result.find((r) => r.region_type === 'H') ?? result[0]
+          const city = String(hRegion?.region_2depth_name ?? '').trim()
+          const province = String(hRegion?.region_1depth_name ?? '').trim()
+          resolve(city || [province, String(hRegion?.region_2depth_name ?? '').trim()].filter(Boolean).join(' '))
+        })
+      },
+      () => reject(new Error('위치 권한이 없어 현재 위치를 가져올 수 없습니다.')),
+      { enableHighAccuracy: true, timeout: 10000 },
+    )
+  })
+}
+
 export function GuideProfileEditPage() {
   const { guideId, loading: idLoading, error: idError } = useResolvedGuideId()
   const [profile, setProfile] = useState(null)
@@ -46,9 +94,11 @@ export function GuideProfileEditPage() {
   const { toasts, addToast } = useToast()
   const photoInputRef = useRef(null)
   const [previewUrl, setPreviewUrl] = useState(null)
+  const [pendingUploadFile, setPendingUploadFile] = useState(null)
   const [imageDeleted, setImageDeleted] = useState(false)
   const [loadError, setLoadError] = useState('')
   const [saving, setSaving] = useState(false)
+  const [resolvingRegion, setResolvingRegion] = useState(false)
 
   const load = useCallback(async (id) => {
     setLoadError('')
@@ -68,6 +118,14 @@ export function GuideProfileEditPage() {
     if (!guideId) return
     void load(guideId)
   }, [guideId, load])
+
+  useEffect(() => {
+    return () => {
+      if (previewUrl && previewUrl.startsWith('blob:')) {
+        URL.revokeObjectURL(previewUrl)
+      }
+    }
+  }, [previewUrl])
 
   const setField = (key, value) => {
     setProfile((p) => (p ? { ...p, [key]: value } : p))
@@ -112,10 +170,33 @@ export function GuideProfileEditPage() {
         setSaving(false)
         return
       }
+      if (pendingUploadFile && !imageDeleted) {
+        const formData = new FormData()
+        formData.append('file', pendingUploadFile)
+        formData.append('folder', 'guide-profile')
+        const uploadRes = await apiRequest('/files/upload', { method: 'POST', body: formData })
+        const uploadText = await uploadRes.text()
+        if (!uploadRes.ok) {
+          addToast(await readJsonError(uploadRes, uploadText), 'error')
+          setSaving(false)
+          return
+        }
+        let uploadedUrl = ''
+        try {
+          const json = uploadText ? JSON.parse(uploadText) : {}
+          uploadedUrl = String(json?.url ?? '').trim()
+        } catch {
+          uploadedUrl = ''
+        }
+        if (!uploadedUrl) {
+          addToast('이미지 업로드 URL을 받지 못했습니다.', 'error')
+          setSaving(false)
+          return
+        }
+        body.profileImage = uploadedUrl
+      }
       if (imageDeleted) {
         body.profileImage = null
-      } else if (previewUrl) {
-        body.profileImage = profile.profileImage ?? undefined
       }
       const res = await apiRequest(`/guides/${guideId}`, { method: 'PUT', json: body })
       const text = await res.text()
@@ -123,8 +204,15 @@ export function GuideProfileEditPage() {
         addToast(await readJsonError(res, text), 'error')
         return
       }
+      const updated = text ? JSON.parse(text) : profile
+      setProfile(updated)
+      if (previewUrl && previewUrl.startsWith('blob:')) {
+        URL.revokeObjectURL(previewUrl)
+      }
+      setPreviewUrl(null)
+      setPendingUploadFile(null)
+      setImageDeleted(false)
       addToast('저장되었습니다.')
-      window.location.reload()
     } catch {
       addToast('네트워크 오류', 'error')
     } finally {
@@ -190,8 +278,19 @@ export function GuideProfileEditPage() {
             onChange={(e) => {
               const file = e.target.files?.[0]
               if (!file) return
-              setPreviewUrl(URL.createObjectURL(file))
-              setImageDeleted(false)
+              void (async () => {
+                try {
+                  const objectUrl = URL.createObjectURL(file)
+                  if (previewUrl && previewUrl.startsWith('blob:')) {
+                    URL.revokeObjectURL(previewUrl)
+                  }
+                  setPreviewUrl(objectUrl)
+                  setPendingUploadFile(file)
+                  setImageDeleted(false)
+                } catch {
+                  addToast('이미지 파일 처리에 실패했습니다.', 'error')
+                }
+              })()
               e.target.value = ''
             }}
           />
@@ -199,8 +298,12 @@ export function GuideProfileEditPage() {
             type="button"
             className="gpv-photo-btn"
             onClick={() => {
+              if (previewUrl && previewUrl.startsWith('blob:')) {
+                URL.revokeObjectURL(previewUrl)
+              }
               setImageDeleted(true)
               setPreviewUrl(null)
+              setPendingUploadFile(null)
               if (photoInputRef.current) photoInputRef.current.value = ''
             }}
           >
@@ -215,6 +318,7 @@ export function GuideProfileEditPage() {
               onChange={(e) => {
                 setField('profileImage', e.target.value)
                 setPreviewUrl(null)
+                setPendingUploadFile(null)
                 setImageDeleted(false)
               }}
               placeholder="https://image-url"
@@ -231,17 +335,41 @@ export function GuideProfileEditPage() {
 
         <div className="gpv-field">
           <label htmlFor="gp-region">주 활동 지역</label>
-          <select id="gp-region" value={profile.region ?? ''} onChange={(e) => setField('region', e.target.value)}>
-            {profile.region && !['제주특별자치도 제주시', '제주특별자치도 서귀포시', '부산광역시', '강원특별자치도 강릉시', '전라남도 여수시'].includes(profile.region) && (
-              <option value={profile.region}>{profile.region}</option>
-            )}
-            <option value="">지역 선택</option>
-            <option value="제주특별자치도 제주시">제주특별자치도 제주시</option>
-            <option value="제주특별자치도 서귀포시">제주특별자치도 서귀포시</option>
-            <option value="부산광역시">부산광역시</option>
-            <option value="강원특별자치도 강릉시">강원특별자치도 강릉시</option>
-            <option value="전라남도 여수시">전라남도 여수시</option>
-          </select>
+          <div className="gpv-region-row">
+            <input
+              id="gp-region"
+              value={profile.region ?? ''}
+              onChange={(e) => setField('region', e.target.value)}
+              placeholder="예: 구미시"
+            />
+            <button
+              type="button"
+              className="gpv-photo-btn gpv-region-btn"
+              disabled={resolvingRegion}
+              onClick={() => {
+                void (async () => {
+                  setResolvingRegion(true)
+                  try {
+                    const kakao = await loadKakaoSdk(KAKAO_APP_KEY)
+                    const city = await detectRegionByCurrentLocation(kakao)
+                    if (!city) {
+                      addToast('현재 위치 지역을 찾지 못했습니다. 직접 입력해 주세요.', 'error')
+                      return
+                    }
+                    setField('region', city)
+                    addToast(`현재 위치 지역(${city})으로 입력했습니다.`)
+                  } catch (e) {
+                    addToast(e instanceof Error ? e.message : '현재 위치 지역 입력에 실패했습니다.', 'error')
+                  } finally {
+                    setResolvingRegion(false)
+                  }
+                })()
+              }}
+            >
+              {resolvingRegion ? '위치 확인 중…' : '현재 위치'}
+            </button>
+          </div>
+          <p className="gm-hint gpv-region-hint">📍 버튼을 누르면 현재 위치 기준 지역이 자동으로 입력됩니다.</p>
         </div>
 
         <div className="gpv-field">

--- a/frontend/src/pages/GuideSettingsPage.jsx
+++ b/frontend/src/pages/GuideSettingsPage.jsx
@@ -40,6 +40,17 @@ async function readJsonError(res, text) {
   }
 }
 
+const HOURS = 8
+const LS_PUSH = 'guide_pref_push_notif'
+const LS_EMAIL = 'guide_pref_email_notif'
+
+function loadBool(key, fallback) {
+  const v = localStorage.getItem(key)
+  if (v === '1') return true
+  if (v === '0') return false
+  return fallback
+}
+
 export function GuideSettingsPage() {
   const { guideId, loading: idLoading, error: idError } = useResolvedGuideId()
   const navigate = useNavigate()
@@ -49,6 +60,10 @@ export function GuideSettingsPage() {
   const [loadError, setLoadError] = useState('')
   const [busy, setBusy] = useState(false)
   const [withdrawing, setWithdrawing] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [pushOn, setPushOn] = useState(() => loadBool(LS_PUSH, true))
+  const [emailOn, setEmailOn] = useState(() => loadBool(LS_EMAIL, false))
+  const [packageWon, setPackageWon] = useState('')
 
   const load = useCallback(async (id) => {
     setLoadError('')
@@ -67,6 +82,9 @@ export function GuideSettingsPage() {
       }
       setProfile(pt ? JSON.parse(pt) : null)
       setSummary(st ? JSON.parse(st) : null)
+      const loadedProfile = pt ? JSON.parse(pt) : null
+      const hourly = loadedProfile?.pricePerHour != null ? Number(loadedProfile.pricePerHour) : 0
+      setPackageWon(hourly > 0 ? String(Math.round(hourly * HOURS)) : '')
     } catch (e) {
       setLoadError(e instanceof Error ? e.message : '불러오기 실패')
     }
@@ -114,6 +132,51 @@ export function GuideSettingsPage() {
     }
   }
 
+  const savePrefs = () => {
+    localStorage.setItem(LS_PUSH, pushOn ? '1' : '0')
+    localStorage.setItem(LS_EMAIL, emailOn ? '1' : '0')
+  }
+
+  const handleSaveFees = async () => {
+    if (!guideId || !profile) return
+    setSaving(true)
+    savePrefs()
+    try {
+      const pkg = Number(packageWon.replace(/[^\d]/g, ''))
+      if (!Number.isFinite(pkg) || pkg <= 0) {
+        addToast('종일 패키지 금액을 올바르게 입력해 주세요.', 'error')
+        return
+      }
+      const hourly = Math.max(1, Math.round(pkg / HOURS))
+      const body = {
+        nickname: profile.nickname,
+        profileImage: profile.profileImage ?? undefined,
+        bio: profile.bio ?? undefined,
+        region: profile.region,
+        language: profile.language,
+        pricePerHour: hourly,
+        isActive: profile?.isActive ?? true,
+        residenceYears: profile.residenceYears ?? undefined,
+        localStory: profile.localStory ?? undefined,
+        keywords: profile.keywords ?? undefined,
+        defaultCourse: profile.defaultCourse ?? undefined,
+        guideStyle: profile.guideStyle ?? undefined,
+      }
+      const res = await apiRequest(`/guides/${guideId}`, { method: 'PUT', json: body })
+      const text = await res.text()
+      if (!res.ok) {
+        addToast(await readJsonError(res, text), 'error')
+        return
+      }
+      setProfile(text ? JSON.parse(text) : profile)
+      addToast('비용/알림 설정이 저장되었습니다.')
+    } catch {
+      addToast('네트워크 오류가 발생했습니다.', 'error')
+    } finally {
+      setSaving(false)
+    }
+  }
+
   if (idLoading) {
     return (
         <div className="g-panel">
@@ -141,12 +204,49 @@ export function GuideSettingsPage() {
   return (
       <div className="g-panel">
         <h1>🔧 가이드 설정</h1>
-        <p className="g-hint">
-          노출·요금은 <Link to="/guide/mypage/fees">가이드 비용</Link>, 프로필 필드는{' '}
-          <Link to="/guide/mypage/profile">프로필 등록</Link>에서 수정합니다. 여기서는 서버에 있는 토글·승인·리뷰 요약만
-          다룹니다.
-        </p>
+        <p className="g-hint">가이드 운영에 필요한 노출/비용/알림/리뷰/계정 설정을 한 곳에서 관리합니다.</p>
         <div className="gm-stack" style={{ marginTop: '1rem', maxWidth: '32rem' }}>
+
+          <section className="gm-card">
+            <h2>가이드 비용 및 알림</h2>
+            <p className="gm-hint">종일 패키지 금액(8시간 기준)과 로컬 알림 옵션을 함께 저장합니다.</p>
+            <div className="g-row">
+              <div>
+                <strong>새로운 예약 요청 알림 (Push)</strong>
+                <p>푸시 알림 API 연동 전 — 이 기기에만 저장됩니다.</p>
+              </div>
+              <label className="g-toggle">
+                <input type="checkbox" checked={pushOn} onChange={(e) => setPushOn(e.target.checked)} />
+                <span className="g-toggle-ui" />
+              </label>
+            </div>
+            <div className="g-row">
+              <div>
+                <strong>메시지 수신 알림 (Email)</strong>
+                <p>이메일 알림 API 연동 전 — 이 기기에만 저장됩니다.</p>
+              </div>
+              <label className="g-toggle">
+                <input type="checkbox" checked={emailOn} onChange={(e) => setEmailOn(e.target.checked)} />
+                <span className="g-toggle-ui" />
+              </label>
+            </div>
+            <div className="g-price-row" style={{ marginTop: '0.85rem' }}>
+              <label htmlFor="pkg-won">종일 패키지</label>
+              <input
+                id="pkg-won"
+                inputMode="numeric"
+                value={packageWon}
+                onChange={(e) => setPackageWon(e.target.value.replace(/[^\d]/g, ''))}
+                placeholder="140000"
+              />
+              <span style={{ fontWeight: 600, color: '#374151' }}>원</span>
+            </div>
+            <div className="g-save-row" style={{ marginTop: '0.9rem' }}>
+              <button type="button" className="g-save" onClick={() => void handleSaveFees()} disabled={saving}>
+                {saving ? '저장 중…' : '비용/알림 저장'}
+              </button>
+            </div>
+          </section>
 
           {/* 활성화 섹션 */}
           <section className="gm-card">
@@ -213,6 +313,9 @@ export function GuideSettingsPage() {
             <p className="gm-hint" style={{ marginTop: '0.5rem' }}>
               승인 API는 관리자용 <code>PATCH /guides/&#123;id&#125;/approve</code> 입니다. 일반 가이드 계정에서는 호출하지
               않습니다.
+            </p>
+            <p className="gm-hint" style={{ marginTop: '0.5rem' }}>
+              프로필 텍스트/이미지는 <Link to="/guide/mypage/profile">프로필 등록</Link>에서 수정할 수 있습니다.
             </p>
           </section>
 

--- a/frontend/src/routes/guideRoutes.jsx
+++ b/frontend/src/routes/guideRoutes.jsx
@@ -5,7 +5,6 @@ import { GuideDashboardLayout } from '../layouts/GuideDashboardLayout'
 import { GuideApplyPage } from '../pages/GuideApplyPage'
 import { GuideCourseEditorPage } from '../pages/GuideCourseEditorPage'
 import { GuideFeedSchedulePage } from '../pages/GuideFeedSchedulePage'
-import { GuideFeesPage } from '../pages/GuideFeesPage'
 import { GuideInboxPage } from '../pages/GuideInboxPage'
 import { GuideIntroEditPage } from '../pages/GuideIntroEditPage'
 import { GuideProfileEditPage } from '../pages/GuideProfileEditPage'
@@ -63,8 +62,8 @@ export const guideRoutes = [
       </ProtectedRoute>
     ),
     children: [
-      { index: true, element: <Navigate to="fees" replace /> },
-      { path: 'fees', element: <GuideFeesPage /> },
+      { index: true, element: <Navigate to="profile" replace /> },
+      { path: 'fees', element: <Navigate to="../settings" replace /> },
       { path: 'settlement', element: <GuideSettlementPage /> },
       {
         path: 'profile',

--- a/frontend/src/routes/mypageRoutes.jsx
+++ b/frontend/src/routes/mypageRoutes.jsx
@@ -2,6 +2,7 @@ import { Navigate } from 'react-router-dom'
 
 import { ProtectedRoute } from '../components/ProtectedRoute'
 import { MypageShell } from '../layouts/MypageShell'
+import { GuestUpcomingTripsPage } from '../pages/GuestUpcomingTripsPage'
 import { MypageItineraryPage } from '../pages/MypageItineraryPage'
 import { MypagePaymentsPage } from '../pages/MypagePaymentsPage'
 import { MypagePrivacyPage } from '../pages/MypagePrivacyPage'
@@ -11,6 +12,14 @@ import { MypageScrapbookPage } from '../pages/MypageScrapbookPage'
 import { MypageTourPage } from '../pages/MypageTourPage'
 
 export const mypageRoutes = [
+  {
+    path: 'upcoming-trips',
+    element: (
+      <ProtectedRoute>
+        <GuestUpcomingTripsPage />
+      </ProtectedRoute>
+    ),
+  },
   {
     path: 'mypage',
     element: (


### PR DESCRIPTION
# 🔗 이슈 번호
- Closes #349 

---


## 💡 주요 변경 사항
- 게스트 매칭 요청 UX
  - `GuideDetailPage`에 `Final Check` 확인 모달 추가
  - 전송 로직을 `sendMatchRequest(payload)`로 분리하여 확인 후 전송만 허용
  - 오버레이 클릭 닫기/최종 전송 버튼 UX 적용
- 일정 처리 안정화
  - 스케줄 없는 날짜 요청 시 자동 슬롯 생성
  - 동일 트랜잭션에서 `PENDING` 반영하여 타이밍 이슈 방지
  - `BLOCKED / PENDING / BOOKED` 상태 검증 유지
- 게스트 캘린더 UX
  - 예약 불가 날짜 클릭 비활성화(`isBlocked`, `isReserved`, `disabled={!selectable}`)
  - 선택 날짜 시간 슬롯 `startTime ~ endTime` 표기 유지
- 가이드 프로필 위치 입력
  - `현재 위치` 버튼 기반 지역 자동 입력 로직 유지
  - `loadKakaoSdk`, `detectRegionByCurrentLocation`, `navigator.geolocation` 흐름 검증
  -   -   - 
## ⚠️ 주의 사항 / 질문
- Kakao SDK 키/브라우저 위치 권한 허용 여부에 따라 현재 위치 입력 결과가 달라질 수 있습니다.
- 스케줄 자동 생성/상태 전이는 서비스 레이어 정책에 의존하므로, 가이드 스케줄 상태 데이터 정합성 확인이 필요합니다.
- - 
## ✅ 체크리스트
- [x] 빌드가 정상적으로 되는가? (`./gradlew :module-domain:compileJava`)
- [x] 핵심 시나리오 수동 테스트를 수행했는가? (확인 모달, 불가 날짜 비활성화, 자동 슬롯 생성, 현재 위치 입력)
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [x] 민감정보/환경설정 파일이 PR에 포함되지 않았는가?