### PR TITLE
Feat/fe#351 가이드 예산 범위 표시 + AI 검색 예시 멘트

### DIFF
--- a/frontend/src/pages/AiQuickSearchPage.jsx
+++ b/frontend/src/pages/AiQuickSearchPage.jsx
@@ -5,7 +5,12 @@ import { apiRequest } from '../api/client'
 
 import './AiQuickSearchPage.css'
 
-const PLACEHOLDER = '제주도에서 조용히 사진 찍기 좋은 오름 추천해줘'
+const PLACEHOLDER =
+  '예시) 제주 2박3일 · 2명(커플) / 예산 하루 10~15만원(총 30~45만원)\n' +
+  '- 맛집 투어 + 야경 좋은 곳 위주로 가고 싶어요\n' +
+  '- 걷는 코스는 적게(부모님 동행) / 술집은 빼고\n' +
+  '- 이동은 렌트카, 오전 10시~저녁 9시 선호\n' +
+  '- 한국어 가능 가이드면 좋아요'
 const LS_AI_SEARCH_SNAPSHOT = 'localguest_ai_search_snapshot_v1'
 const LS_AI_MATCH_DRAFT = 'localguest_ai_match_draft_v1'
 const AI_GUIDE_DEFAULT_SHOW = 3

--- a/frontend/src/pages/GuideInboxPage.jsx
+++ b/frontend/src/pages/GuideInboxPage.jsx
@@ -42,6 +42,17 @@ function formatScheduleTime(t) {
   return String(t)
 }
 
+function formatBudgetRange(minWon, maxWon) {
+  const min = minWon != null && minWon !== '' && !Number.isNaN(Number(minWon)) ? Number(minWon) : null
+  const max = maxWon != null && maxWon !== '' && !Number.isNaN(Number(maxWon)) ? Number(maxWon) : null
+  if (min == null && max == null) return null
+  if (min != null && max != null) {
+    return `₩${min.toLocaleString('ko-KR')}~${max.toLocaleString('ko-KR')}`
+  }
+  const only = min ?? max
+  return `₩${Number(only).toLocaleString('ko-KR')}`
+}
+
 function formatBudget(value) {
   return value ? `₩${Number(value).toLocaleString('ko-KR')}` : '—'
 }
@@ -271,7 +282,7 @@ export function GuideInboxPage() {
                         <td>{`게스트 #${r.guestId}`}</td>
                         <td>{r.destination ?? '—'}</td>
                         <td>{r.desiredDate ?? '—'}</td>
-                        <td>{formatBudget(r.desiredBudget)}</td>
+                        <td>{formatBudgetRange(r.budgetMinWon, r.budgetMaxWon) ?? formatBudget(r.desiredBudget)}</td>
                         <td className="inbox-actions">
                           {r.status === 'PENDING' && (
                             <>
@@ -309,7 +320,9 @@ export function GuideInboxPage() {
                     <p className="inbox-card-line">👤 <strong>게스트</strong> {`게스트 #${r.guestId}`}</p>
                     <p className="inbox-card-line">📍 <strong>목적지</strong> {r.destination ?? '—'}</p>
                     <p className="inbox-card-line">📅 <strong>희망일</strong> {r.desiredDate ?? '—'}</p>
-                    <p className="inbox-card-line">💰 <strong>예산</strong> {formatBudget(r.desiredBudget)}</p>
+                    <p className="inbox-card-line">
+                      💰 <strong>예산</strong> {formatBudgetRange(r.budgetMinWon, r.budgetMaxWon) ?? formatBudget(r.desiredBudget)}
+                    </p>
                     {r.conceptSummary && (
                       <p className="inbox-card-line">🗺️ <strong>여행 컨셉</strong> {r.conceptSummary}</p>
                     )}


### PR DESCRIPTION
## 🔗 이슈 번호

- Closes #351

## 💡 주요 변경 사항

- **가이드 매칭 요청 목록(GuideInboxPage)**
  - `budgetMinWon/budgetMaxWon`이 있으면 예산을 **범위로 우선 표시**
  - 범위가 없으면 기존 `desiredBudget` 표시
- **AI 검색(AiQuickSearchPage)**
  - placeholder(예시 멘트)를 가이드가 계획 짜기 좋게(기간/인원/예산/제약/언어 등 포함) 개선

## ✅ 체크리스트

- [x] `npm run build` (frontend)

Made with [Cursor](https://cursor.com)