### PR TITLE
Fix/be#355 PR#354로 누락된 예산/요약 연동 복구

### DIFF
--- a/backend/module-ai/src/main/java/com/team6/module/ai/dto/response/GuideRecommendResponse.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/dto/response/GuideRecommendResponse.java
@@ -79,6 +79,12 @@ public class GuideRecommendResponse {
         private String concept;
         @Schema(description = "가이드에게 보여줄 요약 문장")
         private String conceptSummary;
+        @Schema(description = "희망 예산(원). 프롬프트 예산 범위가 있으면 평균값으로 채운다(선택)")
+        private Integer desiredBudget;
+        @Schema(description = "희망 예산 하한(원). 프롬프트 예산 범위가 있으면 채운다(선택)")
+        private Integer budgetMinWon;
+        @Schema(description = "희망 예산 상한(원). 프롬프트 예산 범위가 있으면 채운다(선택)")
+        private Integer budgetMaxWon;
         @Schema(description = "예산 힌트(낮음/중간/높음)")
         private String budgetHint;
         private Integer headcount;

--- a/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
@@ -367,10 +367,20 @@ public class PromptRecommendationService {
     private static GuideRecommendResponse.MatchRequestDraft matchRequestDraftFrom(GuideRecommendRequest request) {
         // AI 추천 응답을 바로 매칭 요청 생성 화면으로 연결하기 위한 초안 데이터다.
         // matching 모듈을 직접 호출하는 건 아니고, 프론트가 이 draft를 읽어 요청 폼 기본값으로 쓴다.
+        Integer desiredBudget = null;
+        Integer min = request.getBudgetMinWon();
+        Integer max = request.getBudgetMaxWon();
+        if (min != null && max != null && min >= 0 && max >= 0) {
+            long sum = (long) min + (long) max;
+            desiredBudget = (int) Math.round(sum / 2.0d);
+        }
         return GuideRecommendResponse.MatchRequestDraft.builder()
                 .destination(request.getRegion())
                 .concept(ConceptSummaryGenerator.generateMatchRequestConcept(request))
                 .conceptSummary(ConceptSummaryGenerator.generate(request))
+                .desiredBudget(desiredBudget)
+                .budgetMinWon(min)
+                .budgetMaxWon(max)
                 .budgetHint(request.getBudgetLevel())
                 .headcount(request.getHeadcount())
                 .durationDays(request.getDurationDays())

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/dto/request/MatchRequestCreateRequest.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/dto/request/MatchRequestCreateRequest.java
@@ -45,4 +45,10 @@ public class MatchRequestCreateRequest {
     private LocalDate desiredDate;
 
     private Integer desiredBudget;
+
+    /**
+     * 희망 예산 범위(원). 프롬프트/입력에서 범위를 받는 경우 그대로 저장한다(선택).
+     */
+    private Integer budgetMinWon;
+    private Integer budgetMaxWon;
 }

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/dto/response/MatchRequestCreateResponse.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/dto/response/MatchRequestCreateResponse.java
@@ -23,6 +23,8 @@ public class MatchRequestCreateResponse {
     private String conceptSummary;
     private LocalDate desiredDate;
     private Integer desiredBudget;
+    private Integer budgetMinWon;
+    private Integer budgetMaxWon;
     private String proposedSchedule;
     private String proposeMessage;
     private String status;
@@ -44,6 +46,8 @@ public class MatchRequestCreateResponse {
                 .conceptSummary(entity.getConceptSummary())
                 .desiredDate(entity.getDesiredDate())
                 .desiredBudget(entity.getDesiredBudget())
+                .budgetMinWon(entity.getBudgetMinWon())
+                .budgetMaxWon(entity.getBudgetMaxWon())
                 .proposedSchedule(entity.getProposedSchedule())
                 .proposeMessage(entity.getProposeMessage())
                 .status(entity.getStatus().name())

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/entity/MatchRequest.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/entity/MatchRequest.java
@@ -61,6 +61,22 @@ public class MatchRequest extends BaseTimeEntity {
     @Column(name = "desired_budget")
     private Integer desiredBudget;      // 희망 예산(원)
 
+    /**
+     * 희망 예산 범위(원). 가이드가 “N~M원” 형태로 더 디테일하게 계획을 잡을 수 있도록 보존한다.
+     *
+     * DDL 적용 방법: Flyway/Liquibase 마이그레이션 또는 DBA가 직접 아래 DDL 실행
+     * <pre>
+     * ALTER TABLE match_request
+     *   ADD COLUMN budget_min_won INT NULL AFTER desired_budget,
+     *   ADD COLUMN budget_max_won INT NULL AFTER budget_min_won;
+     * </pre>
+     */
+    @Column(name = "budget_min_won")
+    private Integer budgetMinWon;
+
+    @Column(name = "budget_max_won")
+    private Integer budgetMaxWon;
+
     @Column(name = "proposed_schedule", columnDefinition = "TEXT")
     private String proposedSchedule;    // 가이드 제시 일정(간략)
 
@@ -93,7 +109,9 @@ public class MatchRequest extends BaseTimeEntity {
             String concept,
             String conceptSummary,
             LocalDate desiredDate,
-            Integer desiredBudget
+            Integer desiredBudget,
+            Integer budgetMinWon,
+            Integer budgetMaxWon
     ) {
         return MatchRequest.builder()
                 .guestId(guestId)
@@ -104,6 +122,8 @@ public class MatchRequest extends BaseTimeEntity {
                 .conceptSummary(conceptSummary)
                 .desiredDate(desiredDate)
                 .desiredBudget(desiredBudget)
+                .budgetMinWon(budgetMinWon)
+                .budgetMaxWon(budgetMaxWon)
                 .build();
     }
 

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/service/MatchRequestService.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/service/MatchRequestService.java
@@ -53,7 +53,9 @@ public class MatchRequestService {
                 request.getConcept(),
                 conceptSummary,
                 request.getDesiredDate(),
-                request.getDesiredBudget()
+                request.getDesiredBudget(),
+                request.getBudgetMinWon(),
+                request.getBudgetMaxWon()
         );
 
         MatchRequest saved = matchRequestRepository.save(matchRequest);

--- a/backend/module-domain/src/test/java/com/team6/domain/matching/service/MatchRequestServiceTest.java
+++ b/backend/module-domain/src/test/java/com/team6/domain/matching/service/MatchRequestServiceTest.java
@@ -97,6 +97,8 @@ class MatchRequestServiceTest {
         setField(request, "concept", "food");
         setField(request, "desiredDate", LocalDate.of(2026, 4, 20));
         setField(request, "desiredBudget", 50000);
+        setField(request, "budgetMinWon", 40000);
+        setField(request, "budgetMaxWon", 60000);
         return request;
     }
 


### PR DESCRIPTION
## 🔗 이슈 번호

- Closes #355

## 💡 주요 변경 사항

- **AI(module-ai)**: `GuideRecommendResponse.matchRequestDraft`에
  - `desiredBudget`
  - `budgetMinWon`, `budgetMaxWon`
  을 다시 포함
- **매칭(module-domain)**: `MatchRequest`에 `budget_min_won`, `budget_max_won` 복구 및
  - 생성/조회 DTO에 범위 예산 필드 포함

## ⚠️ 주의 사항

- DB 마이그레이션 툴이 없으므로, 엔티티에 남긴 DDL을 공용 DB에 반영해야 `ddl-auto: validate`가 유지됩니다.

## ✅ 체크리스트

- [x] `./gradlew :module-ai:test`
- [x] `./gradlew :api-server:compileJava`
- [x] `./gradlew :module-domain:test --tests com.team6.domain.matching.service.MatchRequestServiceTest`

Made with [Cursor](https://cursor.com)