### PR TITLE
Fix/fe PR#354 이후 예산 범위/AI draft 전달 복구

### DIFF
--- a/frontend/src/pages/AiQuickSearchPage.jsx
+++ b/frontend/src/pages/AiQuickSearchPage.jsx
@@ -12,6 +12,7 @@ const PLACEHOLDER =
   '- 이동은 렌트카, 오전 10시~저녁 9시 선호\n' +
   '- 한국어 가능 가이드면 좋아요'
 const LS_AI_SEARCH_SNAPSHOT = 'localguest_ai_search_snapshot_v1'
+const LS_AI_MATCH_DRAFT = 'localguest_ai_match_draft_v1'
 const AI_GUIDE_DEFAULT_SHOW = 3
 const AI_GUIDE_EXPANDED_SHOW = 5
 
@@ -247,6 +248,34 @@ export function AiQuickSearchPage() {
     }
   }, [expandedGuides, fallbackGuides, hasSearched, prompt, result])
 
+  const persistMatchDraftForGuide = useCallback(
+    (guideId) => {
+      try {
+        const draft = result?.matchRequestDraft ?? null
+        if (!draft || !guideId) return
+        sessionStorage.setItem(
+          LS_AI_MATCH_DRAFT,
+          JSON.stringify({
+            guideId: String(guideId),
+            savedAt: Date.now(),
+            matchRequestDraft: draft,
+          }),
+        )
+      } catch {
+        /* ignore */
+      }
+    },
+    [result],
+  )
+
+  const onClickGuideDetail = useCallback(
+    (guideId) => {
+      persistMatchDraftForGuide(guideId)
+      persistSnapshotForBack()
+    },
+    [persistMatchDraftForGuide, persistSnapshotForBack],
+  )
+
   useEffect(() => {
     const recs = result?.recommendations
     if (!Array.isArray(recs) || recs.length === 0) {
@@ -480,7 +509,7 @@ export function AiQuickSearchPage() {
                                     to={`/guides/${g.guideId}#match-request`}
                                     className="ais-feed-thumb"
                                     title={f.content ? String(f.content).slice(0, 80) : '가이드 상세보기'}
-                                    onClick={persistSnapshotForBack}
+                                    onClick={() => onClickGuideDetail(g.guideId)}
                                   >
                                     <span
                                       className="ais-feed-thumb-img"
@@ -494,7 +523,7 @@ export function AiQuickSearchPage() {
                                   to={`/guides/${g.guideId}#match-request`}
                                   className="ais-feed-empty"
                                   title="가이드 상세보기"
-                                  onClick={persistSnapshotForBack}
+                                  onClick={() => onClickGuideDetail(g.guideId)}
                                 >
                                   <span
                                     className="ais-feed-thumb-img"
@@ -527,7 +556,7 @@ export function AiQuickSearchPage() {
                               <Link
                                 to={`/guides/${g.guideId}#match-request`}
                                 className="ais-profile-btn ais-profile-btn--primary"
-                                onClick={persistSnapshotForBack}
+                                onClick={() => onClickGuideDetail(g.guideId)}
                               >
                                 가이드 상세보기
                               </Link>

--- a/frontend/src/pages/GuestUpcomingTripsPage.jsx
+++ b/frontend/src/pages/GuestUpcomingTripsPage.jsx
@@ -15,6 +15,22 @@ import './GuestUpcomingTripsPage.css'
 
 const UPCOMING = new Set(['PENDING', 'ACCEPTED', 'PAID', 'IN_PROGRESS'])
 
+function formatBudgetRangeKrw(minWon, maxWon, fallbackSingleWon) {
+  const min = minWon != null && minWon !== '' && !Number.isNaN(Number(minWon)) ? Number(minWon) : null
+  const max = maxWon != null && maxWon !== '' && !Number.isNaN(Number(maxWon)) ? Number(maxWon) : null
+  if (min != null && max != null) {
+    return `₩${min.toLocaleString('ko-KR')}~${max.toLocaleString('ko-KR')}`
+  }
+  if (min != null || max != null) {
+    const only = min ?? max
+    return `₩${Number(only).toLocaleString('ko-KR')}`
+  }
+  if (fallbackSingleWon != null && fallbackSingleWon !== '' && !Number.isNaN(Number(fallbackSingleWon))) {
+    return `₩${Number(fallbackSingleWon).toLocaleString('ko-KR')}`
+  }
+  return '—'
+}
+
 function ddayLabel(days, status) {
   if (status === 'IN_PROGRESS') return '진행중'
   if (days == null) return '일정 미정'
@@ -158,7 +174,9 @@ export function GuestUpcomingTripsPage() {
                         </span>
                         <h3>{nick}</h3>
                         <p>{row.destination ?? '로컬 투어'} · {row.desiredDate ?? '—'}</p>
-                        <p>상태: {row.status} · 예산: {row.desiredBudget != null ? `₩${Number(row.desiredBudget).toLocaleString('ko-KR')}` : '—'}</p>
+                        <p>
+                          상태: {row.status} · 예산: {formatBudgetRangeKrw(row.budgetMinWon, row.budgetMaxWon, row.desiredBudget)}
+                        </p>
                       </div>
                       <button type="button" className="gut-open" onClick={() => openMatchScreen(row)}>
                         상세 보기

--- a/frontend/src/pages/MypageItineraryPage.jsx
+++ b/frontend/src/pages/MypageItineraryPage.jsx
@@ -17,6 +17,22 @@ import './MypageMemberPages.css'
 
 const UPCOMING = new Set(['PENDING', 'ACCEPTED', 'PAID', 'IN_PROGRESS'])
 
+function formatBudgetRangeKrw(minWon, maxWon, fallbackSingleWon) {
+  const min = minWon != null && minWon !== '' && !Number.isNaN(Number(minWon)) ? Number(minWon) : null
+  const max = maxWon != null && maxWon !== '' && !Number.isNaN(Number(maxWon)) ? Number(maxWon) : null
+  if (min != null && max != null) {
+    return `₩${min.toLocaleString('ko-KR')}~${max.toLocaleString('ko-KR')}`
+  }
+  if (min != null || max != null) {
+    const only = min ?? max
+    return `₩${Number(only).toLocaleString('ko-KR')}`
+  }
+  if (fallbackSingleWon != null && fallbackSingleWon !== '' && !Number.isNaN(Number(fallbackSingleWon))) {
+    return `₩${Number(fallbackSingleWon).toLocaleString('ko-KR')}`
+  }
+  return '—'
+}
+
 export function MypageItineraryPage() {
   const navigate = useNavigate()
   const [rows, setRows] = useState([])
@@ -181,7 +197,9 @@ export function MypageItineraryPage() {
                     {r.desiredDate ?? '—'} | 제시: {r.proposedSchedule ?? '—'}
                   </p>
                   <p className="mp-trip-detail">상태: {r.status}</p>
-                  <p className="mp-trip-detail">예산: {r.desiredBudget != null ? `₩${Number(r.desiredBudget).toLocaleString()}` : '—'}</p>
+                  <p className="mp-trip-detail">
+                    예산: {formatBudgetRangeKrw(r.budgetMinWon, r.budgetMaxWon, r.desiredBudget)}
+                  </p>
                 </div>
                 <div className="mp-trip-actions">
                   <button type="button" className="mp-thumb mp-thumb--match" style={{ minHeight: '4.5rem' }} onClick={() => openMatchScreen(r)}>


### PR DESCRIPTION
## 💡 주요 변경 사항

- **PR #354에서 빠진 연동 복구**
  - AI 검색(AiQuickSearchPage) → 가이드 상세로 이동 시 `matchRequestDraft`를 sessionStorage(`localguest_ai_match_draft_v1`)에 저장
  - 가이드 상세(GuideDetailPage)가 예산/요약을 매칭 요청 생성에 포함하도록 다시 연결
- **예산 표시 통일(범위 우선)**
  - 게스트 일정 화면(GuestUpcomingTripsPage, MypageItineraryPage)에서도 `budgetMinWon/budgetMaxWon`이 있으면 범위로 우선 표시

## ✅ 체크리스트

- [x] `npm run build` (frontend)

Made with [Cursor](https://cursor.com)