### PR TITLE
Feat/fe: 프론트엔드 전역 UX·UI 리디자인 및 사용자 플로우 개선

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,27 +5,54 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="84d1b3de-8103-452e-83cf-38ecd34993e7" name="Changes" comment="">
-      <change afterPath="$PROJECT_DIR$/frontend/src/pages/GuestUpcomingTripsPage.css" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/frontend/src/pages/GuestUpcomingTripsPage.jsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/backend/api-server/src/main/resources/application.yml" beforeDir="false" afterPath="$PROJECT_DIR$/backend/api-server/src/main/resources/application.yml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/backend/module-ai/src/main/java/com/team6/module/ai/parser/PromptParser.java" beforeDir="false" afterPath="$PROJECT_DIR$/backend/module-ai/src/main/java/com/team6/module/ai/parser/PromptParser.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/backend/module-ai/src/test/java/com/team6/module/ai/parser/PromptParserTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/backend/module-ai/src/test/java/com/team6/module/ai/parser/PromptParserTest.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/backend/module-domain/src/main/java/com/team6/domain/matching/service/MatchRequestService.java" beforeDir="false" afterPath="$PROJECT_DIR$/backend/module-domain/src/main/java/com/team6/domain/matching/service/MatchRequestService.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/api/client.js" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/api/client.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/backend/module-domain/src/main/java/com/team6/domain/matching/controller/TourExtensionController.java" beforeDir="false" afterPath="$PROJECT_DIR$/backend/module-domain/src/main/java/com/team6/domain/matching/controller/TourExtensionController.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/backend/module-domain/src/main/java/com/team6/domain/matching/entity/TourExtension.java" beforeDir="false" afterPath="$PROJECT_DIR$/backend/module-domain/src/main/java/com/team6/domain/matching/entity/TourExtension.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/backend/module-domain/src/main/java/com/team6/domain/matching/exception/MatchingErrorCode.java" beforeDir="false" afterPath="$PROJECT_DIR$/backend/module-domain/src/main/java/com/team6/domain/matching/exception/MatchingErrorCode.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/backend/module-domain/src/main/java/com/team6/domain/matching/service/PaymentService.java" beforeDir="false" afterPath="$PROJECT_DIR$/backend/module-domain/src/main/java/com/team6/domain/matching/service/PaymentService.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/backend/module-domain/src/main/java/com/team6/domain/matching/service/TourExtensionService.java" beforeDir="false" afterPath="$PROJECT_DIR$/backend/module-domain/src/main/java/com/team6/domain/matching/service/TourExtensionService.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/package-lock.json" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/package-lock.json" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/components/SiteFooter.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/components/SiteFooter.css" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/index.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/index.css" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/layouts/AppLayout.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/layouts/AppLayout.css" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/frontend/src/layouts/AppLayout.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/layouts/AppLayout.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/layouts/DashboardLayout.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/layouts/DashboardLayout.css" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/frontend/src/layouts/DashboardLayout.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/layouts/DashboardLayout.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/layouts/GuideDashboardLayout.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/layouts/GuideDashboardLayout.css" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/frontend/src/layouts/GuideDashboardLayout.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/layouts/GuideDashboardLayout.jsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/layouts/MypageShell.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/layouts/MypageShell.jsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideCourseEditorPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideCourseEditorPage.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/lib/guestMypagePrefs.js" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/lib/guestMypagePrefs.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/AiQuickSearchPage.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/AiQuickSearchPage.css" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/AiQuickSearchPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/AiQuickSearchPage.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/FormPage.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/FormPage.css" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuestUpcomingTripsPage.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuestUpcomingTripsPage.css" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuestUpcomingTripsPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuestUpcomingTripsPage.jsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideDetailPage.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideDetailPage.css" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideDetailPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideDetailPage.jsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideFeedSchedulePage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideFeedSchedulePage.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideFeedTourPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideFeedTourPage.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideInboxPage.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideInboxPage.css" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideInboxPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideInboxPage.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideMatchOptionsPage.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideMatchOptionsPage.css" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideMatchOptionsPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideMatchOptionsPage.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideMatchedCoursePage.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideMatchedCoursePage.css" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideMatchedCoursePage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideMatchedCoursePage.jsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideMypagePages.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideMypagePages.css" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideProfileEditPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideProfileEditPage.jsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideSettingsPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideSettingsPage.jsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/routes/guideRoutes.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/routes/guideRoutes.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideProposalPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideProposalPage.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideReviewsManagePage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideReviewsManagePage.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/HomePage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/HomePage.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/LoginPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/LoginPage.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/MypageMemberPages.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/MypageMemberPages.css" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/MypagePrivacyPage.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/MypagePrivacyPage.css" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/MypagePrivacyPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/MypagePrivacyPage.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/MypageProfilePage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/MypageProfilePage.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/MypageReviewsPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/MypageReviewsPage.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/MypageScrapbookPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/MypageScrapbookPage.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/MypageTourPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/MypageTourPage.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/OnboardingPage.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/OnboardingPage.css" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/PaymentKakaoStubPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/PaymentKakaoStubPage.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/SignupPage.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/SignupPage.css" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/SignupPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/SignupPage.jsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/frontend/src/routes/mypageRoutes.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/routes/mypageRoutes.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/package-lock.json" beforeDir="false" afterPath="$PROJECT_DIR$/package-lock.json" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -170,6 +197,8 @@
       <workItem from="1776641819519" duration="2328000" />
       <workItem from="1776694933190" duration="1647000" />
       <workItem from="1776729193782" duration="3364000" />
+      <workItem from="1776770760643" duration="62000" />
+      <workItem from="1776780245318" duration="3710000" />
     </task>
     <servers />
   </component>

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/controller/TourExtensionController.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/controller/TourExtensionController.java
@@ -2,6 +2,8 @@ package com.team6.domain.matching.controller;
 
 import com.team6.domain.matching.dto.request.TourExtensionSelectRequest;
 import com.team6.domain.matching.dto.response.TourExtensionResponseDto;
+import com.team6.domain.matching.exception.MatchingErrorCode;
+import com.team6.domain.matching.exception.MatchingException;
 import com.team6.domain.matching.service.TourExtensionService;
 import com.team6.domain.matching.support.MatchingAuthenticationSupport;
 import jakarta.validation.Valid;
@@ -27,7 +29,36 @@ public class TourExtensionController {
             @PathVariable Long requestId
     ) {
         Long actorId = matchingAuthenticationSupport.resolveTourExtensionActorId();
-        return ResponseEntity.ok(tourExtensionService.getByRequestId(requestId, actorId));
+        try {
+            return ResponseEntity.ok(tourExtensionService.getByRequestId(requestId, actorId));
+        } catch (MatchingException e) {
+            if (e.getErrorCode() == MatchingErrorCode.TOUR_EXTENSION_GUIDE_NEXT_DAY_BOOKED) {
+                return ResponseEntity.noContent()
+                        .header("X-Extension-Reason", "GUIDE_NEXT_DAY_BOOKED")
+                        .build();
+            }
+            if (e.getErrorCode() == MatchingErrorCode.TOUR_EXTENSION_GUIDE_NEXT_DAY_BLOCKED) {
+                return ResponseEntity.noContent()
+                        .header("X-Extension-Reason", "GUIDE_NEXT_DAY_BLOCKED")
+                        .build();
+            }
+            if (e.getErrorCode() == MatchingErrorCode.TOUR_EXTENSION_GUIDE_UNAVAILABLE_NEXT_DAY) {
+                return ResponseEntity.noContent()
+                        .header("X-Extension-Reason", "GUIDE_NEXT_DAY_UNAVAILABLE")
+                        .build();
+            }
+            if (e.getErrorCode() == MatchingErrorCode.TOUR_EXTENSION_ALREADY_DECIDED) {
+                return ResponseEntity.noContent()
+                        .header("X-Extension-Reason", "ALREADY_DECIDED")
+                        .build();
+            }
+            if (e.getErrorCode() == MatchingErrorCode.TOUR_EXTENSION_NOT_FOUND) {
+                // 연장 대상이 아닌 경우(정상 시나리오)는 404 대신 204로 응답해
+                // 클라이언트에서 "오류"로 보이지 않도록 한다.
+                return ResponseEntity.noContent().build();
+            }
+            throw e;
+        }
     }
 
     // 게스트 전용 연장 선택 API

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/entity/TourExtension.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/entity/TourExtension.java
@@ -86,7 +86,8 @@ public class TourExtension extends BaseTimeEntity {
 
     // 연장 결제 완료
     public void completePayByGuestSelection() {
-        if (this.status != TourExtensionStatus.REQUESTED) {
+        if (this.status != TourExtensionStatus.REQUESTED
+                && this.status != TourExtensionStatus.GUIDE_APPROVED) {
             throw new MatchingException(MatchingErrorCode.MATCH_REQUEST_INVALID_STATUS);
         }
         this.status = TourExtensionStatus.PAID;

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/exception/MatchingErrorCode.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/exception/MatchingErrorCode.java
@@ -30,6 +30,10 @@ public enum MatchingErrorCode {
 
     // TourExtension 관련
     TOUR_EXTENSION_NOT_FOUND(404, "연장 신청을 찾을 수 없습니다"),
+    TOUR_EXTENSION_GUIDE_UNAVAILABLE_NEXT_DAY(400, "가이드가 다음날 예약이 있어 연장이 불가합니다"),
+    TOUR_EXTENSION_GUIDE_NEXT_DAY_BOOKED(400, "가이드가 다음날 예약되어 있어 연장이 불가합니다"),
+    TOUR_EXTENSION_GUIDE_NEXT_DAY_BLOCKED(400, "가이드가 다음날 예약 불가로 설정되어 연장이 불가합니다"),
+    TOUR_EXTENSION_ALREADY_DECIDED(400, "이미 연장 여부가 확정된 투어입니다"),
     TOUR_EXTENSION_DEADLINE_EXCEEDED(400, "연장 선택 기한이 지났습니다"),
     TOUR_EXTENSION_ALREADY_REQUESTED(400, "이미 연장 신청된 투어입니다"),
     TOUR_EXTENSION_CANNOT_APPROVE(400, "현재 상태에서는 승인할 수 없습니다"),

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/service/PaymentService.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/service/PaymentService.java
@@ -14,11 +14,13 @@ import com.team6.domain.matching.entity.Refund;
 import com.team6.domain.matching.entity.enums.MatchRequestStatus;
 import com.team6.domain.matching.entity.enums.PaymentStatus;
 import com.team6.domain.matching.entity.enums.RefundType;
+import com.team6.domain.matching.entity.enums.TourExtensionStatus;
 import com.team6.domain.matching.exception.MatchingErrorCode;
 import com.team6.domain.matching.exception.MatchingException;
 import com.team6.domain.matching.repository.MatchRequestRepository;
 import com.team6.domain.matching.repository.PaymentRepository;
 import com.team6.domain.matching.repository.RefundRepository;
+import com.team6.domain.matching.repository.TourExtensionRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -42,6 +44,7 @@ public class PaymentService {
     private final FakePgClient fakePgClient;
     private final KakaoPayClient kakaoPayClient;
     private final GuideScheduleSyncClient guideScheduleSyncClient;
+    private final TourExtensionRepository tourExtensionRepository;
 
     @Value("${matching.payment.provider:fake}")
     private String paymentProvider;
@@ -58,7 +61,10 @@ public class PaymentService {
         if (!matchRequest.getGuestId().equals(guestId)) {
             throw new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED);
         }
-        if (matchRequest.getStatus() != MatchRequestStatus.PENDING
+
+        if (isExtensionPayment(request.getPaymentType())) {
+            validateExtensionPaymentRequest(matchRequest, request);
+        } else if (matchRequest.getStatus() != MatchRequestStatus.PENDING
                 && matchRequest.getStatus() != MatchRequestStatus.ACCEPTED) {
             throw new MatchingException(MatchingErrorCode.MATCH_REQUEST_INVALID_STATUS);
         }
@@ -163,6 +169,7 @@ public class PaymentService {
 
         payment.complete(pgTransactionId);
         payment.getMatchRequest().markAsPaidIfAcceptedOrPending();
+        completeExtensionIfNeeded(payment);
         syncGuideSchedulePaidSafely(payment);
 
         log.info("[Payment] Stub PG 승인 완료 — paymentId={}, pgTransactionId={}, paidAt={}, refundDeadline={}",
@@ -242,6 +249,38 @@ public class PaymentService {
 
     private boolean isKakaoProvider() {
         return "kakao".equalsIgnoreCase(paymentProvider);
+    }
+
+    private boolean isExtensionPayment(String paymentType) {
+        return "EXTENSION".equalsIgnoreCase(paymentType);
+    }
+
+    private void validateExtensionPaymentRequest(MatchRequest matchRequest, PaymentCreateRequest request) {
+        if (matchRequest.getStatus() != MatchRequestStatus.ACCEPTED
+                && matchRequest.getStatus() != MatchRequestStatus.PAID
+                && matchRequest.getStatus() != MatchRequestStatus.IN_PROGRESS
+                && matchRequest.getStatus() != MatchRequestStatus.COMPLETED) {
+            throw new MatchingException(MatchingErrorCode.MATCH_REQUEST_INVALID_STATUS);
+        }
+        var extension = tourExtensionRepository.findByMatchRequest_Id(matchRequest.getId())
+                .orElseThrow(() -> new MatchingException(MatchingErrorCode.TOUR_EXTENSION_NOT_FOUND));
+        if (extension.getStatus() != TourExtensionStatus.GUIDE_APPROVED) {
+            throw new MatchingException(MatchingErrorCode.MATCH_REQUEST_INVALID_STATUS);
+        }
+        if (extension.getExtendedPrice() == null || !extension.getExtendedPrice().equals(request.getAmount())) {
+            throw new MatchingException(MatchingErrorCode.PAYMENT_AMOUNT_MISMATCH);
+        }
+    }
+
+    private void completeExtensionIfNeeded(Payment payment) {
+        if (!isExtensionPayment(payment.getPaymentType())) {
+            return;
+        }
+        var extension = tourExtensionRepository.findByMatchRequest_Id(payment.getMatchRequest().getId())
+                .orElseThrow(() -> new MatchingException(MatchingErrorCode.TOUR_EXTENSION_NOT_FOUND));
+        extension.completePayByGuestSelection();
+        log.info("[F05-03] 연장 결제 완료 반영 — requestId={}, paymentId={}, extensionId={}",
+                payment.getMatchRequest().getId(), payment.getId(), extension.getId());
     }
 
     /**

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/service/TourExtensionService.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/service/TourExtensionService.java
@@ -1,14 +1,21 @@
 package com.team6.domain.matching.service;
 
+import com.team6.domain.guide.entity.GuideProfile;
+import com.team6.domain.guide.entity.GuideSchedule;
+import com.team6.domain.guide.entity.enums.GuideScheduleStatus;
+import com.team6.domain.guide.repository.GuideProfileRepository;
+import com.team6.domain.guide.repository.GuideScheduleRepository;
 import com.team6.domain.matching.dto.request.TourExtensionSelectRequest;
 import com.team6.domain.matching.dto.response.TourExtensionResponseDto;
 import com.team6.domain.matching.entity.MatchRequest;
 import com.team6.domain.matching.entity.TourExtension;
 import com.team6.domain.matching.entity.enums.MatchRequestStatus;
+import com.team6.domain.matching.entity.enums.PaymentStatus;
 import com.team6.domain.matching.entity.enums.TourExtensionStatus;
 import com.team6.domain.matching.exception.MatchingErrorCode;
 import com.team6.domain.matching.exception.MatchingException;
 import com.team6.domain.matching.repository.MatchRequestRepository;
+import com.team6.domain.matching.repository.PaymentRepository;
 import com.team6.domain.matching.repository.TourExtensionRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,8 +23,11 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 
 @Slf4j
@@ -25,22 +35,61 @@ import java.util.List;
 @RequiredArgsConstructor
 @Transactional
 public class TourExtensionService {
+    private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
+    private static final int DAY_PACKAGE_HOURS = 8;
 
     private final TourExtensionRepository tourExtensionRepository;
     private final MatchRequestRepository matchRequestRepository;
+    private final GuideScheduleRepository guideScheduleRepository;
+    private final GuideProfileRepository guideProfileRepository;
+    private final PaymentRepository paymentRepository;
 
-    @Transactional(readOnly = true)
     public TourExtensionResponseDto getByRequestId(Long requestId, Long memberId) {
-        TourExtension extension = tourExtensionRepository.findByMatchRequest_Id(requestId)
-                .orElseThrow(() -> new MatchingException(MatchingErrorCode.TOUR_EXTENSION_NOT_FOUND));
-
-        boolean isGuest = extension.getGuestId().equals(memberId);
-        boolean isGuide = extension.getMatchRequest().getGuideId().equals(memberId);
+        MatchRequest matchRequest = matchRequestRepository.findById(requestId)
+                .orElseThrow(() -> new MatchingException(MatchingErrorCode.MATCH_REQUEST_NOT_FOUND));
+        boolean isGuest = matchRequest.getGuestId().equals(memberId);
+        boolean isGuide = matchRequest.getGuideId().equals(memberId);
         if (!isGuest && !isGuide) {
             throw new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED);
         }
+        TourExtension extension = tourExtensionRepository.findByMatchRequest_Id(requestId)
+                .orElseGet(() -> createOnDemandTodayExtension(matchRequest));
+        sanitizeLegacyOrUnavailableExtension(extension, matchRequest);
 
         return TourExtensionResponseDto.from(extension);
+    }
+
+    private TourExtension createOnDemandTodayExtension(MatchRequest matchRequest) {
+        LocalDateTime now = nowSeoul();
+        LocalDate today = now.toLocalDate();
+        List<MatchRequestStatus> targetStatuses = List.of(
+                MatchRequestStatus.ACCEPTED,
+                MatchRequestStatus.PAID,
+                MatchRequestStatus.IN_PROGRESS,
+                MatchRequestStatus.COMPLETED
+        );
+        boolean inOpenWindow = now.getHour() >= 21 && now.getHour() <= 23;
+        if (!inOpenWindow
+                || !today.equals(matchRequest.getDesiredDate())
+                || !targetStatuses.contains(matchRequest.getStatus())) {
+            throw new MatchingException(MatchingErrorCode.TOUR_EXTENSION_NOT_FOUND);
+        }
+        NextDayAvailability nextDayAvailability = getNextDayAvailability(matchRequest);
+        if (nextDayAvailability != NextDayAvailability.EXTENDABLE) {
+            throw new MatchingException(toGuideUnavailableErrorCode(nextDayAvailability));
+        }
+
+        TourExtension extension = TourExtension.builder()
+                .matchRequest(matchRequest)
+                .guestId(matchRequest.getGuestId())
+                .extendedDate(matchRequest.getDesiredDate().plusDays(1))
+                .extendedPrice(resolveDayPackagePrice(matchRequest.getGuideId()))
+                .deadlineAt(today.atTime(23, 59, 59))
+                .build();
+        TourExtension saved = tourExtensionRepository.save(extension);
+        log.info("[F05-03] 온디맨드 연장 선택 오픈 생성 — requestId={}, guestId={}",
+                matchRequest.getId(), matchRequest.getGuestId());
+        return saved;
     }
 
     // 게스트 연장 여부 선택 (F05-03)
@@ -52,15 +101,22 @@ public class TourExtensionService {
             throw new MatchingException(MatchingErrorCode.MATCH_REQUEST_UNAUTHORIZED);
         }
 
-        if (LocalDateTime.now().isAfter(extension.getDeadlineAt())) {
+        if (nowSeoul().isAfter(extension.getDeadlineAt())) {
             throw new MatchingException(MatchingErrorCode.TOUR_EXTENSION_DEADLINE_EXCEEDED);
         }
 
-        // 현재 모델에서 "선택 완료" 상태를 저장하기 위해
-        // 연장 선택(true)은 PAID, 미연장 선택(false)은 REJECTED로 기록한다.
+        // 연장 선택(true): 결제 대기 상태(GUIDE_APPROVED)로 전환한다.
+        // 실제 PAID 전환은 EXTENSION 결제 승인 시 처리한다.
         if (Boolean.TRUE.equals(request.getExtend())) {
-            extension.completePayByGuestSelection();
-            log.info("[F05-03] 게스트 하루 연장 선택 완료 — requestId={}, guestId={}", requestId, guestId);
+            if (extension.getStatus() != TourExtensionStatus.REQUESTED
+                    && extension.getStatus() != TourExtensionStatus.GUIDE_APPROVED) {
+                throw new MatchingException(MatchingErrorCode.MATCH_REQUEST_INVALID_STATUS);
+            }
+            if (!isNextDayExtendable(extension.getMatchRequest())) {
+                throw new MatchingException(MatchingErrorCode.MATCH_REQUEST_INVALID_STATUS);
+            }
+            extension.approveByGuide(resolveDayPackagePrice(extension.getMatchRequest().getGuideId()));
+            log.info("[F05-03] 게스트 하루 연장 선택(결제 대기) — requestId={}, guestId={}", requestId, guestId);
         } else {
             extension.rejectByGuest();
             log.info("[F05-03] 게스트 미연장 선택 완료 — requestId={}, guestId={}", requestId, guestId);
@@ -69,14 +125,20 @@ public class TourExtensionService {
         return TourExtensionResponseDto.from(extension);
     }
 
-    // 당일 21:00 알림 + 선택 오픈 레코드 생성
-    @Scheduled(cron = "0 0 21 * * *", zone = "Asia/Seoul")
-    public void openExtensionSelectionAt2100() {
-        LocalDate today = LocalDate.now();
+    // 당일 21:00~23:59 사이에 연장 선택 오픈 레코드를 보정 생성한다.
+    // (서버 재시작/배포 타이밍으로 21:00 단발 배치가 누락돼도 매분 복구되도록)
+    @Scheduled(cron = "0 * * * * *", zone = "Asia/Seoul")
+    public void openExtensionSelectionWindow() {
+        LocalDateTime now = nowSeoul();
+        if (now.getHour() < 21 || now.getHour() > 23) {
+            return;
+        }
+        LocalDate today = now.toLocalDate();
         List<MatchRequestStatus> targetStatuses = List.of(
                 MatchRequestStatus.ACCEPTED,
                 MatchRequestStatus.PAID,
-                MatchRequestStatus.IN_PROGRESS
+                MatchRequestStatus.IN_PROGRESS,
+                MatchRequestStatus.COMPLETED
         );
 
         List<MatchRequest> targets =
@@ -88,18 +150,31 @@ public class TourExtensionService {
             if (exists) {
                 continue;
             }
+            if (!isNextDayExtendable(matchRequest)) {
+                continue;
+            }
+
+            Integer dayPackagePrice;
+            try {
+                dayPackagePrice = resolveDayPackagePrice(matchRequest.getGuideId());
+            } catch (MatchingException e) {
+                continue;
+            }
 
             TourExtension extension = TourExtension.builder()
                     .matchRequest(matchRequest)
                     .guestId(matchRequest.getGuestId())
                     .extendedDate(matchRequest.getDesiredDate().plusDays(1))
+                    .extendedPrice(dayPackagePrice)
                     .deadlineAt(today.atTime(23, 59, 59))
                     .build();
             tourExtensionRepository.save(extension);
             createdCount++;
         }
 
-        log.info("[F05-03] 당일 21:00 연장 선택 오픈 — targetCount={}, createdCount={}", targets.size(), createdCount);
+        if (createdCount > 0) {
+            log.info("[F05-03] 당일 21:00~23:59 연장 선택 오픈 보정 — targetCount={}, createdCount={}", targets.size(), createdCount);
+        }
     }
 
     // 마감(23:59:59) 후 미선택 자동 미연장 처리
@@ -107,7 +182,7 @@ public class TourExtensionService {
     public void autoCancelUnselectedExtensions() {
         List<TourExtension> expired = tourExtensionRepository.findByStatusAndDeadlineAtBefore(
                 TourExtensionStatus.REQUESTED,
-                LocalDateTime.now()
+                nowSeoul()
         );
 
         for (TourExtension extension : expired) {
@@ -117,5 +192,80 @@ public class TourExtensionService {
         if (!expired.isEmpty()) {
             log.info("[F05-03] 연장 미선택 자동 미연장 처리 — count={}", expired.size());
         }
+    }
+
+    private LocalDateTime nowSeoul() {
+        return LocalDateTime.now(SEOUL_ZONE);
+    }
+
+    private boolean isNextDayExtendable(MatchRequest matchRequest) {
+        return getNextDayAvailability(matchRequest) == NextDayAvailability.EXTENDABLE;
+    }
+
+    private NextDayAvailability getNextDayAvailability(MatchRequest matchRequest) {
+        LocalDate nextDay = matchRequest.getDesiredDate().plusDays(1);
+        List<GuideSchedule> nextDaySchedules =
+                guideScheduleRepository.findByGuideProfile_IdAndAvailableDate(matchRequest.getGuideId(), nextDay);
+        boolean hasBlocked = nextDaySchedules.stream()
+                .map(GuideSchedule::getStatus)
+                .anyMatch(status -> status == GuideScheduleStatus.BLOCKED);
+        if (hasBlocked) {
+            return NextDayAvailability.BLOCKED;
+        }
+        boolean hasBooked = nextDaySchedules.stream()
+                .map(GuideSchedule::getStatus)
+                .anyMatch(status -> status == GuideScheduleStatus.PENDING
+                        || status == GuideScheduleStatus.BOOKED);
+        if (hasBooked) {
+            return NextDayAvailability.BOOKED;
+        }
+        return NextDayAvailability.EXTENDABLE;
+    }
+
+    private Integer resolveDayPackagePrice(Long guideProfileId) {
+        GuideProfile profile = guideProfileRepository.findById(guideProfileId)
+                .orElseThrow(() -> new MatchingException(MatchingErrorCode.INVALID_REQUEST));
+        BigDecimal hourly = profile.getPricePerHour();
+        if (hourly == null || hourly.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new MatchingException(MatchingErrorCode.INVALID_REQUEST);
+        }
+        return hourly.multiply(BigDecimal.valueOf(DAY_PACKAGE_HOURS))
+                .setScale(0, RoundingMode.HALF_UP)
+                .intValue();
+    }
+
+    private void sanitizeLegacyOrUnavailableExtension(TourExtension extension, MatchRequest matchRequest) {
+        NextDayAvailability nextDayAvailability = getNextDayAvailability(matchRequest);
+        if ((extension.getStatus() == TourExtensionStatus.REQUESTED || extension.getStatus() == TourExtensionStatus.GUIDE_APPROVED)
+                && nextDayAvailability != NextDayAvailability.EXTENDABLE) {
+            extension.autoCancel();
+            throw new MatchingException(toGuideUnavailableErrorCode(nextDayAvailability));
+        }
+
+        // 과거 로직 잔재: 결제 없이 상태만 PAID가 된 레코드 정리
+        if (extension.getStatus() == TourExtensionStatus.PAID && !hasCompletedExtensionPayment(matchRequest.getId())) {
+            extension.autoCancel();
+            throw new MatchingException(MatchingErrorCode.TOUR_EXTENSION_ALREADY_DECIDED);
+        }
+    }
+
+    private boolean hasCompletedExtensionPayment(Long requestId) {
+        return paymentRepository.findByMatchRequest_IdAndPaymentType(requestId, "EXTENSION")
+                .map(payment -> payment.getStatus() == PaymentStatus.COMPLETED)
+                .orElse(false);
+    }
+
+    private MatchingErrorCode toGuideUnavailableErrorCode(NextDayAvailability availability) {
+        return switch (availability) {
+            case BLOCKED -> MatchingErrorCode.TOUR_EXTENSION_GUIDE_NEXT_DAY_BLOCKED;
+            case BOOKED -> MatchingErrorCode.TOUR_EXTENSION_GUIDE_NEXT_DAY_BOOKED;
+            default -> MatchingErrorCode.TOUR_EXTENSION_GUIDE_UNAVAILABLE_NEXT_DAY;
+        };
+    }
+
+    private enum NextDayAvailability {
+        EXTENDABLE,
+        BOOKED,
+        BLOCKED
     }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -57,7 +57,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -267,6 +266,31 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -274,6 +298,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -901,7 +926,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -948,7 +972,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1057,7 +1080,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1260,7 +1282,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2240,7 +2261,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2308,7 +2328,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2318,7 +2337,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -2645,7 +2663,6 @@
       "integrity": "sha512-P1PbweD+2/udplnThz3btF4cf6AgPky7kk23RtHUkJIU5BIxwPprhRGmOAHs6FTI7UiGbTNrgNP6jSYD6JaRnw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -2793,7 +2810,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/components/SiteFooter.css
+++ b/frontend/src/components/SiteFooter.css
@@ -1,12 +1,53 @@
 .site-footer {
+  position: relative;
+  overflow: hidden;
   margin-top: auto;
-  background: #1f2328;
-  color: #e6e8eb;
+  background: transparent;
+  color: #715f73;
   padding: 1.75rem 1.5rem 2rem;
   font-size: 0.875rem;
+  border-top: 1px solid #f0dce4;
+}
+
+.site-footer::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -8px;
+  height: 64px;
+  pointer-events: none;
+  background:
+    radial-gradient(ellipse at 10% 72%, rgba(255, 214, 230, 0.92) 0 25%, transparent 28%),
+    radial-gradient(ellipse at 24% 66%, rgba(255, 231, 240, 0.92) 0 22%, transparent 25%),
+    radial-gradient(ellipse at 38% 74%, rgba(255, 205, 224, 0.86) 0 28%, transparent 31%),
+    radial-gradient(ellipse at 53% 67%, rgba(255, 230, 240, 0.94) 0 24%, transparent 27%),
+    radial-gradient(ellipse at 67% 73%, rgba(255, 214, 230, 0.9) 0 26%, transparent 29%),
+    radial-gradient(ellipse at 81% 65%, rgba(255, 235, 243, 0.95) 0 23%, transparent 26%),
+    radial-gradient(ellipse at 94% 72%, rgba(255, 206, 223, 0.84) 0 27%, transparent 30%);
+  opacity: 0.86;
+}
+
+.site-footer::after {
+  content: '';
+  position: absolute;
+  inset: -20% -6% 30% -6%;
+  pointer-events: none;
+  opacity: 0.45;
+  background-image:
+    radial-gradient(circle at 8% 6%, rgba(255, 214, 230, 0.92) 0 4px, transparent 5px),
+    radial-gradient(circle at 22% 24%, rgba(255, 236, 245, 0.9) 0 3px, transparent 4px),
+    radial-gradient(circle at 37% 13%, rgba(255, 206, 223, 0.88) 0 4px, transparent 5px),
+    radial-gradient(circle at 51% 8%, rgba(255, 231, 240, 0.9) 0 3px, transparent 4px),
+    radial-gradient(circle at 66% 22%, rgba(255, 212, 228, 0.9) 0 4px, transparent 5px),
+    radial-gradient(circle at 79% 10%, rgba(255, 237, 245, 0.9) 0 3px, transparent 4px),
+    radial-gradient(circle at 92% 24%, rgba(255, 206, 223, 0.88) 0 4px, transparent 5px);
+  animation: site-footer-petal-fall 13s linear infinite;
 }
 
 .site-footer__inner {
+  position: relative;
+  z-index: 1;
   max-width: 1120px;
   margin: 0 auto;
   display: flex;
@@ -17,22 +58,23 @@
 }
 
 .site-footer__brand {
+  font-family: var(--logo-header);
   font-weight: 700;
-  font-size: 1rem;
-  color: #fff;
-  letter-spacing: -0.02em;
+  font-size: 1.5rem;
+  color: #8f4f6c;
+  letter-spacing: 0.01em;
 }
 
 .site-footer__copy {
   margin: 0.35rem 0 0;
-  color: #9aa0a6;
+  color: #8e7b91;
   font-size: 0.8125rem;
 }
 
 .site-footer__tel {
   margin: 0 0 0.35rem;
   font-weight: 600;
-  color: #fff;
+  color: #6d4d6d;
 }
 
 .site-footer__links {
@@ -43,15 +85,24 @@
 }
 
 .site-footer__links a {
-  color: #9aa0a6;
+  color: #7d6780;
   text-decoration: none;
 }
 
 .site-footer__links a:hover {
-  color: #cfd2d6;
+  color: #6f576f;
 }
 
 .site-footer__dot {
-  color: #6b7280;
+  color: #b9a4be;
   user-select: none;
+}
+
+@keyframes site-footer-petal-fall {
+  from {
+    transform: translateY(-6%) translateX(0);
+  }
+  to {
+    transform: translateY(24%) translateX(-2%);
+  }
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,23 +1,30 @@
-:root {
-  --text: #6b6375;
-  --text-h: #08060d;
-  --bg: #fff;
-  --border: #e5e4e7;
-  --code-bg: #f4f3ec;
-  --accent: #aa3bff;
-  --accent-bg: rgba(170, 59, 255, 0.1);
-  --accent-border: rgba(170, 59, 255, 0.5);
-  --social-bg: rgba(244, 243, 236, 0.5);
-  --shadow:
-    rgba(0, 0, 0, 0.1) 0 10px 15px -3px, rgba(0, 0, 0, 0.05) 0 4px 6px -2px;
+@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@600;700&family=Cormorant+Garamond:wght@600;700&family=Noto+Sans:wght@400;500;600;700;800&family=Prata&display=swap');
 
-  --sans: system-ui, 'Segoe UI', Roboto, sans-serif;
-  --heading: system-ui, 'Segoe UI', Roboto, sans-serif;
+:root {
+  --text: #6f6577;
+  --text-h: #3e344a;
+  --bg: #fffafb;
+  --surface: #ffffff;
+  --surface-soft: #fff4f7;
+  --border: #f0dce4;
+  --code-bg: #fff2f6;
+  --accent: #cf6f95;
+  --accent-strong: #b95f83;
+  --accent-bg: #fde7ef;
+  --accent-border: #efbfd0;
+  --social-bg: #fff2f7;
+  --muted: #9f90a7;
+
+  --sans: 'Noto Sans', 'Malgun Gothic', '맑은 고딕', sans-serif;
+  --heading: 'Noto Sans', 'Malgun Gothic', '맑은 고딕', sans-serif;
+  --logo-header: 'Cormorant Garamond', 'Noto Sans', 'Malgun Gothic', '맑은 고딕', sans-serif;
+  --logo-footer: 'Cinzel', 'Noto Sans', 'Malgun Gothic', '맑은 고딕', sans-serif;
+  --logo-alt: 'Prata', 'Noto Sans', 'Malgun Gothic', '맑은 고딕', sans-serif;
   --mono: ui-monospace, Consolas, monospace;
 
   font: 18px/145% var(--sans);
   letter-spacing: 0.18px;
-  color-scheme: light dark;
+  color-scheme: light;
   color: var(--text);
   background: var(--bg);
   font-synthesis: none;
@@ -30,28 +37,11 @@
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --text: #9ca3af;
-    --text-h: #f3f4f6;
-    --bg: #16171d;
-    --border: #2e303a;
-    --code-bg: #1f2028;
-    --accent: #c084fc;
-    --accent-bg: rgba(192, 132, 252, 0.15);
-    --accent-border: rgba(192, 132, 252, 0.5);
-    --social-bg: rgba(47, 48, 58, 0.5);
-    --shadow:
-      rgba(0, 0, 0, 0.4) 0 10px 15px -3px, rgba(0, 0, 0, 0.25) 0 4px 6px -2px;
-  }
-
-  #social .button-icon {
-    filter: invert(1) brightness(2);
-  }
-}
-
 body {
   margin: 0;
+  color: var(--text);
+  background: var(--bg);
+  font-family: var(--sans);
 }
 
 #root {
@@ -106,4 +96,21 @@ code {
   line-height: 135%;
   padding: 4px 8px;
   background: var(--code-bg);
+}
+
+button,
+.button {
+  font-family: inherit;
+  transition: background-color 0.18s ease, border-color 0.18s ease, color 0.18s ease, transform 0.18s ease;
+}
+
+button:hover:not(:disabled),
+.button:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+button:focus-visible,
+.button:focus-visible {
+  outline: 2px solid var(--accent-border);
+  outline-offset: 2px;
 }

--- a/frontend/src/layouts/AppLayout.css
+++ b/frontend/src/layouts/AppLayout.css
@@ -2,8 +2,48 @@
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-  background: #f4f5f7;
-  color: #1f2328;
+  background: #fff8fb;
+  color: #6f6577;
+  position: relative;
+  overflow-x: hidden;
+}
+
+.shell::before,
+.shell::after {
+  content: '';
+  position: fixed;
+  inset: -14% -8% -8%;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.shell::before {
+  opacity: 0.29;
+  background-image:
+    radial-gradient(circle at 10% 8%, rgba(255, 204, 224, 0.95) 0 7px, transparent 8px),
+    radial-gradient(circle at 86% 14%, rgba(255, 232, 242, 0.92) 0 5px, transparent 6px);
+  background-repeat: repeat;
+  background-size: 560px 560px;
+  background-position: 0% -22%;
+  animation: shell-home-petal-fall 138s cubic-bezier(0.25, 0.1, 0.3, 1) infinite;
+}
+
+.shell::after {
+  opacity: 0.2;
+  background-image: radial-gradient(circle at 64% 9%, rgba(255, 214, 231, 0.9) 0 6px, transparent 7px);
+  background-repeat: repeat;
+  background-size: 760px 760px;
+  background-position: 56% -28%;
+  animation: shell-home-petal-fall-alt 196s cubic-bezier(0.2, 0.12, 0.24, 1) infinite;
+}
+
+.shell > * {
+  position: relative;
+  z-index: 1;
+}
+
+.shell--focus {
+  background: #fffafb;
 }
 
 .shell-header {
@@ -12,17 +52,43 @@
   align-items: center;
   gap: 1rem;
   padding: 0.85rem 1.25rem 0.85rem 1.5rem;
-  background: #fff;
-  border-bottom: 1px solid #e8eaed;
+  background: #fffdfd;
+  border-bottom: 1px solid #f0dce4;
 }
 
 .shell-logo {
   justify-self: start;
-  font-weight: 800;
-  font-size: 1.125rem;
-  letter-spacing: -0.03em;
-  color: #1f2328;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.08rem;
+  color: #6f576f;
   text-decoration: none;
+  line-height: 1;
+}
+
+.shell-logo__wordmark {
+  font-family: var(--logo-header);
+  font-size: clamp(1.35rem, 1.8vw, 1.7rem);
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  color: #9b5476;
+}
+
+.shell-logo__tag {
+  font-size: 0.64rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: #b397ae;
+  font-weight: 700;
+}
+
+.shell-logo:hover .shell-logo__wordmark {
+  color: #8f4664;
+}
+
+.shell-logo:hover .shell-logo__tag {
+  color: #a982a0;
 }
 
 .shell-nav-pill {
@@ -33,10 +99,9 @@
   justify-content: flex-start;
   gap: 0.15rem;
   padding: 0.25rem;
-  background: #fff;
+  background: #fff2f7;
   border-radius: 999px;
-  border: 1px solid #e8eaed;
-  box-shadow: 0 4px 18px rgba(31, 35, 40, 0.06);
+  border: 1px solid #f0dce4;
   max-width: 100%;
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
@@ -56,58 +121,58 @@
   border-radius: 999px;
   font-size: 0.875rem;
   font-weight: 500;
-  color: #5c6370;
+  color: #876f86;
   text-decoration: none;
   white-space: nowrap;
   background: transparent;
 }
 
 .shell-pill-link:hover:not(.is-on) {
-  color: #1f2328;
-  background: #f4f5f7;
+  color: #4a3c56;
+  background: #fdeaf1;
 }
 
 /* 활성 탭: 홈·가이드·메시지·AI 검색·마이페이지 동일 회색 (매칭 요청만 별색) */
 .shell-pill-link.is-on:not(.shell-pill-link--guide) {
-  background: #e8eaed;
-  color: #111827;
+  background: #f8dce7;
+  color: #5a3c56;
   font-weight: 700;
 }
 
 .shell-pill-link--spark:not(.is-on) {
-  color: #5c6370;
+  color: #876f86;
   font-weight: 500;
 }
 
 .shell-pill-link--spark:hover:not(.is-on) {
-  color: #1f2328;
-  background: #f4f5f7;
+  color: #4a3c56;
+  background: #fdeaf1;
 }
 
 .shell-pill-link--cta:not(.is-on) {
   background: transparent;
-  color: #5c6370 !important;
+  color: #876f86 !important;
   font-weight: 500;
 }
 
 .shell-pill-link--cta:hover:not(.is-on) {
-  background: #f4f5f7 !important;
-  color: #1f2328 !important;
+  background: #fdeaf1 !important;
+  color: #4a3c56 !important;
 }
 
 .shell-pill-link--guide:not(.is-on) {
-  color: #5c6370;
+  color: #876f86;
   font-weight: 500;
 }
 
 .shell-pill-link--guide:hover:not(.is-on) {
-  color: #1f2328;
-  background: #f4f5f7;
+  color: #4a3c56;
+  background: #fdeaf1;
 }
 
 .shell-pill-link--guide.is-on {
-  background: #e3f2fd;
-  color: #0d47a1;
+  background: #fde7ef;
+  color: #8f4664;
   font-weight: 700;
 }
 
@@ -125,18 +190,18 @@
   font-weight: 600;
   padding: 0.35rem 0.65rem;
   border-radius: 999px;
-  border: 1px solid #d8dde3;
-  background: #fff;
-  color: #3c434d;
+  border: 1px solid #efbfd0;
+  background: #fff4f8;
+  color: #7a5f78;
 }
 
 .shell-mode--muted {
-  color: #7a828d;
+  color: #9f90a7;
 }
 
 .shell-email {
   font-size: 0.8rem;
-  color: #5c6370;
+  color: #8d7890;
   max-width: min(10rem, 28vw);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -158,19 +223,19 @@
 }
 
 .shell-btn--ghost {
-  background: #fff;
-  color: #1f2328;
-  border-color: #d8dde3;
+  background: #fff8fb;
+  color: #6f576f;
+  border-color: #efbfd0;
 }
 
 .shell-btn--dark {
-  background: #1f2328;
-  color: #fff;
-  border-color: #1f2328;
+  background: #f6d8e6;
+  color: #6d3f58;
+  border-color: #efbfd0;
 }
 
 .shell-btn--dark:hover {
-  background: #111418;
+  background: #f2cddd;
 }
 
 .shell-main {
@@ -182,6 +247,30 @@
   box-sizing: border-box;
 }
 
+.shell-main--focus {
+  max-width: min(860px, 100%);
+  padding-top: clamp(1.25rem, 5vw, 2.5rem);
+}
+
+.shell-route-transition {
+  animation: shell-page-enter 480ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  transform-origin: center center;
+  will-change: opacity, transform;
+}
+
+@keyframes shell-page-enter {
+  from {
+    opacity: 0;
+    transform: scale(0.985);
+    filter: blur(1.2px) saturate(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+    filter: none;
+  }
+}
+
 /* 하위 폼·링크에서 재사용 */
 .button,
 .shell-btn--primary {
@@ -190,9 +279,9 @@
   justify-content: center;
   padding: 0.5rem 1rem;
   border-radius: 999px;
-  border: 1px solid #1f2328;
-  background: #1f2328;
-  color: #fff;
+  border: 1px solid #efbfd0;
+  background: #f6d8e6;
+  color: #6d3f58;
   font-size: 0.875rem;
   font-weight: 600;
   cursor: pointer;
@@ -202,9 +291,9 @@
 
 .button.ghost,
 .shell-btn--line {
-  background: #fff;
-  color: #1f2328;
-  border-color: #cfd4da;
+  background: #fff8fb;
+  color: #6f576f;
+  border-color: #efbfd0;
 }
 
 .button:disabled {
@@ -222,6 +311,10 @@
     justify-self: start;
   }
 
+  .shell-logo__tag {
+    font-size: 0.6rem;
+  }
+
   .shell-nav-pill {
     justify-self: stretch;
     order: 3;
@@ -231,6 +324,51 @@
     justify-self: stretch;
     order: 2;
     justify-content: flex-start;
+  }
+}
+
+@keyframes shell-home-petal-fall {
+  0% {
+    transform: translateY(-22%) translateX(1.2%);
+  }
+  13% {
+    transform: translateY(-18%) translateX(-0.6%);
+  }
+  29% {
+    transform: translateY(-10%) translateX(0.8%);
+  }
+  47% {
+    transform: translateY(2%) translateX(-1.4%);
+  }
+  71% {
+    transform: translateY(18%) translateX(0.4%);
+  }
+  88% {
+    transform: translateY(33%) translateX(-0.9%);
+  }
+  100% {
+    transform: translateY(52%) translateX(1.1%);
+  }
+}
+
+@keyframes shell-home-petal-fall-alt {
+  0% {
+    transform: translateY(-26%) translateX(-0.9%);
+  }
+  22% {
+    transform: translateY(-16%) translateX(1%);
+  }
+  44% {
+    transform: translateY(-5%) translateX(-0.7%);
+  }
+  67% {
+    transform: translateY(14%) translateX(0.9%);
+  }
+  85% {
+    transform: translateY(30%) translateX(-0.8%);
+  }
+  100% {
+    transform: translateY(48%) translateX(0.7%);
   }
 }
 
@@ -251,24 +389,13 @@
   height: 1.15rem;
   padding: 0 0.28rem;
   border-radius: 999px;
-  background: #dc2626;
+  background: #d8799a;
   color: #fff;
   font-size: 0.65rem;
   font-weight: 800;
   line-height: 1.15rem;
   text-align: center;
-  box-shadow: 0 0 0 2px #fff;
-  animation: shell-inbox-pulse 2.4s ease-in-out infinite;
-}
-
-@keyframes shell-inbox-pulse {
-  0%,
-  100% {
-    box-shadow: 0 0 0 2px #fff, 0 0 0 0 rgba(220, 38, 38, 0.45);
-  }
-  50% {
-    box-shadow: 0 0 0 2px #fff, 0 0 0 6px rgba(220, 38, 38, 0);
-  }
+  border: 2px solid #fff8fb;
 }
 
 /* 새 매칭 요청 토스트 */
@@ -283,12 +410,11 @@
   max-width: min(22rem, calc(100vw - 2rem));
   padding: 0.65rem 0.75rem 0.65rem 0.85rem;
   border-radius: 10px;
-  border: 1px solid #fecaca;
-  background: #fff;
-  box-shadow: 0 12px 40px rgba(15, 23, 42, 0.14);
+  border: 1px solid #efbfd0;
+  background: #fff7fa;
   font-size: 0.84rem;
   font-weight: 600;
-  color: #7f1d1d;
+  color: #7a4f68;
   line-height: 1.45;
 }
 
@@ -297,21 +423,8 @@
   height: 8px;
   margin-top: 0.35rem;
   border-radius: 50%;
-  background: #ef4444;
+  background: #d8799a;
   flex-shrink: 0;
-  animation: shell-toast-dot 1.2s ease-in-out infinite;
-}
-
-@keyframes shell-toast-dot {
-  0%,
-  100% {
-    opacity: 1;
-    transform: scale(1);
-  }
-  50% {
-    opacity: 0.65;
-    transform: scale(0.92);
-  }
 }
 
 .shell-match-toast__msg {
@@ -327,7 +440,7 @@
   border: none;
   border-radius: 6px;
   background: transparent;
-  color: #9ca3af;
+  color: #b397ae;
   font-size: 1.1rem;
   line-height: 1;
   cursor: pointer;
@@ -335,8 +448,8 @@
 }
 
 .shell-match-toast__close:hover {
-  background: #fef2f2;
-  color: #b91c1c;
+  background: #fdeaf1;
+  color: #9b5476;
 }
 
 @media (max-width: 600px) {

--- a/frontend/src/layouts/AppLayout.jsx
+++ b/frontend/src/layouts/AppLayout.jsx
@@ -22,12 +22,14 @@ function isGuidesMatchCompletePath(pathname) {
 }
 
 function AppLayoutInner() {
-  const { pathname } = useLocation()
+  const location = useLocation()
+  const { pathname, search } = location
   const { isAuthenticated, email, isGuide, logout } = useAuth()
   const { pendingCount } = useGuidePendingRequests()
   const guideMypageActive = isGuide && pathname.startsWith('/guide/mypage')
   const guestItineraryActive = !isGuide && (pathname.startsWith('/mypage/itinerary') || pathname.startsWith('/upcoming-trips'))
   const matchComplete = isGuidesMatchCompletePath(pathname)
+  const focusMode = pathname.startsWith('/auth/signup') || pathname.startsWith('/onboarding')
   const baseTitleRef = useRef(typeof document !== 'undefined' ? document.title : 'LocalGuest')
 
   useEffect(() => {
@@ -42,12 +44,15 @@ function AppLayoutInner() {
 
   const inboxAria =
     pendingCount > 0 ? `매칭 요청, 처리 필요 ${pendingCount}건` : '매칭 요청'
+  const routeTransitionKey = `${pathname}${search}`
 
   return (
-    <div className="shell">
+    <div className={`shell${focusMode ? ' shell--focus' : ''}`}>
+      {!focusMode && (
       <header className="shell-header">
         <Link to="/" className="shell-logo">
-          LocalGuest
+          <span className="shell-logo__wordmark">LocalGuest</span>
+          <span className="shell-logo__tag">your local travel muse</span>
         </Link>
 
         <nav className="shell-nav-pill" aria-label="주요 메뉴">
@@ -71,21 +76,11 @@ function AppLayoutInner() {
           <NavLink to="/messages" className={pillClass()}>
             메시지
           </NavLink>
-          <NavLink
-            to={isGuide ? '/guide/mypage/profile' : '/mypage'}
-            className={({ isActive }) => {
-              const on = isGuide
-                ? guideMypageActive || matchComplete
-                : (isActive || matchComplete) && !guestItineraryActive
-              const parts = ['shell-pill-link', 'shell-pill-link--cta']
-              if (on) {
-                parts.push('is-on')
-              }
-              return parts.join(' ')
-            }}
-          >
-            {isGuide ? '가이드 마이페이지' : '마이페이지'}
-          </NavLink>
+          {!isGuide && (
+            <NavLink to="/mypage/scrapbook" className={pillClass()}>
+              나의 여행 기록
+            </NavLink>
+          )}
           {!isGuide && (
             <NavLink to="/upcoming-trips" className={pillClass('shell-pill-link--cta')}>
               앞으로의 여행 일정
@@ -111,9 +106,19 @@ function AppLayoutInner() {
         <div className="shell-actions">
           {isAuthenticated ? (
             <>
-              <span className="shell-mode" title="역할 표시">
-                {isGuide ? '가이드 모드' : '여행자 모드'}
-              </span>
+              <NavLink
+                to={isGuide ? '/guide/mypage/profile' : '/mypage'}
+                className={({ isActive }) => {
+                  const on = isGuide
+                    ? guideMypageActive || matchComplete
+                    : (isActive || matchComplete) && !guestItineraryActive
+                  const parts = ['shell-btn', 'shell-btn--ghost']
+                  if (on) parts.push('shell-btn--dark')
+                  return parts.join(' ')
+                }}
+              >
+                {isGuide ? '가이드 마이페이지' : '여행자 마이페이지'}
+              </NavLink>
               <span className="shell-email" title={email ?? ''}>
                 {email}
               </span>
@@ -123,7 +128,6 @@ function AppLayoutInner() {
             </>
           ) : (
             <>
-              <span className="shell-mode shell-mode--muted">여행자 모드</span>
               <Link to="/auth/login" className="shell-btn shell-btn--ghost">
                 로그인
               </Link>
@@ -134,12 +138,15 @@ function AppLayoutInner() {
           )}
         </div>
       </header>
+      )}
 
-      <main className="shell-main">
-        <Outlet />
+      <main className={`shell-main${focusMode ? ' shell-main--focus' : ''}`}>
+        <div key={routeTransitionKey} className="shell-route-transition">
+          <Outlet />
+        </div>
       </main>
 
-      <SiteFooter />
+      {!focusMode && <SiteFooter />}
     </div>
   )
 }

--- a/frontend/src/layouts/DashboardLayout.css
+++ b/frontend/src/layouts/DashboardLayout.css
@@ -14,11 +14,10 @@
 }
 
 .dash-side {
-  background: #fff;
-  border: 1px solid #e8eaed;
+  background: #fffdfd;
+  border: 1px solid #f0dce4;
   border-radius: 14px;
   padding: 1.1rem 0.85rem;
-  box-shadow: 0 4px 20px rgba(31, 35, 40, 0.04);
 }
 
 .dash-profile {
@@ -35,33 +34,61 @@
   width: 4.25rem;
   height: 4.25rem;
   border-radius: 50%;
-  background: linear-gradient(145deg, #e8eaed, #d8dde3);
+  background: #f9e8ee;
   margin-bottom: 0.65rem;
 }
 
 .dash-name {
   font-size: 1rem;
-  color: #1f2328;
+  color: #4a3c56;
 }
 
 .dash-email {
   font-size: 0.78rem;
-  color: #7a828d;
+  color: #9f90a7;
   margin-top: 0.2rem;
   word-break: break-all;
 }
 
 .dash-local-note {
   margin: 0.55rem 0 0;
-  padding: 0.45rem 0.5rem;
+  padding: 0.4rem 0.3rem 0.1rem;
   max-width: 100%;
   font-size: 0.72rem;
   line-height: 1.45;
-  color: #5c6370;
+  color: #7f6b82;
   text-align: center;
-  background: #f8fafc;
-  border: 1px solid #e8eaed;
+}
+
+.dash-local-note--in-nav {
+  margin: 0.15rem 0 0.35rem;
+  padding: 0.4rem 0.35rem 0.25rem;
   border-radius: 10px;
+  background: #fff2f7;
+  border: 1px solid #f0dce4;
+}
+
+.dash-tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.35rem;
+}
+
+.dash-tag-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  border: 1px solid #efbfd0;
+  background: #fff7fb;
+  color: #7a4f68;
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.dash-tag-empty {
+  color: #9f90a7;
 }
 
 .dash-nav {
@@ -73,7 +100,7 @@
 .dash-nav-link {
   padding: 0.55rem 0.65rem;
   border-radius: 10px;
-  color: #3c434d;
+  color: #7f6b82;
   text-decoration: none;
   font-size: 0.84rem;
   line-height: 1.35;
@@ -81,14 +108,14 @@
 }
 
 .dash-nav-link:hover {
-  background: #f8f9fb;
+  background: #fdeaf1;
 }
 
 .dash-nav-link.is-active {
-  background: #f3f4f6;
+  background: #f8dce7;
   font-weight: 700;
-  color: #1f2328;
-  border-left-color: #2563eb;
+  color: #5a3c56;
+  border-left-color: #d17a9b;
 }
 
 .dash-footer {
@@ -104,18 +131,20 @@
   padding: 0.5rem 0.65rem;
   border-radius: 10px;
   font-size: 0.84rem;
-  color: #1f2328;
+  color: #5a3c56;
   text-decoration: none;
 }
 
 .dash-extra:hover {
-  background: #f8f9fb;
+  background: #fdeaf1;
 }
 
 .dash-extra--cta {
   font-weight: 700;
-  border: 1px solid #cfd4da;
+  border: 1px solid #efbfd0;
   border-radius: 10px;
+  background: #f6d8e6;
+  color: #6d3f58;
   text-align: center;
   justify-content: center;
 }
@@ -127,21 +156,20 @@
   background: none;
   border-radius: 10px;
   font-size: 0.84rem;
-  color: #c62828;
+  color: #b25f7f;
   cursor: pointer;
   font-family: inherit;
 }
 
 .dash-logout:hover {
-  background: #fff5f5;
+  background: #fdeaf1;
 }
 
 .dash-content {
-  background: #fff;
-  border: 1px solid #e8eaed;
+  background: #fffdfd;
+  border: 1px solid #f0dce4;
   border-radius: 14px;
   padding: clamp(1rem, 3vw, 1.35rem) clamp(0.85rem, 3vw, 1.5rem);
   min-height: min(320px, 50vh);
-  box-shadow: 0 4px 20px rgba(31, 35, 40, 0.04);
   min-width: 0;
 }

--- a/frontend/src/layouts/DashboardLayout.jsx
+++ b/frontend/src/layouts/DashboardLayout.jsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { Link, NavLink, Outlet } from 'react-router-dom'
 
 import { useAuth } from '../context/useAuth.js'
-import { getGuestDisplayName } from '../lib/guestMypagePrefs.js'
+import { getGuestDisplayName, loadTravelTags } from '../lib/guestMypagePrefs.js'
 
 import './DashboardLayout.css'
 
@@ -12,7 +12,7 @@ const guestItems = [
   { to: '/mypage/payments', label: '💳 결제 내역' },
   { to: '/mypage/privacy', label: '⚙️ 개인정보 설정' },
   { to: '/mypage/tour', label: '🔁 투어 연장/환불 관리' },
-  { to: '/mypage/reviews', label: '⭐ 내 리뷰' },
+  { to: '/mypage/reviews', label: '🌟 내 리뷰' },
 ]
 
 export function DashboardLayout() {
@@ -26,6 +26,7 @@ export function DashboardLayout() {
   }, [])
 
   const displayName = useMemo(() => getGuestDisplayName(email), [email, prefsTick])
+  const travelTags = useMemo(() => loadTravelTags(), [prefsTick])
 
   return (
     <div className="dash">
@@ -34,9 +35,19 @@ export function DashboardLayout() {
           <div className="dash-avatar" aria-hidden />
           <strong className="dash-name">{displayName}</strong>
           <span className="dash-email">{email ?? ''}</span>
-          <p className="dash-local-note" role="note">
-            닉네임·알림 등은 서버 프로필이 없을 때 <strong>이 브라우저에만</strong> 저장됩니다.
-          </p>
+          <div className="dash-local-note" role="note" aria-label="여행 성향 태그">
+            {travelTags.length > 0 ? (
+              <div className="dash-tag-list">
+                {travelTags.map((tag) => (
+                  <span key={tag} className="dash-tag-chip">
+                    #{tag}
+                  </span>
+                ))}
+              </div>
+            ) : (
+              <span className="dash-tag-empty">성향 태그 없음</span>
+            )}
+          </div>
         </div>
 
         <nav className="dash-nav" aria-label="마이페이지 메뉴">

--- a/frontend/src/layouts/GuideDashboardLayout.css
+++ b/frontend/src/layouts/GuideDashboardLayout.css
@@ -14,8 +14,8 @@
 }
 
 .g-dash-side {
-  background: #f6f7f8;
-  border-right: 1px solid #eceff3;
+  background: #fff5f9;
+  border-right: 1px solid #f0dce4;
   border-radius: 0;
   padding: 1rem 0.7rem 0.9rem;
   min-width: 0;
@@ -36,37 +36,58 @@
   width: 3.7rem;
   height: 3.7rem;
   border-radius: 50%;
-  background: linear-gradient(145deg, #e8eaed, #d8dde3);
+  background: #f9e8ee;
   margin-bottom: 0.65rem;
 }
 
 .g-dash-name {
   font-size: 0.95rem;
-  color: #1f2328;
+  color: #4a3c56;
 }
 
 .g-dash-email {
   font-size: 0.72rem;
-  color: #7a828d;
+  color: #9f90a7;
   margin-top: 0.2rem;
   word-break: break-all;
+}
+
+.g-dash-style-tags {
+  margin-top: 0.55rem;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.35rem;
+}
+
+.g-dash-style-tag {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  border: 1px solid #efbfd0;
+  background: linear-gradient(180deg, #fff6fb, #fff);
+  color: #8f4664;
+  font-size: 0.68rem;
+  font-weight: 800;
+  padding: 0.2rem 0.5rem;
+  line-height: 1.2;
 }
 
 .g-dash-profile-btn {
   margin-top: 0.65rem;
   padding: 0.3rem 0.75rem;
   border-radius: 999px;
-  border: 1px solid #d8dde3;
-  background: #fff;
+  border: 1px solid #efbfd0;
+  background: #fff8fb;
   font-size: 0.7rem;
   font-weight: 600;
-  color: #3c434d;
+  color: #7a5f78;
   cursor: pointer;
   font-family: inherit;
 }
 
 .g-dash-profile-btn:hover {
-  background: #f4f5f7;
+  background: #fdeaf1;
 }
 
 .g-dash-nav {
@@ -78,7 +99,7 @@
 .g-dash-link {
   padding: 0.48rem 0.55rem;
   border-radius: 8px;
-  color: #3c434d;
+  color: #7f6b82;
   text-decoration: none;
   font-size: 0.8rem;
   line-height: 1.35;
@@ -86,14 +107,14 @@
 }
 
 .g-dash-link:hover {
-  background: #f8f9fb;
+  background: #fdeaf1;
 }
 
 .g-dash-link.is-active {
-  background: #eceff3;
+  background: #f8dce7;
   font-weight: 700;
-  color: #1f2328;
-  border-left-color: #9ca3af;
+  color: #5a3c56;
+  border-left-color: #d17a9b;
 }
 
 .g-dash-link-inner {
@@ -115,24 +136,13 @@
   height: 1.1rem;
   padding: 0 0.28rem;
   border-radius: 999px;
-  background: #dc2626;
+  background: #d8799a;
   color: #fff;
   font-size: 0.62rem;
   font-weight: 800;
   line-height: 1.1rem;
   text-align: center;
-  box-shadow: 0 0 0 2px #f6f7f8;
-  animation: g-dash-badge-pulse 2.4s ease-in-out infinite;
-}
-
-@keyframes g-dash-badge-pulse {
-  0%,
-  100% {
-    box-shadow: 0 0 0 2px #f6f7f8, 0 0 0 0 rgba(220, 38, 38, 0.4);
-  }
-  50% {
-    box-shadow: 0 0 0 2px #f6f7f8, 0 0 0 5px rgba(220, 38, 38, 0);
-  }
+  border: 2px solid #fff5f9;
 }
 
 .g-dash-sep {
@@ -149,13 +159,13 @@
   background: none;
   text-align: left;
   font-size: 0.8rem;
-  color: #8b5e3c;
+  color: #ad6c8c;
   cursor: pointer;
   font-family: inherit;
 }
 
 .g-dash-logout:hover {
-  background: #fff5f5;
+  background: #fdeaf1;
 }
 
 .g-dash-main {
@@ -164,11 +174,10 @@
 }
 
 .g-panel {
-  background: #fff;
-  border: 1px solid #e8eaed;
+  background: #fffdfd;
+  border: 1px solid #f0dce4;
   border-radius: 16px;
   padding: clamp(1rem, 3vw, 1.35rem) clamp(0.85rem, 3vw, 1.5rem) clamp(1.1rem, 3vw, 1.5rem);
-  box-shadow: 0 6px 24px rgba(31, 35, 40, 0.05);
   max-width: min(760px, 100%);
   box-sizing: border-box;
 }
@@ -177,7 +186,7 @@
   margin: 0 0 1.25rem;
   font-size: 1.15rem;
   font-weight: 800;
-  color: #1f2328;
+  color: #4a3c56;
 }
 
 .g-section {
@@ -294,8 +303,8 @@
   padding: 0.55rem 1.25rem;
   border-radius: 999px;
   border: none;
-  background: #1f2328;
-  color: #fff;
+  background: #f6d8e6;
+  color: #6d3f58;
   font-weight: 700;
   font-size: 0.88rem;
   cursor: pointer;

--- a/frontend/src/layouts/GuideDashboardLayout.jsx
+++ b/frontend/src/layouts/GuideDashboardLayout.jsx
@@ -1,7 +1,10 @@
+import { useEffect, useMemo, useState } from 'react'
 import { Link, Navigate, NavLink, Outlet, useLocation } from 'react-router-dom'
 
+import { apiRequest } from '../api/client.js'
 import { useGuidePendingRequests } from '../context/GuidePendingRequestsProvider.jsx'
 import { useAuth } from '../context/useAuth.js'
+import { useResolvedGuideId } from '../hooks/useResolvedGuideId.js'
 
 import './GuideDashboardLayout.css'
 
@@ -12,7 +15,7 @@ const NAV = [
   { to: '/guide/mypage/feed-schedule?tab=schedule', label: '📅 스케줄 관리', tab: 'schedule' },
   { to: '/guide/mypage/settlement', label: '💰 정산 예정 금액' },
   { to: '/guide/mypage/settings', label: '⚙️ 가이드 설정' },
-  { to: '/guide/mypage/reviews', label: '⭐ 가이드 리뷰' },
+  { to: '/guide/mypage/reviews', label: '🌟 가이드 리뷰' },
   { to: '/guide/inbox', label: '🤝 매칭 요청', external: true },
 ]
 
@@ -20,7 +23,38 @@ export function GuideDashboardLayout() {
   const { email, logout, isGuide } = useAuth()
   const { pendingCount } = useGuidePendingRequests()
   const { pathname, search } = useLocation()
+  const { guideId } = useResolvedGuideId()
   const displayName = email ? email.split('@')[0] : '홍길동'
+  const [guideStyleRaw, setGuideStyleRaw] = useState('')
+
+  useEffect(() => {
+    if (!guideId) return
+    let cancelled = false
+    ;(async () => {
+      try {
+        const res = await apiRequest(`/guides/${guideId}`, { method: 'GET', skipAuth: true })
+        const text = await res.text()
+        if (!res.ok || cancelled) return
+        const data = text ? JSON.parse(text) : null
+        if (!cancelled) setGuideStyleRaw(String(data?.guideStyle ?? '').trim())
+      } catch {
+        /* ignore guide style fetch errors in sidebar */
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [guideId])
+
+  const guideStyleTags = useMemo(() => {
+    if (!guideStyleRaw) return []
+    return [...new Set(
+      guideStyleRaw
+        .split(/[,/|]+/g)
+        .map((s) => s.trim())
+        .filter(Boolean),
+    )].slice(0, 3)
+  }, [guideStyleRaw])
 
   if (!isGuide) {
     return <Navigate to="/mypage" replace />
@@ -33,6 +67,15 @@ export function GuideDashboardLayout() {
           <div className="g-dash-avatar" aria-hidden />
           <strong className="g-dash-name">{displayName}</strong>
           <span className="g-dash-email">{email ?? ''}</span>
+          {guideStyleTags.length > 0 && (
+            <div className="g-dash-style-tags" aria-label="가이드 스타일 태그">
+              {guideStyleTags.map((tag) => (
+                <span key={tag} className="g-dash-style-tag">
+                  #{tag}
+                </span>
+              ))}
+            </div>
+          )}
         </div>
         <nav className="g-dash-nav" aria-label="가이드 메뉴">
           {NAV.map((item) => {

--- a/frontend/src/lib/guestMypagePrefs.js
+++ b/frontend/src/lib/guestMypagePrefs.js
@@ -1,9 +1,11 @@
+import { extractTravelDnaTags, loadTravelDna } from './travelDna.js'
+
 const LS_NICK = 'localguest_mypage_nickname'
 const LS_BOOK = 'localguest_mypage_notify_booking'
 const LS_MSG = 'localguest_mypage_notify_guide_msg'
 const LS_TAGS = 'localguest_mypage_travel_tags'
 
-export const DEFAULT_TRAVEL_TAGS = ['로컬맛집', '사진맛집', '여유로운', '전시관람']
+export const DEFAULT_TRAVEL_TAGS = []
 
 function loadBool(key, fallback) {
   const v = localStorage.getItem(key)
@@ -20,12 +22,19 @@ function loadString(key) {
 export function loadTravelTags() {
   try {
     const raw = localStorage.getItem(LS_TAGS)
-    if (!raw) return [...DEFAULT_TRAVEL_TAGS]
+    if (!raw) {
+      const fromDna = extractTravelDnaTags(loadTravelDna())
+      return fromDna.length > 0 ? fromDna : [...DEFAULT_TRAVEL_TAGS]
+    }
     const p = JSON.parse(raw)
-    if (!Array.isArray(p) || p.length === 0) return [...DEFAULT_TRAVEL_TAGS]
+    if (!Array.isArray(p) || p.length === 0) {
+      const fromDna = extractTravelDnaTags(loadTravelDna())
+      return fromDna.length > 0 ? fromDna : [...DEFAULT_TRAVEL_TAGS]
+    }
     return p.map((t) => String(t).trim()).filter(Boolean)
   } catch {
-    return [...DEFAULT_TRAVEL_TAGS]
+    const fromDna = extractTravelDnaTags(loadTravelDna())
+    return fromDna.length > 0 ? fromDna : [...DEFAULT_TRAVEL_TAGS]
   }
 }
 

--- a/frontend/src/lib/travelDna.js
+++ b/frontend/src/lib/travelDna.js
@@ -1,0 +1,43 @@
+export function loadTravelDna() {
+  try {
+    const raw = localStorage.getItem('localguest_travel_dna')
+    if (!raw) return null
+    const parsed = JSON.parse(raw)
+    if (!parsed || typeof parsed !== 'object') return null
+    return {
+      moments: Array.isArray(parsed.moments) ? parsed.moments.filter(Boolean).map(String) : [],
+      pace: parsed.pace ? String(parsed.pace) : '',
+      travelWith: parsed.travelWith ? String(parsed.travelWith) : '',
+      expect: parsed.expect ? String(parsed.expect) : '',
+    }
+  } catch {
+    return null
+  }
+}
+
+export function buildTravelDnaPreview(dna) {
+  if (!dna) return ''
+  const parts = []
+  if (dna.moments?.length) parts.push(`${dna.moments.join(' · ')}을 원하는`)
+  if (dna.pace) parts.push(`${dna.pace} 여행을 즐기는`)
+  if (dna.travelWith) parts.push(`${dna.travelWith} 떠나는`)
+  if (dna.expect) parts.push(`${dna.expect}을 기대하는`)
+  return parts.length ? `${parts.join(', ')} 여행자` : ''
+}
+
+export function extractTravelDnaTags(dna) {
+  if (!dna) return []
+  const raw = [
+    ...(Array.isArray(dna.moments) ? dna.moments : []),
+    dna.pace,
+    dna.travelWith,
+    dna.expect,
+  ]
+  const uniq = new Set()
+  for (const item of raw) {
+    const t = String(item ?? '').trim()
+    if (!t) continue
+    uniq.add(t)
+  }
+  return Array.from(uniq)
+}

--- a/frontend/src/pages/AiQuickSearchPage.css
+++ b/frontend/src/pages/AiQuickSearchPage.css
@@ -53,19 +53,18 @@
 
 .ais-prompt-bar {
   display: flex;
-  align-items: flex-end;
+  align-items: flex-start;
   gap: 0.5rem;
-  padding: 0.55rem 0.55rem 0.55rem 0.85rem;
-  background: #fff;
-  border-radius: 999px;
-  border: 1px solid #e5e7eb;
-  box-shadow: 0 10px 40px rgba(15, 23, 42, 0.08);
+  padding: 0.8rem 0.75rem 0.75rem 0.95rem;
+  background: #fffdfd;
+  border-radius: 22px;
+  border: 1px solid #f0dce4;
 }
 
 .ais-input {
   flex: 1;
-  min-height: 2.5rem;
-  max-height: 8rem;
+  min-height: 6.6rem;
+  max-height: 13rem;
   border: none;
   outline: none;
   resize: none;
@@ -74,7 +73,7 @@
   line-height: 1.45;
   color: #1f2328;
   background: transparent;
-  padding: 0.35rem 0 0.35rem 0.15rem;
+  padding: 0.3rem 0 0.3rem 0.15rem;
 }
 
 .ais-input::placeholder {
@@ -86,14 +85,20 @@
   width: 2.65rem;
   height: 2.65rem;
   border-radius: 50%;
-  border: none;
-  background: #1f2328;
-  color: #fff;
+  border: 1px solid #efbfd0;
+  background: linear-gradient(135deg, #f6d8e6 0%, #edbfd3 100%);
+  color: #6d3f58;
   cursor: pointer;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: background 0.2s ease, transform 0.15s ease;
+  transition: background 0.2s ease, transform 0.15s ease, box-shadow 0.2s ease;
+  box-shadow: 0 6px 14px rgba(186, 113, 147, 0.22);
+  margin-top: 0.18rem;
+}
+
+.ais--hero .ais-input {
+  min-height: 7.2rem;
 }
 
 .ais-send:disabled {
@@ -102,8 +107,9 @@
 }
 
 .ais-send:not(:disabled):hover {
-  background: #111418;
+  background: linear-gradient(135deg, #f2ccdd 0%, #e7adc5 100%);
   transform: scale(1.04);
+  box-shadow: 0 8px 18px rgba(186, 113, 147, 0.3);
 }
 
 .ais-send-icon {
@@ -114,8 +120,8 @@
 .ais-send-spinner {
   width: 1.1rem;
   height: 1.1rem;
-  border: 2px solid rgba(255, 255, 255, 0.35);
-  border-top-color: #fff;
+  border: 2px solid rgba(141, 71, 102, 0.28);
+  border-top-color: #8a4e69;
   border-radius: 50%;
   animation: ais-spin 0.7s linear infinite;
 }
@@ -314,8 +320,9 @@
   width: 1.65rem;
   height: 1.65rem;
   border-radius: 999px;
-  background: #1f2328;
-  color: #fff;
+  background: linear-gradient(145deg, #f7d7e5, #edc0d3);
+  border: 1px solid #efbfd0;
+  color: #7a4f68;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -327,7 +334,7 @@
 .ais-rank-text {
   font-size: 0.76rem;
   font-weight: 800;
-  color: #111827;
+  color: #7a4f68;
 }
 
 .ais-guide-feeds {
@@ -470,9 +477,13 @@
 }
 
 .ais-profile-btn--primary {
-  background: #1f2328;
-  color: #fff !important;
-  border-color: #1f2328;
+  background: linear-gradient(135deg, #f6d8e6 0%, #edbfd3 100%);
+  color: #6d3f58 !important;
+  border-color: #efbfd0;
+}
+
+.ais-profile-btn--primary:hover {
+  background: linear-gradient(135deg, #f2cddd 0%, #e7adc5 100%);
 }
 
 .ais-more {

--- a/frontend/src/pages/AiQuickSearchPage.jsx
+++ b/frontend/src/pages/AiQuickSearchPage.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useLocation } from 'react-router-dom'
 
 import { apiRequest } from '../api/client'
@@ -6,11 +6,11 @@ import { apiRequest } from '../api/client'
 import './AiQuickSearchPage.css'
 
 const PLACEHOLDER =
-  '예시) 제주 2박3일 · 2명(커플) / 예산 하루 10~15만원(총 30~45만원)\n' +
-  '- 맛집 투어 + 야경 좋은 곳 위주로 가고 싶어요\n' +
-  '- 걷는 코스는 적게(부모님 동행) / 술집은 빼고\n' +
-  '- 이동은 렌트카, 오전 10시~저녁 9시 선호\n' +
-  '- 한국어 가능 가이드면 좋아요'
+  '예시) 부산 2박3일 / 3명(부모님+성인) / 총예산 40~60만원\n' +
+  '- 희망 시간: 오전 10시 시작, 저녁 8시 전 종료\n' +
+  '- 하고 싶은 것: 바다뷰 카페, 로컬 맛집, 야경 산책\n' +
+  '- 제약사항: 계단 많은 코스/장거리 도보는 피하고 싶어요\n' +
+  '- 언어: 한국어 가능한 가이드 희망 (영어 가능하면 더 좋아요)'
 const LS_AI_SEARCH_SNAPSHOT = 'localguest_ai_search_snapshot_v1'
 const LS_AI_MATCH_DRAFT = 'localguest_ai_match_draft_v1'
 const AI_GUIDE_DEFAULT_SHOW = 3
@@ -52,7 +52,23 @@ function pickSpots(prompt, keywords) {
   return DEFAULT_SPOTS
 }
 
-function tagsForGuide(rec, keywords) {
+function styleTags(styleRaw) {
+  if (!styleRaw) return []
+  return [...new Set(
+    String(styleRaw)
+      .split(/[,/|]+/g)
+      .map((s) => s.trim())
+      .filter(Boolean),
+  )]
+    .slice(0, 3)
+    .map((t) => (t.startsWith('#') ? t : `#${t}`))
+}
+
+function tagsForGuide(rec, keywords, styleRaw) {
+  const fromStyle = styleTags(styleRaw)
+  if (fromStyle.length > 0) {
+    return fromStyle
+  }
   const fromMatch = rec?.matched?.tags
   if (Array.isArray(fromMatch) && fromMatch.length > 0) {
     return fromMatch.slice(0, 3).map((t) => (String(t).startsWith('#') ? String(t) : `#${t}`))
@@ -61,7 +77,7 @@ function tagsForGuide(rec, keywords) {
   if (Array.isArray(acts) && acts.length > 0) {
     return acts.slice(0, 3).map((t) => `#${t}`)
   }
-  return ['#로컬투어', '#맞춤동행', '#현지인']
+  return []
 }
 
 function normalizeFallbackGuide(g, reasonText) {
@@ -71,6 +87,7 @@ function normalizeFallbackGuide(g, reasonText) {
     representativeImageUrl: g?.profileImage ?? null,
     publicFeedThumbnailUrls: [],
     region: g?.region ?? '',
+    guideStyle: g?.guideStyle ?? '',
     averageRating: g?.averageRating ?? 0,
     reviewCount: g?.reviewCount ?? 0,
     reason:
@@ -142,7 +159,13 @@ export function AiQuickSearchPage() {
   const [expandedGuides, setExpandedGuides] = useState(false)
   /** @type {Record<string, Array<{ feedId: number, imageUrl?: string, content?: string }>>} */
   const [guideFeedsById, setGuideFeedsById] = useState({})
+  /** @type {Record<string, string>} */
+  const [guideStyleById, setGuideStyleById] = useState({})
   const typeTimerRef = useRef(null)
+  const recommendations = useMemo(() => {
+    if (!Array.isArray(result?.recommendations)) return []
+    return result.recommendations
+  }, [result?.recommendations])
 
   const openPanelSoon = useCallback(() => {
     setPanelOpen(false)
@@ -277,13 +300,43 @@ export function AiQuickSearchPage() {
   )
 
   useEffect(() => {
-    const recs = result?.recommendations
-    if (!Array.isArray(recs) || recs.length === 0) {
+    const idsSource = recommendations.length > 0 ? recommendations : fallbackGuides
+    const ids = [...new Set(idsSource.map((r) => r?.guideId).filter((id) => id != null))].map(String)
+    if (ids.length === 0) {
+      setGuideStyleById({})
+      return
+    }
+    let cancelled = false
+    ;(async () => {
+      const next = {}
+      await Promise.all(
+        ids.map(async (id) => {
+          try {
+            const res = await apiRequest(`/guides/${id}`, { method: 'GET', skipAuth: true })
+            const text = await res.text()
+            if (!res.ok) return
+            const row = text ? JSON.parse(text) : null
+            const style = String(row?.guideStyle ?? '').trim()
+            if (style) next[id] = style
+          } catch {
+            /* ignore */
+          }
+        }),
+      )
+      if (!cancelled) setGuideStyleById(next)
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [recommendations, fallbackGuides])
+
+  useEffect(() => {
+    if (recommendations.length === 0) {
       setGuideFeedsById({})
       return
     }
     const showMax = expandedGuides ? AI_GUIDE_EXPANDED_SHOW : AI_GUIDE_DEFAULT_SHOW
-    const ids = [...new Set(recs.slice(0, showMax).map((r) => r?.guideId).filter((id) => id != null))].map(String)
+    const ids = [...new Set(recommendations.slice(0, showMax).map((r) => r?.guideId).filter((id) => id != null))].map(String)
     if (ids.length === 0) return
 
     let cancelled = false
@@ -309,7 +362,7 @@ export function AiQuickSearchPage() {
     return () => {
       cancelled = true
     }
-  }, [result])
+  }, [recommendations, expandedGuides])
 
   const runSearch = async (e, options = {}) => {
     e?.preventDefault()
@@ -383,9 +436,8 @@ export function AiQuickSearchPage() {
     }
   }
 
-  const recs = result?.recommendations && Array.isArray(result.recommendations) ? result.recommendations : []
   const showMax = expandedGuides ? AI_GUIDE_EXPANDED_SHOW : AI_GUIDE_DEFAULT_SHOW
-  const topGuides = recs.length > 0 ? recs.slice(0, showMax) : fallbackGuides.slice(0, showMax)
+  const topGuides = recommendations.length > 0 ? recommendations.slice(0, showMax) : fallbackGuides.slice(0, showMax)
   const keywords = result?.keywords
   const spots = pickSpots(prompt, keywords)
   const activityHint =
@@ -403,7 +455,7 @@ export function AiQuickSearchPage() {
           <textarea
             id="ais-input"
             className="ais-input"
-            rows={hasSearched ? 2 : 1}
+            rows={5}
             value={prompt}
             onChange={(e) => setPrompt(e.target.value)}
             onKeyDown={onPromptKeyDown}
@@ -494,7 +546,7 @@ export function AiQuickSearchPage() {
                           g.representativeImageUrl ||
                           (Array.isArray(g.publicFeedThumbnailUrls) && g.publicFeedThumbnailUrls[0]) ||
                           null
-                        const tags = tagsForGuide(g, keywords)
+                        const tags = tagsForGuide(g, keywords, (gid ? guideStyleById[gid] : '') || g.guideStyle)
                         return (
                           <li key={g.guideId ?? idx} className="ais-guide-card">
                             <div className="ais-rank" aria-label={`추천 순위 ${idx + 1}위`}>
@@ -541,17 +593,19 @@ export function AiQuickSearchPage() {
                               <div className="ais-guide-main">
                                 <p className="ais-guide-name">{g.guideName ?? '가이드'}</p>
                                 <p className="ais-guide-rating">
-                                  ⭐ {rating} <span className="ais-guide-rc">({rc})</span>
+                                  🌟 {rating} <span className="ais-guide-rc">({rc})</span>
                                 </p>
                                 <p className="ais-guide-region">{g.region ?? ''}</p>
                                 <p className="ais-guide-reason">{g.reason ? String(g.reason).slice(0, 120) : ''}</p>
-                                <div className="ais-guide-tags">
-                                  {tags.map((t) => (
-                                    <span key={t} className="ais-chip">
-                                      {t}
-                                    </span>
-                                  ))}
-                                </div>
+                                {tags.length > 0 && (
+                                  <div className="ais-guide-tags">
+                                    {tags.map((t) => (
+                                      <span key={t} className="ais-chip">
+                                        {t}
+                                      </span>
+                                    ))}
+                                  </div>
+                                )}
                               </div>
                               <Link
                                 to={`/guides/${g.guideId}#match-request`}
@@ -566,7 +620,7 @@ export function AiQuickSearchPage() {
                       })}
                     </ul>
                   )}
-                  {!loading && !expandedGuides && recs.length > AI_GUIDE_DEFAULT_SHOW && (
+                  {!loading && !expandedGuides && recommendations.length > AI_GUIDE_DEFAULT_SHOW && (
                     <button
                       type="button"
                       className="ais-more"

--- a/frontend/src/pages/FormPage.css
+++ b/frontend/src/pages/FormPage.css
@@ -27,6 +27,31 @@
   background: #fff;
 }
 
+.form-role-switch {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem;
+}
+
+.form-role-btn {
+  padding: 0.62rem 0.8rem;
+  border-radius: 10px;
+  border: 1px solid #efbfd0;
+  background: #fff8fb;
+  color: #7a5f78;
+  font-size: 0.88rem;
+  font-weight: 700;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background-color 0.18s ease, border-color 0.18s ease, color 0.18s ease;
+}
+
+.form-role-btn.is-on {
+  background: #f6d8e6;
+  border-color: #efbfd0;
+  color: #6d3f58;
+}
+
 .field {
   display: flex;
   flex-direction: column;
@@ -104,6 +129,50 @@
   background: #f5f5f5;
   color: #333;
   border: 1px solid #ddd;
+}
+
+.form-login-submit {
+  border: 1px solid #efbfd0;
+  background: #f6d8e6;
+  color: #6d3f58;
+  font-weight: 700;
+}
+
+.form-login-submit:hover:not(:disabled) {
+  background: #f2cddd;
+}
+
+.form-social--inside {
+  margin-top: 0.1rem;
+  padding-top: 0.25rem;
+}
+
+.form-google-login {
+  width: 100%;
+  margin-top: 0.2rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.52rem;
+  border-color: #efbfd0 !important;
+  background: #fff8fb !important;
+  color: #8f4664 !important;
+  font-weight: 700;
+}
+
+.form-google-login__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.4rem;
+  height: 1.4rem;
+  border-radius: 999px;
+  border: 1px solid #efbfd0;
+  background: #fff;
+  color: #8f4664;
+  font-size: 0.86rem;
+  font-weight: 800;
+  line-height: 1;
 }
 
 .form-social {

--- a/frontend/src/pages/GuestUpcomingTripsPage.css
+++ b/frontend/src/pages/GuestUpcomingTripsPage.css
@@ -5,19 +5,32 @@
 }
 
 .gut-hero {
+  text-align: center;
+  background: #fffdfd;
+  border: 1px solid #f0dce4;
+  border-radius: 16px;
+  padding: clamp(1rem, 3vw, 1.35rem) clamp(0.9rem, 3vw, 1.25rem);
   margin-bottom: 1rem;
 }
 
 .gut-hero h1 {
   margin: 0 0 0.3rem;
   font-size: clamp(1.2rem, 4vw, 1.6rem);
-  color: #111827;
+  color: #4a3c56;
+  font-family: var(--heading);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  line-height: 1.3;
 }
 
 .gut-hero p {
   margin: 0;
-  color: #4b5563;
-  font-size: 0.9rem;
+  color: #7a6a80;
+  font-family: var(--sans);
+  font-size: 0.92rem;
+  line-height: 1.55;
+  max-width: 42rem;
+  margin-inline: auto;
 }
 
 .gut-sections {
@@ -42,8 +55,10 @@
 
 .gut-section-head h2 {
   margin: 0;
-  font-size: 0.98rem;
-  color: #111827;
+  font-size: 1.02rem;
+  color: #5a3c56;
+  font-weight: 800;
+  letter-spacing: -0.01em;
 }
 
 .gut-section-head span {
@@ -106,14 +121,21 @@
 }
 
 .gut-open {
-  border: 1px solid #111827;
+  border: 1px solid #efbfd0;
   border-radius: 999px;
-  background: #111827;
-  color: #fff;
+  background: linear-gradient(135deg, #f6d8e6 0%, #edbfd3 100%);
+  color: #6d3f58;
   font-size: 0.78rem;
   font-weight: 700;
   padding: 0.4rem 0.7rem;
   cursor: pointer;
   font-family: inherit;
+  transition: background 0.18s ease, border-color 0.18s ease, transform 0.18s ease;
+}
+
+.gut-open:hover {
+  background: linear-gradient(135deg, #f2cddd 0%, #e7adc5 100%);
+  border-color: #e8a8bf;
+  transform: translateY(-1px);
 }
 

--- a/frontend/src/pages/GuestUpcomingTripsPage.jsx
+++ b/frontend/src/pages/GuestUpcomingTripsPage.jsx
@@ -39,6 +39,18 @@ function ddayLabel(days, status) {
   return `${Math.abs(days)}일 지남`
 }
 
+function statusText(status) {
+  const s = String(status ?? '').toUpperCase()
+  if (s === 'PENDING') return '요청 대기'
+  if (s === 'ACCEPTED') return '결제 전'
+  if (s === 'PAID') return '결제 완료'
+  if (s === 'IN_PROGRESS') return '진행 중'
+  if (s === 'COMPLETED') return '여행 완료'
+  if (s === 'CANCELLED') return '취소됨'
+  if (s === 'REJECTED') return '거절됨'
+  return '상태 확인 필요'
+}
+
 function groupRows(rows) {
   const paymentPending = []
   const inProgress = []
@@ -59,11 +71,11 @@ function groupRows(rows) {
   }
 
   return [
-    { key: 'payment', title: '결제하고 확정 필요', rows: paymentPending },
-    { key: 'inprogress', title: '지금 진행 중', rows: inProgress },
+    { key: 'payment', title: '결제 전 (확정 필요)', rows: paymentPending },
+    { key: 'inprogress', title: '진행 중인 여행', rows: inProgress },
     { key: 'dday', title: '오늘 출발 (D-Day)', rows: dday },
     { key: 'd1', title: '내일 출발 (D-1)', rows: d1 },
-    { key: 'upcoming', title: '다가오는 일정', rows: upcoming },
+    { key: 'upcoming', title: '다가오는 여행 일정', rows: upcoming },
   ].filter((section) => section.rows.length > 0)
 }
 
@@ -142,8 +154,8 @@ export function GuestUpcomingTripsPage() {
   return (
     <div className="gut-page">
       <header className="gut-hero">
-        <h1>📆 앞으로의 여행 일정</h1>
-        <p>다가오는 투어를 D-Day 기준으로 빠르게 확인하고, 바로 매칭 상세로 이동할 수 있어요.</p>
+        <h1>📆 내 여행 일정 한눈에 보기</h1>
+        <p>가까운 일정부터 D-Day 순서로 확인하고, 필요한 일정은 바로 눌러 상세/매칭 화면으로 이동해 보세요.</p>
       </header>
 
       {loading && <PageLoading />}
@@ -175,11 +187,11 @@ export function GuestUpcomingTripsPage() {
                         <h3>{nick}</h3>
                         <p>{row.destination ?? '로컬 투어'} · {row.desiredDate ?? '—'}</p>
                         <p>
-                          상태: {row.status} · 예산: {formatBudgetRangeKrw(row.budgetMinWon, row.budgetMaxWon, row.desiredBudget)}
+                          상태: {statusText(row.status)} · 예산: {formatBudgetRangeKrw(row.budgetMinWon, row.budgetMaxWon, row.desiredBudget)}
                         </p>
                       </div>
                       <button type="button" className="gut-open" onClick={() => openMatchScreen(row)}>
-                        상세 보기
+                        일정 확인하기
                       </button>
                     </article>
                   )

--- a/frontend/src/pages/GuideCoursePanel.css
+++ b/frontend/src/pages/GuideCoursePanel.css
@@ -345,10 +345,11 @@
   width: 26px;
   height: 26px;
   border-radius: 50%;
-  background: #111;
-  color: #fff;
+  background: linear-gradient(145deg, #f7d7e5, #edc0d3);
+  border: 1px solid #efbfd0;
+  color: #7a4f68;
   font-size: 12px;
-  font-weight: 600;
+  font-weight: 700;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -438,8 +439,9 @@
 }
 
 .gcp-btn--primary {
-  background: #111;
-  color: #fff;
+  background: linear-gradient(135deg, #f6d8e6 0%, #edbfd3 100%);
+  border: 1px solid #efbfd0;
+  color: #6d3f58;
 }
 
 .gcp-btn--ghost {
@@ -450,5 +452,7 @@
   padding-right: 20px;
 }
 
-.gcp-btn--primary:hover:not(:disabled) { opacity: 0.85; }
+.gcp-btn--primary:hover:not(:disabled) {
+  background: linear-gradient(135deg, #f2cddd 0%, #e7adc5 100%);
+}
 .gcp-btn--ghost:hover { background: #e5e7eb; }

--- a/frontend/src/pages/GuideDetailPage.css
+++ b/frontend/src/pages/GuideDetailPage.css
@@ -16,6 +16,22 @@
   font-size: 0.95rem;
 }
 
+.gdp-back-btn {
+  border: 1px solid #efbfd0;
+  background: linear-gradient(180deg, #fff6fb, #fff);
+  color: #7a5f78;
+  border-radius: 999px;
+  padding: 0.42rem 0.78rem;
+  font-size: 0.86rem;
+  font-weight: 700;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.gdp-back-btn:hover {
+  background: #fff8fb;
+}
+
 .gdp-back a:hover {
   text-decoration: underline;
 }
@@ -283,22 +299,66 @@
 
 .gdp-match {
   margin-top: 2.25rem;
-  padding: 1.25rem;
-  border: 1px solid #e5e7eb;
-  border-radius: 12px;
-  background: #fafafa;
+  padding: 1.3rem;
+  border: 1px solid #f0dce4;
+  border-radius: 16px;
+  background: #fffbfd;
 }
 
 .gdp-match h2 {
-  margin-top: 0;
-  font-size: 1.15rem;
+  margin: 0;
+  font-size: 1.16rem;
+  color: #4a3c56;
+  letter-spacing: -0.01em;
+}
+
+.gdp-match-intro {
+  margin: 0.55rem 0 0;
+  color: #7a6a80;
+  font-size: 0.92rem;
+  line-height: 1.55;
+}
+
+.gdp-match-login {
+  margin: 0.7rem 0 0;
+  font-size: 0.88rem;
+}
+
+.gdp-match-login a {
+  color: #8f4664;
+  font-weight: 700;
+}
+
+.gdp-match-guide-warn {
+  margin: 0.7rem 0 0;
+  color: #b15e81;
+  font-size: 0.88rem;
+  font-weight: 600;
+}
+
+.gdp-match-form {
+  margin-top: 0.95rem;
+  display: grid;
+  gap: 0.9rem;
+  max-width: 640px;
+}
+
+.gdp-match-field {
+  display: grid;
+  gap: 0.38rem;
+}
+
+.gdp-match-label {
+  color: #5a3c56;
+  font-size: 0.88rem;
+  font-weight: 700;
 }
 
 .gdp-match-cal {
-  border: 1px solid #e5e7eb;
-  border-radius: 12px;
+  border: 1px solid #f0dce4;
+  border-radius: 14px;
   background: #fff;
-  padding: 0.75rem;
+  padding: 0.82rem;
 }
 
 .gdp-match-cal-head {
@@ -306,15 +366,17 @@
   align-items: center;
   justify-content: space-between;
   margin-bottom: 0.55rem;
+  color: #5a3c56;
 }
 
 .gdp-match-nav {
-  border: 1px solid #d1d5db;
-  background: #fff;
-  border-radius: 8px;
+  border: 1px solid #efbfd0;
+  background: #fff7fa;
+  border-radius: 10px;
   width: 1.9rem;
   height: 1.9rem;
   cursor: pointer;
+  color: #8f4664;
 }
 
 .gdp-match-week {
@@ -326,8 +388,9 @@
 
 .gdp-match-week span {
   font-size: 0.66rem;
-  color: #9ca3af;
+  color: #b397ae;
   text-align: center;
+  font-weight: 700;
 }
 
 .gdp-match-days {
@@ -338,18 +401,18 @@
 
 .gdp-match-day {
   position: relative;
-  border: 1px solid #e5e7eb;
+  border: 1px solid #efbfd0;
   border-radius: 8px;
   height: 2rem;
-  background: #f9fafb;
+  background: #fff7fa;
   font-size: 0.82rem;
-  color: #6b7280;
+  color: #8f4664;
 }
 
 .gdp-match-day.is-on {
-  background: #eff6ff;
-  border-color: #bfdbfe;
-  color: #1d4ed8;
+  background: #fdeaf1;
+  border-color: #efbfd0;
+  color: #8f4664;
   cursor: pointer;
 }
 
@@ -366,9 +429,9 @@
 }
 
 .gdp-match-day.is-selected {
-  background: #2563eb;
-  border-color: #2563eb;
-  color: #fff;
+  background: #f6d8e6;
+  border-color: #efbfd0;
+  color: #6d3f58;
   font-weight: 700;
 }
 
@@ -379,8 +442,9 @@
 
 .gdp-match-cal-hint {
   margin: 0.55rem 0 0;
-  font-size: 0.74rem;
-  color: #6b7280;
+  font-size: 0.76rem;
+  color: #8d7890;
+  line-height: 1.5;
 }
 
 .gdp-match-x {
@@ -399,25 +463,100 @@
 }
 
 .gdp-match-time {
-  border: 1px solid #d1d5db;
+  border: 1px solid #efbfd0;
   border-radius: 999px;
-  background: #fff;
-  color: #374151;
+  background: #fff8fb;
+  color: #7a5f78;
   font-size: 0.76rem;
   padding: 0.25rem 0.65rem;
   cursor: pointer;
 }
 
 .gdp-match-time.is-selected {
-  border-color: #1f2937;
-  background: #1f2937;
-  color: #fff;
+  border-color: #efbfd0;
+  background: #f6d8e6;
+  color: #6d3f58;
 }
 
 .gdp-match-default-slot {
   margin: 0.55rem 0 0;
   font-size: 0.78rem;
-  color: #4b5563;
+  color: #7f6b82;
+}
+
+.gdp-match-input,
+.gdp-match-textarea {
+  width: 100%;
+  border: 1px solid #efbfd0;
+  background: #fffdfd;
+  border-radius: 10px;
+  padding: 0.62rem 0.72rem;
+  font: inherit;
+  font-size: 0.9rem;
+  color: #5a3c56;
+  box-sizing: border-box;
+}
+
+.gdp-match-input::placeholder,
+.gdp-match-textarea::placeholder {
+  color: #b397ae;
+}
+
+.gdp-match-budget-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  gap: 0.45rem;
+  align-items: center;
+}
+
+.gdp-match-budget-sep {
+  color: #9f90a7;
+  font-weight: 700;
+  font-size: 0.9rem;
+}
+
+.gdp-match-budget-hint {
+  margin: 0;
+  font-size: 0.74rem;
+  color: #9f90a7;
+}
+
+.gdp-match-textarea {
+  resize: vertical;
+  min-height: 5.8rem;
+  line-height: 1.5;
+}
+
+.gdp-match-error {
+  margin: 0;
+  color: #b15e81;
+  font-size: 0.84rem;
+  font-weight: 600;
+}
+
+.gdp-match-actions {
+  display: flex;
+}
+
+.gdp-match-submit {
+  border: 1px solid #efbfd0;
+  border-radius: 999px;
+  background: #f6d8e6;
+  color: #6d3f58;
+  font-size: 0.88rem;
+  font-weight: 800;
+  padding: 0.62rem 1.2rem;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.gdp-match-submit:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.gdp-match-submit:hover:not(:disabled) {
+  background: #f2cddd;
 }
 
 .gdp-confirm-overlay {

--- a/frontend/src/pages/GuideDetailPage.jsx
+++ b/frontend/src/pages/GuideDetailPage.jsx
@@ -4,6 +4,7 @@ import { Link, useParams, useLocation, useNavigate } from 'react-router-dom'
 import { PageEmpty, PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client'
 import { useAuth } from '../context/useAuth.js'
+import { buildTravelDnaPreview, loadTravelDna } from '../lib/travelDna.js'
 
 import './GuideDetailPage.css'
 
@@ -109,16 +110,16 @@ function compareScheduleTime(a, b) {
 }
 
 /**
- * @param {unknown} keywords
+ * @param {unknown} guideStyle
  * @returns {string[]}
  */
-function parseProfileTags(keywords) {
-  if (keywords == null || keywords === '') return []
-  return String(keywords)
-    .split(/[,#\s]+/)
+function parseGuideStyleTags(guideStyle) {
+  if (guideStyle == null || guideStyle === '') return []
+  return String(guideStyle)
+    .split(/[,/|]+/)
     .map((s) => s.trim())
     .filter(Boolean)
-    .slice(0, 10)
+    .slice(0, 3)
     .map((t) => (t.startsWith('#') ? t : `#${t}`))
 }
 
@@ -170,11 +171,21 @@ function feedPrimaryImage(feed) {
   return ''
 }
 
+function parseNonNegativeInt(raw) {
+  if (raw == null || raw === '') return null
+  const n = Number(raw)
+  if (!Number.isFinite(n) || n < 0) return null
+  return Math.round(n)
+}
+
 export function GuideDetailPage() {
   const { guideId } = useParams()
   const location = useLocation()
   const navigate = useNavigate()
   const { isAuthenticated, isGuide } = useAuth()
+  const fromMatchedCourse = location.state?.fromMatchedCourse === true
+  const hideMatchRequest = location.state?.hideMatchRequest === true
+  const returnTo = typeof location.state?.returnTo === 'string' ? location.state.returnTo : ''
 
   const [aiConceptSummary, setAiConceptSummary] = useState(null)
   const [aiDesiredBudget, setAiDesiredBudget] = useState(null)
@@ -195,6 +206,8 @@ export function GuideDetailPage() {
     return new Date(now.getFullYear(), now.getMonth(), 1)
   })
   const [destination, setDestination] = useState('')
+  const [budgetMinWonInput, setBudgetMinWonInput] = useState('')
+  const [budgetMaxWonInput, setBudgetMaxWonInput] = useState('')
   const [concept, setConcept] = useState('')
   const [submitErr, setSubmitErr] = useState('')
   const [submitting, setSubmitting] = useState(false)
@@ -215,6 +228,8 @@ export function GuideDetailPage() {
       if (draft?.desiredBudget != null && draft.desiredBudget !== '') setAiDesiredBudget(Number(draft.desiredBudget))
       if (draft?.budgetMinWon != null && draft.budgetMinWon !== '') setAiBudgetMinWon(Number(draft.budgetMinWon))
       if (draft?.budgetMaxWon != null && draft.budgetMaxWon !== '') setAiBudgetMaxWon(Number(draft.budgetMaxWon))
+      if (draft?.budgetMinWon != null && draft.budgetMinWon !== '') setBudgetMinWonInput(String(Number(draft.budgetMinWon)))
+      if (draft?.budgetMaxWon != null && draft.budgetMaxWon !== '') setBudgetMaxWonInput(String(Number(draft.budgetMaxWon)))
       if (draft?.concept) setAiHiddenConcept(String(draft.concept))
 
       // 목적지는 사용자가 비워둔 경우에만 보조로 채운다.
@@ -303,7 +318,7 @@ export function GuideDetailPage() {
     }
   }, [loading, detail, location.hash])
 
-  const tags = useMemo(() => parseProfileTags(detail?.profile?.keywords), [detail])
+  const tags = useMemo(() => parseGuideStyleTags(detail?.profile?.guideStyle), [detail])
 
   const ratingLine = useMemo(() => {
     const p = detail?.profile
@@ -317,7 +332,7 @@ export function GuideDetailPage() {
     const label = Number.isFinite(stars) ? stars.toFixed(1) : String(avg)
     return (
       <>
-        ⭐ <strong>{label}</strong>
+        🌟 <strong>{label}</strong>
         {cnt > 0 ? <span> · 리뷰 {cnt}건</span> : null}
       </>
     )
@@ -472,7 +487,27 @@ export function GuideDetailPage() {
       ? null
       : schedules.find((s) => Number(s.scheduleId) === Number(selectedScheduleId))
     const desiredDate = selectedDateKey || (sch?.availableDate != null ? formatScheduleDate(sch.availableDate) : undefined)
-    const conceptText = concept.trim() || (aiHiddenConcept ? String(aiHiddenConcept).trim() : '')
+    const dnaPreview = buildTravelDnaPreview(loadTravelDna())
+    const conceptText = concept.trim() || (aiHiddenConcept ? String(aiHiddenConcept).trim() : '') || dnaPreview
+    const manualMin = parseNonNegativeInt(budgetMinWonInput)
+    const manualMax = parseNonNegativeInt(budgetMaxWonInput)
+    let budgetMinWon = manualMin
+    let budgetMaxWon = manualMax
+    if (budgetMinWon == null && budgetMaxWon == null) {
+      budgetMinWon = parseNonNegativeInt(aiBudgetMinWon)
+      budgetMaxWon = parseNonNegativeInt(aiBudgetMaxWon)
+    }
+    if (budgetMinWon != null && budgetMaxWon == null) budgetMaxWon = budgetMinWon
+    if (budgetMaxWon != null && budgetMinWon == null) budgetMinWon = budgetMaxWon
+    if (budgetMinWon != null && budgetMaxWon != null && budgetMinWon > budgetMaxWon) {
+      setSubmitErr('예산 범위는 최소 금액이 최대 금액보다 클 수 없습니다.')
+      return
+    }
+    let desiredBudgetValue =
+      aiDesiredBudget != null && !Number.isNaN(Number(aiDesiredBudget)) ? Number(aiDesiredBudget) : undefined
+    if (budgetMinWon != null && budgetMaxWon != null) {
+      desiredBudgetValue = Math.round((budgetMinWon + budgetMaxWon) / 2)
+    }
 
     setConfirmModal({
       destination: dest,
@@ -483,13 +518,10 @@ export function GuideDetailPage() {
         scheduleId: selectedScheduleId != null ? Number(selectedScheduleId) : undefined,
         destination: dest,
         concept: conceptText || undefined,
-        conceptSummary: aiConceptSummary ? String(aiConceptSummary).trim() : undefined,
-        desiredBudget:
-          aiDesiredBudget != null && !Number.isNaN(Number(aiDesiredBudget)) ? Number(aiDesiredBudget) : undefined,
-        budgetMinWon:
-          aiBudgetMinWon != null && !Number.isNaN(Number(aiBudgetMinWon)) ? Number(aiBudgetMinWon) : undefined,
-        budgetMaxWon:
-          aiBudgetMaxWon != null && !Number.isNaN(Number(aiBudgetMaxWon)) ? Number(aiBudgetMaxWon) : undefined,
+        conceptSummary: (aiConceptSummary ? String(aiConceptSummary).trim() : '') || dnaPreview || undefined,
+        desiredBudget: desiredBudgetValue,
+        budgetMinWon: budgetMinWon ?? undefined,
+        budgetMaxWon: budgetMaxWon ?? undefined,
         desiredDate: desiredDate || undefined,
       },
     })
@@ -541,7 +573,27 @@ export function GuideDetailPage() {
   return (
     <div className="gdp">
       <p className="gdp-back">
-        <Link to="/guides">← 목록</Link>
+        {fromMatchedCourse ? (
+          <button
+            type="button"
+            className="gdp-back-btn"
+            onClick={() => {
+              if (window.history.length > 1) {
+                navigate(-1)
+                return
+              }
+              if (returnTo) {
+                navigate(returnTo)
+                return
+              }
+              navigate('/guides')
+            }}
+          >
+            ← 상세 코스로 돌아가기
+          </button>
+        ) : (
+          <Link to="/guides">← 목록</Link>
+        )}
       </p>
 
       <header className="gdp-hero">
@@ -672,7 +724,7 @@ export function GuideDetailPage() {
                 <div className="gdp-review-head">
                   <span className="gdp-review-name">{r.writeNickname ?? '여행자'}</span>
                   <span className="gdp-review-stars">
-                    {'⭐'.repeat(Math.min(5, Math.max(0, Number(r.rating) || 0)))}
+                    {'🌟'.repeat(Math.min(5, Math.max(0, Number(r.rating) || 0)))}
                   </span>
                 </div>
                 {r.content && String(r.content).trim() ? (
@@ -684,34 +736,35 @@ export function GuideDetailPage() {
         )}
       </section>
 
-      <section className="gdp-match" id="match-request">
-        <h2>매칭 요청하기</h2>
-        <p style={{ color: '#4b5563', fontSize: '0.95rem', lineHeight: 1.5 }}>
-          날짜를 고르고 목적지를 적으면 가이드에게 매칭 요청이 전달됩니다. 기본은 모든 날짜 요청 가능이며, 가이드가 막은 날짜만 선택할 수 없어요.
-        </p>
-
-        {!isAuthenticated && (
-          <p>
-            <Link
-              to="/auth/login"
-              state={{
-                returnTo: `/guides/${guideId}#match-request`,
-                hint: '로그인 후 이 가이드에게 매칭 요청을 보낼 수 있어요.',
-              }}
-            >
-              로그인하고 요청하기
-            </Link>
+      {!hideMatchRequest && (
+        <section className="gdp-match" id="match-request">
+          <h2>매칭 요청하기</h2>
+          <p className="gdp-match-intro">
+            날짜를 먼저 선택한 뒤 여행 지역과 원하는 여행 스타일을 적어 주세요. 입력한 정보가 가이드에게 그대로 전달됩니다.
           </p>
-        )}
 
-        {isAuthenticated && isGuide && (
-          <p style={{ color: '#b45309' }}>가이드 계정으로는 게스트 매칭 요청을 보낼 수 없습니다. 여행자로 로그인해 주세요.</p>
-        )}
+          {!isAuthenticated && (
+            <p className="gdp-match-login">
+              <Link
+                to="/auth/login"
+                state={{
+                  returnTo: `/guides/${guideId}#match-request`,
+                  hint: '로그인 후 이 가이드에게 매칭 요청을 보낼 수 있어요.',
+                }}
+              >
+                로그인하고 요청하기
+              </Link>
+            </p>
+          )}
 
-        {isAuthenticated && !isGuide && (
-          <form onSubmit={(e) => void onSubmitMatch(e)} style={{ display: 'grid', gap: '0.85rem', maxWidth: 480 }}>
-            <label style={{ display: 'grid', gap: 6 }}>
-              <span>예약 날짜 선택</span>
+          {isAuthenticated && isGuide && (
+            <p className="gdp-match-guide-warn">가이드 계정에서는 요청을 보낼 수 없어요. 여행자 계정으로 로그인해 주세요.</p>
+          )}
+
+          {isAuthenticated && !isGuide && (
+            <form onSubmit={(e) => void onSubmitMatch(e)} className="gdp-match-form">
+            <label className="gdp-match-field">
+              <span className="gdp-match-label">예약 날짜</span>
               <div className="gdp-match-cal">
                 <div className="gdp-match-cal-head">
                   <button
@@ -769,7 +822,9 @@ export function GuideDetailPage() {
                     )
                   })}
                 </div>
-                <p className="gdp-match-cal-hint">지난 날짜와 예약된 날짜는 선택할 수 없어요. 기본은 예약 가능이며, 가이드가 막은 날짜도 비활성화됩니다.</p>
+                <p className="gdp-match-cal-hint">
+                  지난 날짜와 이미 예약된 날짜는 선택할 수 없습니다. 가이드가 비활성화한 날짜도 자동으로 제외돼요.
+                </p>
 
                 {selectedDateSchedules.length > 0 ? (
                   <div className="gdp-match-times" role="radiogroup" aria-label="시간 선택">
@@ -793,45 +848,66 @@ export function GuideDetailPage() {
                 )}
               </div>
             </label>
-            <label style={{ display: 'grid', gap: 6 }}>
-              <span>여행 목적지 · 지역</span>
+            <label className="gdp-match-field">
+              <span className="gdp-match-label">여행 지역</span>
               <input
+                className="gdp-match-input"
                 type="text"
                 value={destination}
                 onChange={(ev) => setDestination(ev.target.value)}
-                placeholder="예: 구미, 경북 구미시"
+                placeholder="예: 구미 / 경북 구미시 / 제주 제주시"
                 required
               />
             </label>
-            <label style={{ display: 'grid', gap: 6 }}>
-              <span>하고 싶은 일 (선택)</span>
+            <label className="gdp-match-field">
+              <span className="gdp-match-label">예산 범위 (선택)</span>
+              <div className="gdp-match-budget-row">
+                <input
+                  className="gdp-match-input"
+                  type="number"
+                  min="0"
+                  inputMode="numeric"
+                  value={budgetMinWonInput}
+                  onChange={(ev) => setBudgetMinWonInput(ev.target.value)}
+                  placeholder="최소 예산(원)"
+                />
+                <span className="gdp-match-budget-sep">~</span>
+                <input
+                  className="gdp-match-input"
+                  type="number"
+                  min="0"
+                  inputMode="numeric"
+                  value={budgetMaxWonInput}
+                  onChange={(ev) => setBudgetMaxWonInput(ev.target.value)}
+                  placeholder="최대 예산(원)"
+                />
+              </div>
+              <p className="gdp-match-budget-hint">한쪽만 입력하면 단일 금액으로 처리됩니다.</p>
+            </label>
+            <label className="gdp-match-field">
+              <span className="gdp-match-label">원하는 여행 스타일 (선택)</span>
               <textarea
+                className="gdp-match-textarea"
                 rows={3}
                 value={concept}
                 onChange={(ev) => setConcept(ev.target.value)}
-                placeholder="예: 동네 맛집과 산책 코스를 함께하고 싶어요."
+                placeholder="예: 현지 맛집 + 산책 위주로 여유 있게, 걷는 코스는 짧게 원해요."
               />
             </label>
-            {submitErr && <p style={{ color: '#b91c1c', margin: 0 }}>{submitErr}</p>}
-            <div>
+            {submitErr && <p className="gdp-match-error">{submitErr}</p>}
+            <div className="gdp-match-actions">
               <button
                 type="submit"
+                className="gdp-match-submit"
                 disabled={submitting || !selectedDateKey || blockedDateSet.has(selectedDateKey) || reservedDateSet.has(selectedDateKey)}
-                style={{
-                  padding: '0.6rem 1.2rem',
-                  borderRadius: 8,
-                  border: 'none',
-                  background: '#111',
-                  color: '#fff',
-                  cursor: schedules.length === 0 ? 'not-allowed' : 'pointer',
-                }}
               >
-                {submitting ? '전송 중…' : '매칭 요청 보내기'}
+                {submitting ? '요청 전송 중…' : '매칭 요청 보내기'}
               </button>
             </div>
-          </form>
-        )}
-      </section>
+            </form>
+          )}
+        </section>
+      )}
 
       {confirmModal && (
         <div

--- a/frontend/src/pages/GuideFeedTourPage.jsx
+++ b/frontend/src/pages/GuideFeedTourPage.jsx
@@ -183,7 +183,7 @@ export function GuideFeedTourPage() {
         <article className="gft-card">
           <h1 className="gft-title">{tourTitle}</h1>
           <p className="gft-rating">
-            ⭐ {rating}{' '}
+            🌟 {rating}{' '}
             <span className="gft-rc">({rc}개의 리뷰)</span>
           </p>
           <div className="gft-tags">
@@ -225,7 +225,7 @@ export function GuideFeedTourPage() {
                   <li key={r.id} className="gft-review">
                     <div className="gft-review-head">
                       <span className="gft-review-name">{r.writeNickname ?? '여행자'}</span>
-                      <span className="gft-review-stars">{'⭐'.repeat(Math.min(5, Math.max(0, Number(r.rating) || 0)))}</span>
+                      <span className="gft-review-stars">{'🌟'.repeat(Math.min(5, Math.max(0, Number(r.rating) || 0)))}</span>
                     </div>
                     <p className="gft-review-text">{r.content}</p>
                   </li>

--- a/frontend/src/pages/GuideInboxPage.css
+++ b/frontend/src/pages/GuideInboxPage.css
@@ -54,6 +54,11 @@
   background: #fffcf2;
 }
 
+.inbox-status-section--extension {
+  border-color: #ddd6fe;
+  background: #faf5ff;
+}
+
 .inbox-status-head {
   display: flex;
   align-items: center;
@@ -102,18 +107,38 @@
   white-space: nowrap;
 }
 
+.inbox-dna-cell {
+  max-width: 14rem;
+}
+
+.inbox-dna-text {
+  display: inline-block;
+  max-width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: top;
+}
+
 .inbox-btn {
   margin-right: 0.35rem;
   margin-bottom: 0.25rem;
   padding: 0.35rem 0.65rem;
   border-radius: 8px;
-  border: 1px solid #1f2328;
-  background: #1f2328;
-  color: #fff;
+  border: 1px solid #efbfd0;
+  background: linear-gradient(135deg, #f6d8e6 0%, #edbfd3 100%);
+  color: #6d3f58;
   font-size: 0.78rem;
   font-weight: 700;
   cursor: pointer;
   font-family: inherit;
+  transition: background 0.18s ease, border-color 0.18s ease, transform 0.18s ease;
+}
+
+.inbox-btn:hover:not(:disabled) {
+  background: linear-gradient(135deg, #f2cddd 0%, #e7adc5 100%);
+  border-color: #e8a8bf;
+  transform: translateY(-1px);
 }
 
 .inbox-btn:disabled {

--- a/frontend/src/pages/GuideInboxPage.jsx
+++ b/frontend/src/pages/GuideInboxPage.jsx
@@ -54,7 +54,49 @@ function formatBudgetRange(minWon, maxWon) {
 }
 
 function formatBudget(value) {
-  return value ? `₩${Number(value).toLocaleString('ko-KR')}` : '—'
+  if (value == null || value === '' || Number.isNaN(Number(value))) return '—'
+  return `₩${Number(value).toLocaleString('ko-KR')}`
+}
+
+function compactDnaSummary(value) {
+  if (value == null) return '—'
+  const text = String(value).replace(/\s+/g, ' ').trim()
+  return text || '—'
+}
+
+async function tryFetchExtension(requestId) {
+  if (requestId == null) return null
+  try {
+    const res = await apiRequest(`/matching/extensions/${requestId}`, { method: 'GET' })
+    const text = await res.text()
+    if (!res.ok) return null
+    return text ? JSON.parse(text) : null
+  } catch {
+    return null
+  }
+}
+
+function extensionStatusLabel(status) {
+  const map = {
+    REQUESTED: '연장 요청',
+    GUIDE_APPROVED: '연장 결제 대기',
+    PAID: '연장 결제 완료',
+  }
+  return (
+    <span
+      style={{
+        fontSize: '0.76rem',
+        fontWeight: 700,
+        padding: '0.2rem 0.55rem',
+        borderRadius: 999,
+        background: '#ede9fe',
+        color: '#5b21b6',
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {map[String(status)] ?? '연장'}
+    </span>
+  )
 }
 
 const STATUS_SECTIONS = [
@@ -71,6 +113,7 @@ export function GuideInboxPage() {
   const { refresh: refreshPendingBadge } = useGuidePendingRequests()
   const { guideId } = useResolvedGuideId()
   const [rows, setRows] = useState([])
+  const [extensionsByRequestId, setExtensionsByRequestId] = useState({})
   const [schedulesById, setSchedulesById] = useState({})
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(true)
@@ -156,19 +199,59 @@ export function GuideInboxPage() {
     void loadSchedules()
   }, [loadSchedules])
 
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      if (!isGuide || rows.length === 0) {
+        if (!cancelled) setExtensionsByRequestId({})
+        return
+      }
+      const entries = await Promise.all(
+        rows.map(async (r) => {
+          const ext = await tryFetchExtension(r.requestId)
+          if (!ext) return null
+          return [r.requestId, ext]
+        }),
+      )
+      if (cancelled) return
+      const m = {}
+      for (const e of entries) {
+        if (e) m[e[0]] = e[1]
+      }
+      setExtensionsByRequestId(m)
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [isGuide, rows])
+
   const groupedRows = useMemo(() => {
+    const extensionRows = rows.filter((row) => {
+      const extension = extensionsByRequestId[row.requestId]
+      return extension && (extension.status === 'REQUESTED' || extension.status === 'GUIDE_APPROVED')
+    })
+    const extensionRequestIds = new Set(extensionRows.map((row) => Number(row.requestId)))
     const sections = STATUS_SECTIONS.map((section) => ({
       ...section,
-      rows: rows.filter((row) => section.statuses.includes(String(row.status ?? ''))),
+      rows: rows.filter((row) => {
+        if (extensionRequestIds.has(Number(row.requestId))) return false
+        return section.statuses.includes(String(row.status ?? ''))
+      }),
     }))
     const included = new Set(STATUS_SECTIONS.flatMap((section) => section.statuses))
-    const others = rows.filter((row) => !included.has(String(row.status ?? '')))
+    const others = rows.filter((row) => {
+      if (extensionRequestIds.has(Number(row.requestId))) return false
+      return !included.has(String(row.status ?? ''))
+    })
     const rejectedSection = sections.find((section) => section.key === 'REJECTED')
     const mainSections = sections.filter((section) => section.key !== 'REJECTED' && section.rows.length > 0)
+    if (extensionRows.length > 0) {
+      mainSections.unshift({ key: 'EXTENSION', label: '연장 요청', statuses: [], rows: extensionRows })
+    }
     if (others.length > 0) mainSections.push({ key: 'OTHER', label: '기타', statuses: [], rows: others })
     if (rejectedSection?.rows.length) mainSections.push(rejectedSection)
     return mainSections
-  }, [rows])
+  }, [rows, extensionsByRequestId])
 
   const openCourseWriter = async (r) => {
     if (guideId == null) {
@@ -255,7 +338,7 @@ export function GuideInboxPage() {
           {groupedRows.map((section) => (
             <section
               key={section.key}
-              className={`inbox-status-section${section.key === 'IN_PROGRESS' ? ' inbox-status-section--inprogress' : ''}${section.key === 'PENDING' ? ' inbox-status-section--pending' : ''}`}
+              className={`inbox-status-section${section.key === 'IN_PROGRESS' ? ' inbox-status-section--inprogress' : ''}${section.key === 'PENDING' ? ' inbox-status-section--pending' : ''}${section.key === 'EXTENSION' ? ' inbox-status-section--extension' : ''}`}
               aria-label={`${section.label} 요청`}
             >
               <header className="inbox-status-head">
@@ -272,36 +355,43 @@ export function GuideInboxPage() {
                       <th>목적지</th>
                       <th>희망일</th>
                       <th>예산</th>
+                      <th>여행 성향</th>
                       <th>동작</th>
                     </tr>
                   </thead>
                   <tbody>
-                    {section.rows.map((r) => (
-                      <tr key={r.requestId}>
-                        <td>{statusLabel(r.status)}</td>
-                        <td>{`게스트 #${r.guestId}`}</td>
-                        <td>{r.destination ?? '—'}</td>
-                        <td>{r.desiredDate ?? '—'}</td>
-                        <td>{formatBudgetRange(r.budgetMinWon, r.budgetMaxWon) ?? formatBudget(r.desiredBudget)}</td>
-                        <td className="inbox-actions">
-                          {r.status === 'PENDING' && (
-                            <>
-                              <button type="button" className="inbox-btn" onClick={() => openCourseWriter(r)} disabled={busyId != null}>
-                                코스 작성하기
-                              </button>
-                              <button
-                                type="button"
-                                className="inbox-btn inbox-btn--danger"
-                                onClick={() => void reject(r.requestId)}
-                                disabled={busyId != null}
-                              >
-                                거절
-                              </button>
-                            </>
-                          )}
-                        </td>
-                      </tr>
-                    ))}
+                    {section.rows.map((r) => {
+                      const dnaSummary = compactDnaSummary(r.conceptSummary)
+                      return (
+                        <tr key={r.requestId}>
+                          <td>{section.key === 'EXTENSION' ? extensionStatusLabel(extensionsByRequestId[r.requestId]?.status) : statusLabel(r.status)}</td>
+                          <td>{`게스트 #${r.guestId}`}</td>
+                          <td>{r.destination ?? '—'}</td>
+                          <td>{r.desiredDate ?? '—'}</td>
+                          <td>{formatBudgetRange(r.budgetMinWon, r.budgetMaxWon) ?? formatBudget(r.desiredBudget)}</td>
+                          <td className="inbox-dna-cell" title={dnaSummary !== '—' ? dnaSummary : undefined}>
+                            <span className="inbox-dna-text">{dnaSummary}</span>
+                          </td>
+                          <td className="inbox-actions">
+                            {r.status === 'PENDING' && (
+                              <>
+                                <button type="button" className="inbox-btn" onClick={() => openCourseWriter(r)} disabled={busyId != null}>
+                                  코스 작성하기
+                                </button>
+                                <button
+                                  type="button"
+                                  className="inbox-btn inbox-btn--danger"
+                                  onClick={() => void reject(r.requestId)}
+                                  disabled={busyId != null}
+                                >
+                                  거절
+                                </button>
+                              </>
+                            )}
+                          </td>
+                        </tr>
+                      )
+                    })}
                   </tbody>
                 </table>
               </div>
@@ -315,7 +405,7 @@ export function GuideInboxPage() {
                   >
                     <header className="inbox-card-head">
                       <span className="inbox-card-id">#{r.requestId}</span>
-                      {statusLabel(r.status)}
+                      {section.key === 'EXTENSION' ? extensionStatusLabel(extensionsByRequestId[r.requestId]?.status) : statusLabel(r.status)}
                     </header>
                     <p className="inbox-card-line">👤 <strong>게스트</strong> {`게스트 #${r.guestId}`}</p>
                     <p className="inbox-card-line">📍 <strong>목적지</strong> {r.destination ?? '—'}</p>
@@ -328,6 +418,9 @@ export function GuideInboxPage() {
                     )}
                     {r.createdAt && (
                       <p className="inbox-card-line">🕐 <strong>요청일</strong> {new Date(r.createdAt).toLocaleDateString('ko-KR')}</p>
+                    )}
+                    {section.key === 'EXTENSION' && (
+                      <p className="inbox-proposed-hint">🔔 게스트가 투어 연장을 요청했습니다. 결제 상태를 확인해 주세요.</p>
                     )}
                     {r.status === 'ACCEPTED' && (
                       <p className="inbox-proposed-hint">✉️ 제시안을 전송했습니다. 게스트가 수락하면 결제로 진행됩니다.</p>

--- a/frontend/src/pages/GuideIntroEditPage.jsx
+++ b/frontend/src/pages/GuideIntroEditPage.jsx
@@ -50,12 +50,13 @@ export function GuideIntroEditPage() {
   const [residenceYears, setResidenceYears] = useState('0')
   const [language, setLanguage] = useState('')
   const [guideStyle, setGuideStyle] = useState('')
-  const [keywords, setKeywords] = useState([])
   const [defaultCourse, setDefaultCourse] = useState('')
-  const [tagInput, setTagInput] = useState('')
   const [loadError, setLoadError] = useState('')
   const [saving, setSaving] = useState(false)
   const { toasts, addToast } = useToast()
+
+  const parsedResidenceYears = Number.parseInt(String(residenceYears || '').replace(/[^\d]/g, ''), 10)
+  const residenceYearsPreview = Number.isFinite(parsedResidenceYears) ? parsedResidenceYears : 0
 
   const load = useCallback(async (id) => {
     setLoadError('')
@@ -72,11 +73,6 @@ export function GuideIntroEditPage() {
       setResidenceYears(p?.residenceYears != null ? String(p.residenceYears) : '0')
       setLanguage(p?.language ?? '')
       setGuideStyle(p?.guideStyle ?? '')
-      setKeywords(
-        p?.keywords
-          ? String(p.keywords).split(',').map((s) => s.trim()).filter(Boolean)
-          : []
-      )
       setDefaultCourse(p?.defaultCourse ?? '')
     } catch (e) {
       setLoadError(e instanceof Error ? e.message : '불러오기 실패')
@@ -87,24 +83,6 @@ export function GuideIntroEditPage() {
     if (!guideId) return
     void load(guideId)
   }, [guideId, load])
-
-  const addKeyword = (raw) => {
-    const tag = raw.trim()
-    if (!tag || keywords.includes(tag) || keywords.length >= 5) return
-    setKeywords((prev) => [...prev, tag])
-    setTagInput('')
-  }
-
-  const handleKeywordKeyDown = (e) => {
-    if (e.key === 'Enter' || e.key === ',') {
-      e.preventDefault()
-      addKeyword(tagInput)
-    }
-  }
-
-  const removeKeyword = (tag) => {
-    setKeywords((prev) => prev.filter((k) => k !== tag))
-  }
 
   const handleSave = async () => {
     if (!guideId || !profile) return
@@ -117,7 +95,6 @@ export function GuideIntroEditPage() {
         residenceYears: residenceYears !== '' ? Number(residenceYears) : undefined,
         language,
         guideStyle: guideStyle,
-        keywords: keywords.join(','),
         defaultCourse,
       }
       const body = buildGuidePutBody(merged)
@@ -134,11 +111,6 @@ export function GuideIntroEditPage() {
       setResidenceYears(p?.residenceYears != null ? String(p.residenceYears) : '0')
       setLanguage(p?.language ?? '')
       setGuideStyle(p?.guideStyle ?? '')
-      setKeywords(
-        p?.keywords
-          ? String(p.keywords).split(',').map((s) => s.trim()).filter(Boolean)
-          : []
-      )
       setDefaultCourse(p?.defaultCourse ?? '')
       addToast('저장되었습니다.')
     } catch {
@@ -209,17 +181,29 @@ export function GuideIntroEditPage() {
 
           <div className="gm-field">
             <label htmlFor="gi-years">
-              거주 연수 <span className="gi-range-val">{residenceYears}년</span>
+              거주 연수 <span className="gi-range-val">{residenceYearsPreview}년</span>
             </label>
-            <input
-              id="gi-years"
-              type="range"
-              min={0}
-              max={50}
-              value={residenceYears}
-              onChange={(e) => setResidenceYears(e.target.value)}
-              className="gi-range"
-            />
+            <div className="gi-years-row">
+              <input
+                id="gi-years"
+                type="number"
+                min={0}
+                max={80}
+                inputMode="numeric"
+                value={residenceYears}
+                onChange={(e) => {
+                  const next = e.target.value.replace(/[^\d]/g, '')
+                  if (next === '') {
+                    setResidenceYears('')
+                    return
+                  }
+                  setResidenceYears(String(Math.min(80, Number(next))))
+                }}
+                className="gi-years-input"
+                placeholder="거주 연수"
+              />
+              <span className="gi-years-suffix">년</span>
+            </div>
           </div>
 
           <div className="gm-field">
@@ -263,44 +247,6 @@ export function GuideIntroEditPage() {
                 onChange={(e) => setGuideStyle(e.target.value)}
                 placeholder="직접 입력 (선택 옵션 외)"
               />
-            </div>
-          </div>
-
-          <div className="gm-field">
-            <label>관심 키워드 <span className="gi-range-val">{keywords.length}/5</span></label>
-            <div className="gi-tag-row">
-              <input
-                className="gi-tag-input"
-                value={tagInput}
-                onChange={(e) => {
-                  const val = e.target.value
-                  if (val.endsWith(',')) {
-                    addKeyword(val.slice(0, -1))
-                  } else {
-                    setTagInput(val)
-                  }
-                }}
-                onKeyDown={handleKeywordKeyDown}
-                placeholder={keywords.length >= 5 ? '최대 5개까지 입력 가능합니다' : '키워드 입력 후 Enter 또는 콤마'}
-                disabled={keywords.length >= 5}
-              />
-              {keywords.length > 0 && (
-                <div className="gi-tag-list">
-                  {keywords.map((k) => (
-                    <span key={k} className="gi-tag">
-                      {k}
-                      <button
-                        type="button"
-                        className="gi-tag-del"
-                        onClick={() => removeKeyword(k)}
-                        aria-label={`${k} 삭제`}
-                      >
-                        ×
-                      </button>
-                    </span>
-                  ))}
-                </div>
-              )}
             </div>
           </div>
 

--- a/frontend/src/pages/GuideMatchOptionsPage.css
+++ b/frontend/src/pages/GuideMatchOptionsPage.css
@@ -37,10 +37,10 @@
   margin: 0 0 0.8rem;
   padding: 0.62rem 0.85rem;
   border-radius: 12px;
-  background: #eff6ff;
-  border: 1px solid #bfdbfe;
+  background: #fff4f8;
+  border: 1px solid #efbfd0;
   font-size: 0.79rem;
-  color: #1e3a8a;
+  color: #7a5f78;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -52,10 +52,10 @@
 }
 
 .gmo-watch-btn {
-  border: 1px solid #93c5fd;
+  border: 1px solid #efbfd0;
   border-radius: 8px;
   background: #fff;
-  color: #1d4ed8;
+  color: #8f4664;
   font-size: 0.76rem;
   font-weight: 700;
   padding: 0.34rem 0.62rem;
@@ -72,11 +72,11 @@
   margin: 0 0 0.8rem;
   padding: 0.68rem 0.9rem;
   border-radius: 12px;
-  background: #ecfdf3;
-  border: 1px solid #86efac;
+  background: #fdeaf1;
+  border: 1px solid #efbfd0;
   font-size: 0.82rem;
   font-weight: 700;
-  color: #166534;
+  color: #8f4664;
   animation: gmoArrivedPop 0.35s ease-out;
 }
 
@@ -97,7 +97,7 @@
   align-items: flex-start;
   padding: 1.1rem 1.15rem;
   background: #fff;
-  border: 1px solid #e8eaed;
+  border: 1px solid #f0dce4;
   border-radius: 18px;
   margin-bottom: 1.25rem;
   box-shadow: 0 8px 28px rgba(15, 23, 42, 0.05);
@@ -112,19 +112,19 @@
 }
 
 .gmo-hero--clickable:hover {
-  border-color: #d1d5db;
-  box-shadow: 0 10px 32px rgba(15, 23, 42, 0.08);
+  border-color: #efbfd0;
+  box-shadow: 0 10px 32px rgba(143, 70, 100, 0.12);
 }
 
 .gmo-hero--clickable:focus-visible {
-  outline: 2px solid #2563eb;
+  outline: 2px solid #efbfd0;
   outline-offset: 3px;
 }
 
 .gmo-hero-hint {
   margin: 0.45rem 0 0;
   font-size: 0.72rem;
-  color: #64748b;
+  color: #9f90a7;
   font-weight: 500;
 }
 
@@ -147,39 +147,20 @@
   margin: 0 0 0.35rem;
   font-size: 1.1rem;
   font-weight: 800;
-  color: #111827;
+  color: #4a3c56;
 }
 
 .gmo-hero-meta {
   margin: 0 0 0.5rem;
   font-size: 0.84rem;
-  color: #6b7280;
+  color: #8d7890;
 }
 
 .gmo-hero-quote {
   margin: 0;
   font-size: 0.88rem;
   line-height: 1.55;
-  color: #374151;
-}
-
-.gmo-likes {
-  position: absolute;
-  top: 1rem;
-  right: 1rem;
-  display: flex;
-  align-items: center;
-  gap: 0.25rem;
-  font-size: 0.82rem;
-  font-weight: 700;
-  color: #ec4899;
-}
-
-@media (max-width: 520px) {
-  .gmo-likes {
-    position: static;
-    margin-top: 0.5rem;
-  }
+  color: #5a3c56;
 }
 
 /* 세로 흐름: 가격 → 지도 (가이드는 상단 히어로, 일정은 하단 코스 블록) */
@@ -192,7 +173,7 @@
 
 .gmo-preview {
   background: #fff;
-  border: 1px solid #e8eaed;
+  border: 1px solid #f0dce4;
   border-radius: 16px;
   padding: 1rem 1.05rem;
   display: flex;
@@ -211,7 +192,7 @@
   min-height: 220px;
   flex: 1;
   border-radius: 12px;
-  background: linear-gradient(160deg, #f3f4f6, #e5e7eb);
+  background: linear-gradient(160deg, #fff4f8, #f7e8ee);
   overflow: hidden;
 }
 
@@ -229,7 +210,7 @@
   justify-content: center;
   text-align: center;
   padding: 1.25rem;
-  background: rgba(243, 244, 246, 0.68);
+  background: rgba(255, 247, 250, 0.74);
   backdrop-filter: blur(1px);
 }
 
@@ -237,26 +218,46 @@
   width: 3rem;
   height: 3rem;
   border-radius: 50%;
-  background: #1f2328;
-  color: #fff;
-  font-size: 1.25rem;
+  background: #f6d8e6;
+  border: 1px solid #efbfd0;
   display: flex;
   align-items: center;
   justify-content: center;
   margin-bottom: 0.65rem;
 }
 
+.gmo-lock-glyph {
+  width: 0.9rem;
+  height: 0.75rem;
+  border: 2px solid #8f4664;
+  border-radius: 3px;
+  position: relative;
+}
+
+.gmo-lock-glyph::before {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: -0.48rem;
+  width: 0.62rem;
+  height: 0.46rem;
+  transform: translateX(-50%);
+  border: 2px solid #8f4664;
+  border-bottom: none;
+  border-radius: 8px 8px 0 0;
+}
+
 .gmo-map-title {
   margin: 0 0 0.35rem;
   font-size: 0.88rem;
   font-weight: 800;
-  color: #374151;
+  color: #5a3c56;
 }
 
 .gmo-map-sub {
   margin: 0;
   font-size: 0.78rem;
-  color: #6b7280;
+  color: #8d7890;
   line-height: 1.45;
   max-width: 16rem;
 }
@@ -438,10 +439,8 @@
   margin-bottom: 0.4rem;
   padding: 0.95rem 1rem;
   border-radius: 14px;
-  border: 1px solid #dbeafe;
-  background: linear-gradient(120deg, #eff6ff 0%, #f8faff 55%, #eff6ff 100%);
-  background-size: 210% 100%;
-  animation: gmoPendingWave 2.4s ease-in-out infinite;
+  border: 1px solid #efbfd0;
+  background: linear-gradient(120deg, #fff4f8 0%, #fff8fb 55%, #fff4f8 100%);
 }
 
 .gmo-course-pending-dot {
@@ -449,55 +448,27 @@
   width: 0.58rem;
   height: 0.58rem;
   border-radius: 50%;
-  background: #2563eb;
-  box-shadow: 0 0 0 rgba(37, 99, 235, 0.35);
-  animation: gmoPulse 1.25s ease-out infinite;
+  background: #d17a9b;
+  box-shadow: none;
 }
 
 .gmo-course-pending-title {
   margin: 0.25rem 0 0;
   font-size: 0.9rem;
   font-weight: 800;
-  color: #1e3a8a;
+  color: #8f4664;
 }
 
 .gmo-course-pending-sub {
   margin: 0.25rem 0 0;
   font-size: 0.8rem;
   line-height: 1.5;
-  color: #334155;
-}
-
-@keyframes gmoPulse {
-  0% {
-    transform: scale(1);
-    box-shadow: 0 0 0 0 rgba(37, 99, 235, 0.35);
-  }
-  70% {
-    transform: scale(1.05);
-    box-shadow: 0 0 0 8px rgba(37, 99, 235, 0);
-  }
-  100% {
-    transform: scale(1);
-    box-shadow: 0 0 0 0 rgba(37, 99, 235, 0);
-  }
-}
-
-@keyframes gmoPendingWave {
-  0% {
-    background-position: 0% 50%;
-  }
-  50% {
-    background-position: 100% 50%;
-  }
-  100% {
-    background-position: 0% 50%;
-  }
+  color: #7a6a80;
 }
 
 .gmo-price-panel {
   background: #fff;
-  border: 1px solid #e8eaed;
+  border: 1px solid #f0dce4;
   border-radius: 16px;
   padding: 1rem 1.05rem;
   display: flex;
@@ -508,14 +479,14 @@
   margin: 0 0 0.5rem;
   font-size: 0.95rem;
   font-weight: 800;
-  color: #111827;
+  color: #4a3c56;
 }
 
 .gmo-price-lead {
   margin: 0 0 0.85rem;
   font-size: 0.78rem;
   line-height: 1.5;
-  color: #64748b;
+  color: #8d7890;
 }
 
 .gmo-price-highlight {
@@ -525,21 +496,21 @@
   gap: 0.75rem;
   padding: 0.85rem 0.95rem;
   border-radius: 12px;
-  border: 2px solid #1f2328;
-  background: #fafafa;
+  border: 1px solid #efbfd0;
+  background: #fff8fb;
   margin-bottom: 0.65rem;
 }
 
 .gmo-price-label {
   font-size: 0.8rem;
   font-weight: 700;
-  color: #374151;
+  color: #7a5f78;
 }
 
 .gmo-price-value {
   font-size: 1rem;
   font-weight: 800;
-  color: #111827;
+  color: #6d3f58;
   white-space: nowrap;
 }
 
@@ -549,10 +520,10 @@
   align-items: center;
   padding-top: 0.65rem;
   margin-bottom: 0.85rem;
-  border-top: 1px solid #eef0f3;
+  border-top: 1px solid #f3dbe5;
   font-size: 0.88rem;
   font-weight: 700;
-  color: #374151;
+  color: #7a5f78;
 }
 
 .gmo-total--single {
@@ -561,28 +532,31 @@
 
 .gmo-total strong {
   font-size: 1.05rem;
-  color: #111827;
+  color: #6d3f58;
 }
 
 .gmo-pay {
   width: 100%;
   padding: 0.7rem 1rem;
   border-radius: 12px;
-  border: none;
-  background: #1f2328;
-  color: #fff;
+  border: 1px solid #efbfd0;
+  background: #f6d8e6;
+  color: #6d3f58;
   font-size: 0.88rem;
   font-weight: 800;
   cursor: pointer;
 }
 
 .gmo-pay:disabled {
-  opacity: 0.45;
+  opacity: 1;
+  background: #e3dfe3;
+  border-color: #d7d1d8;
+  color: #8f8b91;
   cursor: not-allowed;
 }
 
 .gmo-pay:not(:disabled):hover {
-  background: #111418;
+  background: #f2cddd;
 }
 
 .gmo-course-gate {

--- a/frontend/src/pages/GuideMatchOptionsPage.jsx
+++ b/frontend/src/pages/GuideMatchOptionsPage.jsx
@@ -217,7 +217,6 @@ export function GuideMatchOptionsPage() {
       ? Number(profile.averageRating).toFixed(1)
       : '—'
   const rc = profile?.reviewCount != null ? profile.reviewCount : 0
-  const likes = useMemo(() => Math.max(Math.round(rc * 2.8) + 40, 12), [rc])
 
   const quote = useMemo(() => {
     const b = profile?.bio?.trim()
@@ -494,13 +493,10 @@ export function GuideMatchOptionsPage() {
         <div className="gmo-hero-body">
           <h1 className="gmo-hero-name">{profile.nickname ?? '가이드'}</h1>
           <p className="gmo-hero-meta">
-            📍 {profile.region ?? ''} · ⭐ {rating} ({rc} 리뷰)
+            {profile.region ?? ''} · 평점 {rating} ({rc} 리뷰)
           </p>
           <p className="gmo-hero-quote">{quote}</p>
           <p className="gmo-hero-hint">클릭하면 소개·피드·후기를 볼 수 있어요</p>
-        </div>
-        <div className="gmo-likes" aria-hidden>
-          <span>♡</span> {likes}
         </div>
       </header>
 
@@ -544,7 +540,7 @@ export function GuideMatchOptionsPage() {
             <div ref={previewMapRef} className="gmo-map-canvas" />
             <div className="gmo-map-overlay">
               <div className="gmo-lock" aria-hidden>
-                🔒
+                <span className="gmo-lock-glyph" />
               </div>
               <p className="gmo-map-title">매칭 후 상세 코스가 공개됩니다</p>
               <p className="gmo-map-sub">결제 및 매칭을 완료하고 나만의 비밀 지도를 확인하세요.</p>
@@ -634,7 +630,7 @@ export function GuideMatchOptionsPage() {
               </button>
             </div>
             <p className="gmo-profile-dialog-meta">
-              📍 {profile.region ?? ''} · ⭐ {rating} ({rc} 리뷰)
+              {profile.region ?? ''} · 평점 {rating} ({rc} 리뷰)
             </p>
             {modalTags.length > 0 && (
               <div className="gmo-profile-dialog-tags">
@@ -712,7 +708,7 @@ export function GuideMatchOptionsPage() {
                       <div className="gmo-profile-dialog-review-head">
                         <span className="gmo-profile-dialog-review-name">{r.writeNickname ?? '여행자'}</span>
                         <span className="gmo-profile-dialog-review-stars">
-                          {'⭐'.repeat(Math.min(5, Math.max(0, Number(r.rating) || 0)))}
+                          {'🌟'.repeat(Math.min(5, Math.max(0, Number(r.rating) || 0)))}
                         </span>
                       </div>
                       {r.content && String(r.content).trim() ? (

--- a/frontend/src/pages/GuideMatchedCoursePage.css
+++ b/frontend/src/pages/GuideMatchedCoursePage.css
@@ -7,6 +7,7 @@
 }
 
 .gmc-back {
+  /* kept for legacy pages; scrapbook detail uses `.mp-back-chip` */
   border: none;
   background: none;
   padding: 0;
@@ -78,24 +79,13 @@ a.gmc-hero--link:focus-visible {
 .gmc-meta {
   margin: 0 0 0.4rem;
   font-size: 0.82rem;
-  color: #6b7280;
+  color: #8d7890;
 }
 
 .gmc-quote {
   margin: 0;
   font-size: 0.86rem;
   color: #374151;
-}
-
-.gmc-likes {
-  align-self: flex-start;
-  background: #fff1f2;
-  color: #ec4899;
-  border: 1px solid #f9a8d4;
-  border-radius: 999px;
-  padding: 0.25rem 0.7rem;
-  font-size: 0.8rem;
-  font-weight: 700;
 }
 
 .gmc-course {
@@ -115,6 +105,37 @@ a.gmc-hero--link:focus-visible {
   color: #6b7280;
 }
 
+.gmc-pre-info {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+.gmc-pre-card {
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  padding: 12px 16px;
+}
+
+.gmc-pre-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: #9ca3af;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  display: block;
+  margin-bottom: 4px;
+}
+
+.gmc-pre-value {
+  font-size: 14px;
+  color: #111827;
+  margin: 0;
+  line-height: 1.5;
+}
+
 .gmc-grid {
   display: grid;
   grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.85fr);
@@ -128,6 +149,7 @@ a.gmc-hero--link:focus-visible {
 }
 
 .gmc-map-wrap {
+  position: relative;
   background: #fff;
   border: 1px solid #e8eaed;
   border-radius: 14px;
@@ -141,40 +163,110 @@ a.gmc-hero--link:focus-visible {
   background: linear-gradient(160deg, #f3f4f6, #e5e7eb);
 }
 
+.gmc-map-lock {
+  position: absolute;
+  inset: 0;
+  background: rgba(255, 247, 250, 0.8);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  backdrop-filter: blur(2px);
+}
+
+.gmc-lock-icon {
+  width: 2.2rem;
+  height: 2.2rem;
+  border-radius: 50%;
+  background: #f6d8e6;
+  border: 1px solid #efbfd0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.gmc-lock-glyph {
+  width: 0.74rem;
+  height: 0.62rem;
+  border: 2px solid #8f4664;
+  border-radius: 3px;
+  position: relative;
+}
+
+.gmc-lock-glyph::before {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: -0.42rem;
+  width: 0.52rem;
+  height: 0.38rem;
+  transform: translateX(-50%);
+  border: 2px solid #8f4664;
+  border-bottom: none;
+  border-radius: 8px 8px 0 0;
+}
+
+.gmc-lock-title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: #374151;
+}
+
+.gmc-lock-desc {
+  margin: 0;
+  padding: 0 16px;
+  font-size: 12px;
+  color: #6b7280;
+  text-align: center;
+}
+
 .gmc-pin {
   display: inline-flex;
   align-items: center;
-  gap: 0.38rem;
-  transform: translateY(-8px);
+  gap: 0.42rem;
+  transform: translateY(-10px);
 }
 
 .gmc-pin-badge {
-  width: 1.1rem;
-  height: 1.1rem;
+  width: 1.56rem;
+  height: 1.56rem;
   border-radius: 50%;
-  background: #1f2328;
+  background: linear-gradient(145deg, #ffe9f3, #f6d8e6);
+  border: 1px solid #efbfd0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 6px 14px rgba(143, 70, 100, 0.2);
+}
+
+.gmc-pin-badge-inner {
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  background: #8f4664;
   color: #fff;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.62rem;
-  font-weight: 800;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.24);
+  font-size: 0.66rem;
+  font-weight: 900;
 }
 
 .gmc-pin-label {
   display: inline-flex;
   align-items: center;
-  height: 1.2rem;
-  padding: 0 0.45rem;
+  height: 1.3rem;
+  padding: 0 0.52rem;
   border-radius: 999px;
-  background: #fff;
-  border: 1px solid #e5e7eb;
-  color: #374151;
-  font-size: 0.63rem;
-  font-weight: 700;
+  background: rgba(255, 255, 255, 0.96);
+  border: 1px solid rgba(239, 191, 208, 0.82);
+  color: #6d3f58;
+  font-size: 0.66rem;
+  font-weight: 800;
   white-space: nowrap;
-  box-shadow: 0 2px 8px rgba(15, 23, 42, 0.08);
+  box-shadow: 0 4px 10px rgba(143, 70, 100, 0.12);
 }
 
 .gmc-map-err {
@@ -215,26 +307,32 @@ a.gmc-hero--link:focus-visible {
   line-height: 1.45;
 }
 
+.gmc-spot--locked {
+  opacity: 0.6;
+}
+
 .gmc-chat-btn {
   margin-top: auto;
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  gap: 0.34rem;
   width: 100%;
-  padding: 0.72rem 1rem;
-  border: none;
+  padding: 0.76rem 1rem;
+  border: 1px solid #efbfd0;
   border-radius: 999px;
-  background: #1f2328;
-  color: #fff !important;
+  background: linear-gradient(160deg, #ffeef6, #f6d8e6);
+  color: #7b4760 !important;
   text-decoration: none;
-  font-size: 0.85rem;
+  font-size: 0.84rem;
   font-weight: 800;
   cursor: pointer;
   font-family: inherit;
+  box-shadow: 0 7px 16px rgba(143, 70, 100, 0.13);
 }
 
 .gmc-chat-btn:hover {
-  background: #111418;
+  background: linear-gradient(160deg, #ffe5f1, #f2ccdd);
 }
 
 .gmc-chat-btn:disabled {

--- a/frontend/src/pages/GuideMatchedCoursePage.jsx
+++ b/frontend/src/pages/GuideMatchedCoursePage.jsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom'
+import { Link, useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom'
 
 import { PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client'
@@ -40,7 +40,7 @@ function fallbackLatLng(idx) {
 function createSpotOverlay(kakao, map, latlng, idx, name) {
   const root = document.createElement('div')
   root.className = 'gmc-pin'
-  root.innerHTML = `<span class="gmc-pin-badge">${idx + 1}</span><span class="gmc-pin-label">${name}</span>`
+  root.innerHTML = `<span class="gmc-pin-badge"><span class="gmc-pin-badge-inner">${idx + 1}</span></span><span class="gmc-pin-label">${name}</span>`
   return new kakao.maps.CustomOverlay({ map, position: latlng, yAnchor: 1.25, content: root })
 }
 
@@ -58,6 +58,7 @@ function findLatestRequest(list, guideId, requestId) {
 export function GuideMatchedCoursePage() {
   const { guideId } = useParams()
   const [searchParams] = useSearchParams()
+  const location = useLocation()
   const navigate = useNavigate()
   const mapRef = useRef(null)
 
@@ -222,7 +223,6 @@ export function GuideMatchedCoursePage() {
   const rating = profile?.averageRating != null && profile?.averageRating !== ''
     ? Number(profile.averageRating).toFixed(1) : '—'
   const rc = profile?.reviewCount != null ? profile.reviewCount : 0
-  const likes = useMemo(() => Math.max(Math.round(rc * 2.8) + 40, 12), [rc])
 
   if (loading) return <div className="gmc"><PageLoading /></div>
   if (error || !profile) {
@@ -244,6 +244,11 @@ export function GuideMatchedCoursePage() {
       {/* 가이드 프로필 헤더 (기존 유지) */}
       <Link
         to={`/guides/${guideId}`}
+        state={{
+          fromMatchedCourse: true,
+          hideMatchRequest: true,
+          returnTo: `${location.pathname}${location.search}`,
+        }}
         className="gmc-hero gmc-hero--link"
         aria-label={`${profile.nickname ?? '가이드'} 프로필 및 피드 보기`}
       >
@@ -253,11 +258,10 @@ export function GuideMatchedCoursePage() {
         />
         <div className="gmc-hero-body">
           <h1 className="gmc-name">{profile.nickname ?? '가이드'}</h1>
-          <p className="gmc-meta">📍 {profile.region ?? ''} · ⭐ {rating} ({rc} 리뷰)</p>
+          <p className="gmc-meta">{profile.region ?? ''} · 평점 {rating} ({rc} 리뷰)</p>
           <p className="gmc-quote">"{profile.bio?.slice(0, 120) || '관광객은 모르는 사진 찍기 좋은 조용한 루트를 안내합니다.'}"</p>
           <p className="gmc-hero-cta">프로필·피드 보기 →</p>
         </div>
-        <div className="gmc-likes">♥ {likes}</div>
       </Link>
 
       {/* 코스 섹션 */}
@@ -291,7 +295,7 @@ export function GuideMatchedCoursePage() {
             {/* 결제 전 지도 잠금 오버레이 */}
             {!isPaid && (
               <div className="gmc-map-lock">
-                <span className="gmc-lock-icon">🔒</span>
+                <span className="gmc-lock-icon"><span className="gmc-lock-glyph" /></span>
                 <p className="gmc-lock-title">결제 완료 후 코스 공개</p>
                 <p className="gmc-lock-desc">상세 코스와 지도는 결제 후 확인할 수 있어요</p>
               </div>

--- a/frontend/src/pages/GuideMypagePages.css
+++ b/frontend/src/pages/GuideMypagePages.css
@@ -70,8 +70,8 @@
   padding: 0.55rem 1.1rem;
   border-radius: 999px;
   border: none;
-  background: #1f2328;
-  color: #fff;
+  background: #f6d8e6;
+  color: #6d3f58;
   font-weight: 700;
   font-size: 0.86rem;
   cursor: pointer;
@@ -84,14 +84,15 @@
 }
 
 .gm-btn--ghost {
-  background: #fff;
-  color: #1f2328;
-  border: 1px solid #d1d5db;
+  background: #fff8fb;
+  color: #7a5f78;
+  border: 1px solid #efbfd0;
 }
 
 .gm-btn--danger {
-  background: #b91c1c;
-  color: #fff;
+  background: #fff4f8;
+  color: #b45e83;
+  border: 1px solid #efbfd0;
 }
 
 .gm-split {
@@ -155,6 +156,84 @@
   cursor: not-allowed;
 }
 
+.gm-confirm-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 90;
+  background: rgba(15, 23, 42, 0.42);
+  backdrop-filter: blur(2px);
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+}
+
+.gm-confirm {
+  width: min(100%, 380px);
+  border-radius: 16px;
+  border: 1px solid #efbfd0;
+  background: linear-gradient(180deg, #fff, #fff8fb);
+  box-shadow: 0 20px 46px rgba(15, 23, 42, 0.2);
+  padding: 1rem 1rem 0.95rem;
+}
+
+.gm-confirm-kicker {
+  margin: 0 0 0.35rem;
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  border: 1px solid #efbfd0;
+  background: #fff6fb;
+  color: #8f4664;
+  font-size: 0.72rem;
+  font-weight: 700;
+  padding: 0.14rem 0.48rem;
+}
+
+.gm-confirm h3 {
+  margin: 0;
+  color: #4a3c56;
+  font-size: 1.02rem;
+}
+
+.gm-confirm p {
+  margin: 0.45rem 0 0;
+  color: #7a5f78;
+  font-size: 0.86rem;
+}
+
+.gm-confirm-actions {
+  margin-top: 0.95rem;
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.45rem;
+}
+
+.gm-confirm-btn {
+  border-radius: 10px;
+  font-family: inherit;
+  font-size: 0.82rem;
+  font-weight: 700;
+  padding: 0.45rem 0.85rem;
+  cursor: pointer;
+}
+
+.gm-confirm-btn--line {
+  border: 1px solid #d1d5db;
+  background: #fff;
+  color: #4b5563;
+}
+
+.gm-confirm-btn--danger {
+  border: 1px solid #efbfd0;
+  background: #f6d8e6;
+  color: #6d3f58;
+}
+
+.gm-confirm-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 /* guide feed/schedule split tab (F06-03/04) */
 .gfs-tabs {
   display: inline-flex;
@@ -179,8 +258,8 @@
 }
 
 .gfs-tab.is-on {
-  background: #1f2328;
-  color: #fff;
+  background: #f8dce7;
+  color: #6d3f58;
 }
 
 .gfs-feed {
@@ -256,8 +335,8 @@
 }
 
 .gfi-mode-tab.is-on {
-  background: #1f2328;
-  color: #fff;
+  background: #f8dce7;
+  color: #6d3f58;
 }
 
 .gfi-mode-tab--disabled {
@@ -518,8 +597,8 @@
 .gfs-upload-btn {
   border: none;
   border-radius: 999px;
-  background: #2f95ee;
-  color: #fff;
+  background: #f6d8e6;
+  color: #6d3f58;
   font-family: inherit;
   font-weight: 800;
   font-size: 0.9rem;
@@ -1322,9 +1401,9 @@
 }
 
 .gi-card .gi-chip.is-on {
-  background: #1f2328;
-  border-color: #1f2328;
-  color: #fff !important;
+  background: linear-gradient(180deg, #f6d8e6, #f2ccdd);
+  border-color: #efbfd0;
+  color: #6d3f58 !important;
 }
 
 .gpv-tag-list {
@@ -1365,8 +1444,8 @@
   width: 100%;
   border: none;
   border-radius: 12px;
-  background: #1f2328;
-  color: #fff;
+  background: #f6d8e6;
+  color: #6d3f58;
   font-size: 0.95rem;
   font-weight: 800;
   padding: 0.8rem 1rem;
@@ -1426,22 +1505,53 @@
 }
 
 .gi-chip {
-  border: 1px solid #d1d5db;
+  border: 1px solid #efbfd0;
   border-radius: 999px;
-  background: #fff;
-  color: #4b5563;
+  background: #fff8fb;
+  color: #7a5f78;
   font-size: 0.8rem;
-  font-weight: 600;
+  font-weight: 700;
   padding: 0.35rem 0.75rem;
   cursor: pointer;
   font-family: inherit;
-  transition: background 0.1s, color 0.1s, border-color 0.1s;
+  transition: background 0.1s, color 0.1s, border-color 0.1s, transform 0.1s;
+}
+
+.gi-chip:hover {
+  background: #fdeaf1;
+  border-color: #e7a8c2;
+  transform: translateY(-1px);
 }
 
 .gi-chip.is-on {
-  background: #1f2328;
-  color: #fff;
-  border-color: #1f2328;
+  background: linear-gradient(180deg, #f6d8e6, #f2ccdd);
+  color: #6d3f58;
+  border-color: #efbfd0;
+  box-shadow: 0 6px 12px rgba(143, 70, 100, 0.12);
+}
+
+.gi-years-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.gi-years-input {
+  width: 7rem;
+  border: 1px solid #efbfd0;
+  border-radius: 10px;
+  background: #fff8fb;
+  padding: 0.5rem 0.65rem;
+  font: inherit;
+  font-size: 0.86rem;
+  color: #5a3c56;
+  box-sizing: border-box;
+}
+
+.gi-years-suffix {
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: #8f4664;
 }
 
 .gi-custom-input {
@@ -1524,9 +1634,9 @@
   margin-top: 8px;
   padding: 6px 14px;
   border-radius: 8px;
-  border: 1.5px solid #111;
+  border: 1.5px solid #efbfd0;
   background: transparent;
-  color: #111;
+  color: #6d3f58;
   font-size: 13px;
   font-weight: 600;
   font-family: inherit;
@@ -1535,8 +1645,8 @@
 }
 
 .gss-course-btn:hover {
-  background: #111;
-  color: #fff;
+  background: #fdeaf1;
+  color: #8f4664;
 }
 
 /* 코스 작성 완료된 카드는 좌측 테두리 강조 */
@@ -2085,8 +2195,8 @@
 
 .gss3-dact:disabled { opacity: 0.45; cursor: not-allowed; }
 
-.gss3-dact--primary { background: #1f2328; color: #fff; border-color: #1f2328; }
-.gss3-dact--primary:hover:not(:disabled) { background: #374151; }
+.gss3-dact--primary { background: #f6d8e6; color: #6d3f58; border-color: #efbfd0; }
+.gss3-dact--primary:hover:not(:disabled) { background: #f2cddd; }
 .gss3-dact--success { background: #15803d; color: #fff; border-color: #15803d; }
 .gss3-dact--success:hover:not(:disabled) { background: #166534; }
 .gss3-dact--warn    { background: #d97706; color: #fff; border-color: #d97706; }
@@ -2161,8 +2271,8 @@
   padding: 11px 16px;
   border: none;
   border-radius: 6px;
-  background: #0f172a;
-  color: #fff;
+  background: #f6d8e6;
+  color: #6d3f58;
   font-size: 0.82rem;
   font-weight: 700;
   font-family: inherit;
@@ -2172,7 +2282,7 @@
 }
 
 .gss3-apply:hover:not(:disabled) {
-  background: #1e293b;
+  background: #f2cddd;
 }
 
 .gss3-apply:disabled {
@@ -2355,8 +2465,8 @@
 
 .gss3-bact:hover { background: #f3f4f6; }
 
-.gss3-bact--primary { background: #1f2328; color: #fff; border-color: #1f2328; }
-.gss3-bact--primary:hover { background: #374151; }
+.gss3-bact--primary { background: #f6d8e6; color: #6d3f58; border-color: #efbfd0; }
+.gss3-bact--primary:hover { background: #f2cddd; }
 .gss3-bact--warn    { background: #d97706; color: #fff; border-color: #d97706; }
 .gss3-bact--warn:hover    { background: #b45309; }
 

--- a/frontend/src/pages/GuideProposalPage.jsx
+++ b/frontend/src/pages/GuideProposalPage.jsx
@@ -212,7 +212,7 @@ export function GuideProposalPage() {
           <div>
             <p className="gp-name">{profile.nickname ?? '가이드'}</p>
             <p className="gp-meta">
-              ⭐ {rating} ({rc}) · {profile.region ?? ''}
+              🌟 {rating} ({rc}) · {profile.region ?? ''}
             </p>
           </div>
         </div>

--- a/frontend/src/pages/GuideReviewsManagePage.jsx
+++ b/frontend/src/pages/GuideReviewsManagePage.jsx
@@ -18,7 +18,7 @@ function formatDt(iso) {
 
 function stars(rating) {
   const n = Math.max(1, Math.min(5, Math.round(Number(rating ?? 0))))
-  return '★'.repeat(n)
+  return '🌟'.repeat(n)
 }
 
 export function GuideReviewsManagePage() {
@@ -94,7 +94,7 @@ export function GuideReviewsManagePage() {
 
   return (
     <div className="g-panel">
-      <h1>⭐ 가이드 리뷰</h1>
+      <h1>🌟 가이드 리뷰</h1>
 
       {loadError && (
         <PageError message={loadError} onRetry={() => guideId != null && void loadPage(guideId, page)} />
@@ -115,7 +115,7 @@ export function GuideReviewsManagePage() {
             <article className="grv-score-card">
               <p>나의 평균 평점</p>
               <strong>
-                ★ {Number(summary.averageRating).toFixed(1)}
+                🌟 {Number(summary.averageRating).toFixed(1)}
               </strong>
               <span>리뷰 {summary.reviewCount}개</span>
             </article>

--- a/frontend/src/pages/GuideSettingsPage.jsx
+++ b/frontend/src/pages/GuideSettingsPage.jsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 
 import { PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client.js'
@@ -56,7 +56,6 @@ export function GuideSettingsPage() {
   const navigate = useNavigate()
   const { toasts, addToast } = useToast()
   const [profile, setProfile] = useState(null)
-  const [summary, setSummary] = useState(null)
   const [loadError, setLoadError] = useState('')
   const [busy, setBusy] = useState(false)
   const [withdrawing, setWithdrawing] = useState(false)
@@ -64,24 +63,17 @@ export function GuideSettingsPage() {
   const [pushOn, setPushOn] = useState(() => loadBool(LS_PUSH, true))
   const [emailOn, setEmailOn] = useState(() => loadBool(LS_EMAIL, false))
   const [packageWon, setPackageWon] = useState('')
+  const [deactivateConfirmOpen, setDeactivateConfirmOpen] = useState(false)
 
   const load = useCallback(async (id) => {
     setLoadError('')
     try {
-      const [pr, sr] = await Promise.all([
-        apiRequest(`/guides/${id}`, { method: 'GET', skipAuth: true }),
-        apiRequest(`/guides/${id}/reviews/summary`, { method: 'GET', skipAuth: true }),
-      ])
+      const pr = await apiRequest(`/guides/${id}`, { method: 'GET', skipAuth: true })
       const pt = await pr.text()
-      const st = await sr.text()
       if (!pr.ok) {
         throw new Error(await readJsonError(pr, pt))
       }
-      if (!sr.ok) {
-        throw new Error(await readJsonError(sr, st))
-      }
       setProfile(pt ? JSON.parse(pt) : null)
-      setSummary(st ? JSON.parse(st) : null)
       const loadedProfile = pt ? JSON.parse(pt) : null
       const hourly = loadedProfile?.pricePerHour != null ? Number(loadedProfile.pricePerHour) : 0
       setPackageWon(hourly > 0 ? String(Math.round(hourly * HOURS)) : '')
@@ -105,8 +97,9 @@ export function GuideSettingsPage() {
         addToast(await readJsonError(res, text), 'error')
         return
       }
-      setProfile(text ? JSON.parse(text) : profile)
-      addToast('전환되었습니다.')
+      const next = text ? JSON.parse(text) : profile
+      setProfile(next)
+      addToast(next?.isActive ? '활성화되었습니다.' : '비활성화되어 게스트에게 보이지 않습니다.')
     } catch {
       addToast('요청 실패', 'error')
     } finally {
@@ -213,7 +206,6 @@ export function GuideSettingsPage() {
             <div className="g-row">
               <div>
                 <strong>새로운 예약 요청 알림 (Push)</strong>
-                <p>푸시 알림 API 연동 전 — 이 기기에만 저장됩니다.</p>
               </div>
               <label className="g-toggle">
                 <input type="checkbox" checked={pushOn} onChange={(e) => setPushOn(e.target.checked)} />
@@ -223,7 +215,6 @@ export function GuideSettingsPage() {
             <div className="g-row">
               <div>
                 <strong>메시지 수신 알림 (Email)</strong>
-                <p>이메일 알림 API 연동 전 — 이 기기에만 저장됩니다.</p>
               </div>
               <label className="g-toggle">
                 <input type="checkbox" checked={emailOn} onChange={(e) => setEmailOn(e.target.checked)} />
@@ -250,16 +241,8 @@ export function GuideSettingsPage() {
 
           {/* 활성화 섹션 */}
           <section className="gm-card">
-            <h2>활성화</h2>
-            <p className="gm-hint">
-              <code>PATCH /api/guides/&#123;guideId&#125;/active</code> — 서버에서 활성 여부를 토글합니다.
-            </p>
-            <p style={{ margin: '0.5rem 0', fontSize: '0.9rem' }}>
-              현재 상태:{' '}
-              <strong style={{ color: profile?.isActive ? '#15803d' : '#b91c1c' }}>
-                {profile?.isActive ? '활성' : '비활성'}
-              </strong>
-            </p>
+            <h2>게스트 노출 설정</h2>
+            <p className="gm-hint">비활성화 시 게스트에게 뜨지 않아요.</p>
             <div style={{ display: 'flex', gap: '0.6rem', marginTop: '0.5rem' }}>
               {/* 활성화 버튼 */}
               <button
@@ -284,7 +267,9 @@ export function GuideSettingsPage() {
               {/* 비활성화 버튼 */}
               <button
                   type="button"
-                  onClick={() => { if (profile?.isActive) void toggleActive() }}
+                  onClick={() => {
+                    if (profile?.isActive) setDeactivateConfirmOpen(true)
+                  }}
                   disabled={busy || !profile?.isActive}
                   style={{
                     padding: '0.5rem 1.2rem',
@@ -310,22 +295,12 @@ export function GuideSettingsPage() {
             <p style={{ margin: 0, fontSize: '0.9rem' }}>
               승인 여부: <strong>{profile?.isApproved ? '승인됨' : '미승인'}</strong>
             </p>
-            <p className="gm-hint" style={{ marginTop: '0.5rem' }}>
-              승인 API는 관리자용 <code>PATCH /guides/&#123;id&#125;/approve</code> 입니다. 일반 가이드 계정에서는 호출하지
-              않습니다.
-            </p>
-            <p className="gm-hint" style={{ marginTop: '0.5rem' }}>
-              프로필 텍스트/이미지는 <Link to="/guide/mypage/profile">프로필 등록</Link>에서 수정할 수 있습니다.
-            </p>
           </section>
 
           {/* 계정 탈퇴 섹션 */}
           <section className="gm-card">
             <h2>계정 탈퇴</h2>
-            <p className="gm-hint">
-              <code>DELETE /members/me?role=GUIDE</code> — 가이드 자격을 탈퇴합니다. 탈퇴 후에는 가이드 기능을 사용할 수
-              없습니다.
-            </p>
+            <p className="gm-hint">가이드 자격을 탈퇴합니다. 탈퇴 후에는 가이드 기능을 사용할 수 없습니다.</p>
             <button
                 type="button"
                 className="gm-btn gm-btn--danger"
@@ -336,19 +311,32 @@ export function GuideSettingsPage() {
             </button>
           </section>
 
-          {/* 리뷰 요약 섹션 */}
-          <section className="gm-card">
-            <h2>리뷰 요약</h2>
-            <p className="gm-hint">
-              <code>GET /api/guides/&#123;guideId&#125;/reviews/summary</code>
-            </p>
-            <p style={{ margin: '0.5rem 0 0', fontSize: '0.95rem' }}>
-              평균 평점: <strong>{summary?.averageRating != null ? Number(summary.averageRating).toFixed(2) : '—'}</strong>{' '}
-              / 리뷰 수: <strong>{summary?.reviewCount ?? '—'}</strong>
-            </p>
-          </section>
-
         </div>
+        {deactivateConfirmOpen && (
+          <div className="gm-confirm-overlay" role="dialog" aria-modal="true" aria-label="비활성화 확인" onClick={() => !busy && setDeactivateConfirmOpen(false)}>
+            <div className="gm-confirm" onClick={(e) => e.stopPropagation()}>
+              <p className="gm-confirm-kicker">노출 숨기기</p>
+              <h3>정말 숨기겠어요?</h3>
+              <p>비활성화 시 게스트에게 보이지 않아요.</p>
+              <div className="gm-confirm-actions">
+                <button type="button" className="gm-confirm-btn gm-confirm-btn--line" onClick={() => setDeactivateConfirmOpen(false)} disabled={busy}>
+                  취소
+                </button>
+                <button
+                  type="button"
+                  className="gm-confirm-btn gm-confirm-btn--danger"
+                  disabled={busy}
+                  onClick={() => {
+                    setDeactivateConfirmOpen(false)
+                    void toggleActive()
+                  }}
+                >
+                  확인
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
         <Toast toasts={toasts} />
       </div>
   )

--- a/frontend/src/pages/GuideSettlementPage.jsx
+++ b/frontend/src/pages/GuideSettlementPage.jsx
@@ -44,6 +44,27 @@ function buildMonthlyBars(amount) {
   }))
 }
 
+function sanitizeSettlementDescription(raw) {
+  const text = String(raw ?? '').trim()
+  if (!text) return ''
+  return text
+    .replace(/\(COMPLETED\)/gi, '')
+    .replace(/COMPLETED/gi, '')
+    .replace(/\(플랫폼\s*수수료·정산\s*규칙\s*적용\s*전\)/g, '')
+    .replace(/\s{2,}/g, ' ')
+    .trim()
+}
+
+function statusText(status) {
+  const s = String(status ?? '').toUpperCase()
+  if (s === 'PAID') return '결제 완료'
+  if (s === 'IN_PROGRESS') return '투어 진행 중'
+  if (s === 'COMPLETED') return '여행 완료'
+  if (s === 'ACCEPTED') return '예약 확정'
+  if (s === 'PENDING') return '요청 대기'
+  return s || '상태 확인중'
+}
+
 export function GuideSettlementPage() {
   const [data, setData] = useState(null)
   const [guideRequests, setGuideRequests] = useState([])
@@ -133,7 +154,7 @@ export function GuideSettlementPage() {
                 <div>
                   <p className="gst-title">{row.destination ?? '로컬 투어'}</p>
                   <p className="gst-meta">
-                    {formatDate(row.desiredDate)} · {row.status}
+                    {formatDate(row.desiredDate)} · {statusText(row.status)}
                   </p>
                 </div>
                 <strong className="gst-plus">+ {formatMoney(row.desiredBudget ?? 0)}</strong>
@@ -141,7 +162,7 @@ export function GuideSettlementPage() {
             ))}
           </section>
 
-          {data.description && <p className="g-hint">{data.description}</p>}
+          {data.description && <p className="g-hint">{sanitizeSettlementDescription(data.description)}</p>}
         </section>
       )}
     </div>

--- a/frontend/src/pages/HomePage.css
+++ b/frontend/src/pages/HomePage.css
@@ -1,6 +1,8 @@
 /* F02 메인 — 서비스 소개, 추천 여행지, 로컬 전문가 */
 
 .f02 {
+  position: relative;
+  overflow: hidden;
   width: 100%;
   max-width: 1080px;
   margin: 0 auto;
@@ -8,12 +10,98 @@
   box-sizing: border-box;
 }
 
+.f02::before,
+.f02::after {
+  content: '';
+  position: absolute;
+  inset: -12% -8%;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.f02::before {
+  opacity: 0.55;
+  background-image:
+    radial-gradient(circle at 4% 2%, rgba(255, 202, 223, 0.95) 0 6px, transparent 7px),
+    radial-gradient(circle at 13% 19%, rgba(255, 232, 242, 0.95) 0 4px, transparent 5px),
+    radial-gradient(circle at 22% 6%, rgba(255, 196, 219, 0.94) 0 6px, transparent 7px),
+    radial-gradient(circle at 31% 17%, rgba(255, 226, 238, 0.92) 0 4px, transparent 5px),
+    radial-gradient(circle at 40% 5%, rgba(255, 201, 222, 0.94) 0 6px, transparent 7px),
+    radial-gradient(circle at 49% 21%, rgba(255, 235, 244, 0.95) 0 4px, transparent 5px),
+    radial-gradient(circle at 58% 8%, rgba(255, 197, 220, 0.93) 0 6px, transparent 7px),
+    radial-gradient(circle at 67% 19%, rgba(255, 229, 240, 0.94) 0 4px, transparent 5px),
+    radial-gradient(circle at 76% 6%, rgba(255, 199, 221, 0.93) 0 6px, transparent 7px),
+    radial-gradient(circle at 85% 22%, rgba(255, 236, 245, 0.96) 0 4px, transparent 5px),
+    radial-gradient(circle at 94% 9%, rgba(255, 203, 224, 0.94) 0 6px, transparent 7px);
+  animation: f02-bg-petal-fall 12s linear infinite;
+}
+
+.f02::after {
+  opacity: 0.42;
+  background-image:
+    radial-gradient(circle at 8% 11%, rgba(255, 237, 245, 0.95) 0 3px, transparent 4px),
+    radial-gradient(circle at 18% 4%, rgba(255, 209, 227, 0.9) 0 5px, transparent 6px),
+    radial-gradient(circle at 29% 15%, rgba(255, 241, 247, 0.95) 0 3px, transparent 4px),
+    radial-gradient(circle at 39% 3%, rgba(255, 211, 228, 0.9) 0 5px, transparent 6px),
+    radial-gradient(circle at 51% 14%, rgba(255, 239, 246, 0.95) 0 3px, transparent 4px),
+    radial-gradient(circle at 61% 5%, rgba(255, 210, 227, 0.9) 0 5px, transparent 6px),
+    radial-gradient(circle at 72% 16%, rgba(255, 241, 247, 0.95) 0 3px, transparent 4px),
+    radial-gradient(circle at 83% 4%, rgba(255, 210, 227, 0.9) 0 5px, transparent 6px),
+    radial-gradient(circle at 95% 15%, rgba(255, 239, 246, 0.95) 0 3px, transparent 4px);
+  animation: f02-bg-petal-fall-alt 16s linear infinite;
+}
+
+.f02 > * {
+  position: relative;
+  z-index: 1;
+}
+
 .f02-hero {
-  background: linear-gradient(165deg, #3a3d44 0%, #2c2f35 100%);
+  position: relative;
+  overflow: hidden;
+  background: linear-gradient(165deg, #ffeef5 0%, #f8dce7 56%, #fff6fa 100%);
   border-radius: 20px;
   padding: clamp(1.25rem, 4vw, 2rem);
   margin-bottom: clamp(1.75rem, 4vw, 2.5rem);
-  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.12);
+  box-shadow: 0 16px 34px rgba(186, 113, 147, 0.2);
+}
+
+.f02-hero::before {
+  content: '';
+  position: absolute;
+  inset: -20% -8%;
+  pointer-events: none;
+  opacity: 0.72;
+  background-image:
+    radial-gradient(circle at 6% 8%, rgba(255, 214, 230, 0.85) 0 6px, transparent 7px),
+    radial-gradient(circle at 18% 22%, rgba(255, 237, 245, 0.85) 0 4px, transparent 5px),
+    radial-gradient(circle at 31% 12%, rgba(255, 209, 225, 0.8) 0 5px, transparent 6px),
+    radial-gradient(circle at 48% 7%, rgba(255, 231, 240, 0.84) 0 4px, transparent 5px),
+    radial-gradient(circle at 63% 19%, rgba(255, 214, 230, 0.8) 0 6px, transparent 7px),
+    radial-gradient(circle at 77% 10%, rgba(255, 236, 245, 0.85) 0 5px, transparent 6px),
+    radial-gradient(circle at 89% 24%, rgba(255, 211, 227, 0.82) 0 4px, transparent 5px);
+  animation: f02-petal-fall 9.5s linear infinite;
+}
+
+.f02-hero::after {
+  content: '';
+  position: absolute;
+  left: -1rem;
+  right: -1rem;
+  bottom: -1rem;
+  height: 4.1rem;
+  pointer-events: none;
+  border-radius: 0 0 18px 18px;
+  background:
+    radial-gradient(ellipse at 7% 70%, rgba(255, 214, 230, 0.8) 0 24%, transparent 27%),
+    radial-gradient(ellipse at 21% 65%, rgba(255, 228, 238, 0.9) 0 21%, transparent 24%),
+    radial-gradient(ellipse at 36% 74%, rgba(255, 206, 223, 0.78) 0 27%, transparent 30%),
+    radial-gradient(ellipse at 52% 67%, rgba(255, 230, 240, 0.92) 0 24%, transparent 27%),
+    radial-gradient(ellipse at 68% 72%, rgba(255, 214, 230, 0.86) 0 26%, transparent 29%),
+    radial-gradient(ellipse at 82% 66%, rgba(255, 232, 241, 0.92) 0 21%, transparent 24%),
+    radial-gradient(ellipse at 94% 73%, rgba(255, 205, 224, 0.78) 0 26%, transparent 29%);
+  filter: blur(0.2px);
+  opacity: 0.95;
 }
 
 .f02-hero-inner {
@@ -69,16 +157,20 @@
   justify-content: center;
   padding: 0.65rem 1.2rem;
   border-radius: 999px;
-  background: #1f2328;
-  color: #fff !important;
+  background: linear-gradient(135deg, #f7bfd4 0%, #eaa6c2 100%);
+  color: #6c3f57 !important;
+  border: 1px solid #efbfd0;
   font-size: 0.88rem;
   font-weight: 700;
   text-decoration: none;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18);
+  box-shadow: 0 6px 16px rgba(186, 113, 147, 0.24);
+  transition: transform 0.18s ease, filter 0.18s ease, box-shadow 0.18s ease;
 }
 
 .f02-cta:hover {
-  background: #111418;
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px rgba(186, 113, 147, 0.3);
+  filter: brightness(0.98);
 }
 
 .f02-hero-visual {
@@ -343,4 +435,31 @@
 .f02-err {
   color: #b91c1c;
   font-size: 0.88rem;
+}
+
+@keyframes f02-petal-fall {
+  0% {
+    transform: translateY(-8%) translateX(0);
+  }
+  100% {
+    transform: translateY(28%) translateX(-2.2%);
+  }
+}
+
+@keyframes f02-bg-petal-fall {
+  0% {
+    transform: translateY(-9%) translateX(0);
+  }
+  100% {
+    transform: translateY(31%) translateX(-2.4%);
+  }
+}
+
+@keyframes f02-bg-petal-fall-alt {
+  0% {
+    transform: translateY(-12%) translateX(1.6%);
+  }
+  100% {
+    transform: translateY(36%) translateX(-1.4%);
+  }
 }

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -166,7 +166,7 @@ export function HomePage() {
                     <div className="f02-expert-top">
                       <div className="f02-expert-avatar" style={g.profileImage ? { backgroundImage: `url(${g.profileImage})` } : undefined} />
                       <div className="f02-expert-meta">
-                        <p className="f02-expert-rating">⭐ {rating}</p>
+                        <p className="f02-expert-rating">🌟 {rating}</p>
                         <strong className="f02-expert-name">{g.nickname ?? '가이드'}</strong>
                         <span className="f02-expert-region">{g.region ?? '지역 미등록'}</span>
                       </div>

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Link, useLocation, useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 
 import { beginGoogleOAuth } from '../api/client'
 import { useAuth } from '../context/useAuth.js'
@@ -77,7 +77,6 @@ export function LoginPage() {
   return (
     <div className="form-page">
       <h1>로그인</h1>
-      <p className="form-hint">F01-02 · 이메일 / 비밀번호 (백엔드 JWT)</p>
 
       {flash && (
         <div className="form-success" style={{ marginBottom: '1rem' }}>
@@ -86,13 +85,26 @@ export function LoginPage() {
       )}
 
       <form className="form-card" onSubmit={(e) => void handleSubmit(e)}>
-        <label className="field">
-          <span>로그인 유형</span>
-          <select value={role} onChange={(ev) => setRole(ev.target.value)}>
-            <option value="GUEST">여행자 (GUEST)</option>
-            <option value="GUIDE">가이드 (GUIDE)</option>
-          </select>
-        </label>
+        <div className="form-role-switch" role="tablist" aria-label="로그인 유형">
+          <button
+            type="button"
+            className={`form-role-btn${role === 'GUEST' ? ' is-on' : ''}`}
+            onClick={() => setRole('GUEST')}
+            role="tab"
+            aria-selected={role === 'GUEST'}
+          >
+            여행자
+          </button>
+          <button
+            type="button"
+            className={`form-role-btn${role === 'GUIDE' ? ' is-on' : ''}`}
+            onClick={() => setRole('GUIDE')}
+            role="tab"
+            aria-selected={role === 'GUIDE'}
+          >
+            가이드
+          </button>
+        </div>
         <label className="field">
           <span>이메일</span>
           <input
@@ -114,28 +126,26 @@ export function LoginPage() {
           />
         </label>
 
+        <div className="form-social form-social--inside">
+          <button
+            type="button"
+            className="submit ghost form-google-login"
+            onClick={() => beginGoogleOAuth(role, returnTo)}
+            title="Google OAuth2 로그인"
+          >
+            <span className="form-google-login__icon" aria-hidden="true">
+              G
+            </span>
+            <span>구글로 로그인</span>
+          </button>
+        </div>
+
         {error && <p className="form-error">{error}</p>}
 
-        <button type="submit" className="submit" disabled={loading}>
+        <button type="submit" className="submit form-login-submit" disabled={loading}>
           {loading ? '처리 중…' : '로그인'}
         </button>
       </form>
-
-      <div className="form-social">
-        <p>소셜 로그인</p>
-        <button
-          type="button"
-          className="submit ghost"
-          onClick={() => beginGoogleOAuth(role, returnTo)}
-          title="Google OAuth2 로그인"
-        >
-          Google 로그인
-        </button>
-      </div>
-
-      <p className="form-footer">
-        계정이 없나요? <Link to="/auth/signup">회원가입</Link>
-      </p>
 
       {roleMismatch && (
         <div

--- a/frontend/src/pages/MypageMemberPages.css
+++ b/frontend/src/pages/MypageMemberPages.css
@@ -61,15 +61,15 @@
   font: inherit;
   font-weight: 600;
   font-size: 0.86rem;
-  color: #6b7280;
+  color: #8d7890;
   cursor: pointer;
   border-bottom: 2px solid transparent;
   margin-bottom: -1px;
 }
 
 .mp-tabs button.is-on {
-  color: #1f2328;
-  border-bottom-color: #1f2328;
+  color: #5a3c56;
+  border-bottom-color: #d17a9b;
 }
 
 .mp-cards {
@@ -99,6 +99,10 @@
 
 .mp-trip-card--past {
   border-left-color: #cbd5e1;
+}
+
+.mp-trip-card--scrap {
+  grid-template-columns: 1fr;
 }
 
 .mp-trip-card__meta {
@@ -145,18 +149,55 @@
   line-height: 1.5;
 }
 
+.mp-route {
+  margin-top: 0.25rem;
+  padding-top: 0.35rem;
+  border-top: 1px dashed #e5e7eb;
+}
+
+.mp-route-title {
+  margin: 0 0 0.3rem;
+  font-size: 0.78rem;
+  font-weight: 800;
+  color: #1f2937;
+}
+
+.mp-route-list {
+  margin: 0;
+  padding-left: 1.05rem;
+  display: grid;
+  gap: 0.18rem;
+}
+
+.mp-route-list li {
+  font-size: 0.8rem;
+  color: #374151;
+  line-height: 1.45;
+}
+
+.mp-review-done {
+  margin: 0;
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: #2563eb;
+}
+
 .mp-trip-actions {
   display: flex;
   flex-direction: column;
   gap: 0.45rem;
 }
 
+.mp-trip-actions--under-route {
+  margin-top: 0.55rem;
+}
+
 .mp-btn {
   padding: 0.45rem 0.85rem;
   border-radius: 999px;
   border: none;
-  background: #1f2328;
-  color: #fff;
+  background: #f6d8e6;
+  color: #6d3f58;
   font-weight: 700;
   font-size: 0.8rem;
   cursor: pointer;
@@ -170,15 +211,93 @@
 }
 
 .mp-btn--line {
-  background: #fff;
-  color: #374151;
-  border: 1px solid #d1d5db;
+  background: #fff8fb;
+  color: #7a5f78;
+  border: 1px solid #efbfd0;
+}
+
+.mp-back-chip {
+  border: 1px solid rgba(232, 184, 203, 0.7);
+  background: linear-gradient(180deg, rgba(255, 246, 251, 0.92), rgba(255, 255, 255, 0.9));
+  color: #6b4a5a;
+  font-weight: 800;
+  font-size: 0.86rem;
+  padding: 0.55rem 0.8rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  cursor: pointer;
+  box-shadow: 0 8px 18px rgba(143, 70, 100, 0.08);
+  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+}
+
+.mp-back-chip:hover {
+  transform: translateY(-1px);
+  border-color: rgba(232, 184, 203, 0.95);
+  box-shadow: 0 10px 22px rgba(143, 70, 100, 0.11);
+}
+
+.mp-back-chip:active {
+  transform: translateY(0);
+}
+
+.mp-back-chip:focus-visible {
+  outline: 2px solid rgba(247, 170, 204, 0.9);
+  outline-offset: 2px;
+}
+
+.mp-back-chip__icon {
+  width: 1.55rem;
+  height: 1.55rem;
+  border-radius: 999px;
+  background: rgba(255, 225, 238, 0.85);
+  border: 1px solid rgba(232, 184, 203, 0.8);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #8f4664;
+  font-size: 0.95rem;
+  line-height: 1;
+}
+
+.mp-guide-link {
+  color: #8f4664;
+  font-weight: 900;
+  text-decoration: none;
+  border-bottom: 1px dashed rgba(143, 70, 100, 0.35);
+  padding-bottom: 1px;
+}
+
+.mp-guide-link:hover {
+  border-bottom-color: rgba(143, 70, 100, 0.7);
+}
+
+.mp-review-scrap-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.38rem 0.72rem;
+  border-radius: 999px;
+  border: 1px solid #efbfd0;
+  background: linear-gradient(180deg, #fff6fb, #fff);
+  color: #8f4664;
+  font-size: 0.76rem;
+  font-weight: 800;
+  text-decoration: none;
+  box-shadow: 0 5px 12px rgba(143, 70, 100, 0.08);
+  transition: transform 0.14s ease, box-shadow 0.14s ease;
+}
+
+.mp-review-scrap-link:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 16px rgba(143, 70, 100, 0.12);
 }
 
 .mp-btn--danger {
-  background: #fff;
-  color: #ef4444;
-  border: 1px solid #fca5a5;
+  background: #fff4f8;
+  color: #b45e83;
+  border: 1px solid #efbfd0;
 }
 
 .mp-thumb {
@@ -235,10 +354,133 @@ button.mp-thumb--match:focus-visible {
   color: #6b7280;
 }
 
+.mp-scrap-empty {
+  border: 1px dashed #efbfd0;
+  background: linear-gradient(180deg, #fff9fc, #fffdfd);
+  border-radius: 14px;
+}
+
+.mp-scrap-empty .page-state-empty-title {
+  color: #7a4f68;
+  font-weight: 800;
+}
+
+.mp-scrap-empty .page-state-empty-body {
+  color: #8e7a8d;
+}
+
 .mp-gallery {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
   gap: 0.75rem;
+}
+
+.mp-scrap-ticket {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 7.2rem;
+  gap: 0;
+  border: 1px solid #e8eaed;
+  border-radius: 16px;
+  background: #fff;
+  overflow: hidden;
+  box-shadow: 0 2px 10px rgba(31, 35, 40, 0.05);
+}
+
+.mp-scrap-ticket-left {
+  padding: 0.95rem 1rem;
+}
+
+.mp-scrap-ticket-right {
+  border: none;
+  border-left: 2px dashed #e8b8cb;
+  padding: 0;
+  font: inherit;
+  appearance: none;
+  cursor: pointer;
+  background: linear-gradient(180deg, #fff1f7, #f9dce8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  transform-origin: center left;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.mp-scrap-ticket-right:hover:not(:disabled) {
+  background: linear-gradient(180deg, #ffe8f2, #f4cde0);
+  border-left-color: #e8a8bf;
+}
+
+.mp-scrap-ticket-right.is-tearing {
+  animation: mpTicketStubTear 0.42s cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+  pointer-events: none;
+}
+
+@keyframes mpTicketStubTear {
+  0% {
+    opacity: 1;
+    transform: translateY(0) rotate(0deg);
+    filter: none;
+  }
+  70% {
+    opacity: 0.9;
+    transform: translateY(-22px) rotate(-7deg);
+    filter: drop-shadow(0 10px 14px rgba(0, 0, 0, 0.14));
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-68px) rotate(-13deg);
+    filter: drop-shadow(0 14px 24px rgba(0, 0, 0, 0.2));
+  }
+}
+
+.mp-scrap-ticket-right::before,
+.mp-scrap-ticket-right::after {
+  content: '';
+  position: absolute;
+  left: -9px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+}
+
+.mp-scrap-ticket-right::before {
+  top: -9px;
+}
+
+.mp-scrap-ticket-right::after {
+  bottom: -9px;
+}
+
+.mp-ticket-tear-zone:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.mp-ticket-tear-zone-label {
+  border: 1px solid transparent;
+  background: transparent;
+  color: #8f4664;
+  font-weight: 800;
+  font-size: 0.92rem;
+  border-radius: 999px;
+  padding: 0.62rem 1.1rem;
+  letter-spacing: -0.01em;
+}
+
+.mp-ticket-tear-zone:hover:not(:disabled) .mp-ticket-tear-zone-label {
+  background: transparent;
+  border-color: transparent;
+}
+
+.mp-scrap-detail {
+  margin-top: 0.75rem;
+  border: 1px solid #e8eaed;
+  border-radius: 16px;
+  background: #fff;
+  padding: 1rem 1.05rem;
 }
 
 .mp-polaroid {
@@ -299,6 +541,38 @@ button.mp-thumb--match:focus-visible {
   .mp-pay-cards {
     display: flex;
   }
+
+  .mp-scrap-ticket {
+    grid-template-columns: 1fr;
+  }
+
+  .mp-scrap-ticket-right {
+    border-left: none;
+    border-top: 2px dashed #e8b8cb;
+    padding: 0.55rem;
+  }
+
+  .mp-scrap-ticket-right::before,
+  .mp-scrap-ticket-right::after {
+    display: none;
+  }
+
+  .mp-ticket-tear-zone-label {
+    padding: 0.5rem 0.95rem;
+  }
+}
+
+.mp-course-full {
+  margin: 0;
+  padding: 0.75rem 0.85rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  background: #f9fafb;
+  color: #374151;
+  font-size: 0.82rem;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .mp-pay-card {
@@ -507,4 +781,125 @@ button.mp-thumb--match:focus-visible {
   border: 1px solid #e5e7eb;
   font: inherit;
   box-sizing: border-box;
+}
+
+.mp-review-modal {
+  position: relative;
+  max-width: 30rem;
+  border-radius: 22px;
+  padding: 1.8rem 1.1rem 1rem;
+  max-height: min(88vh, 44rem);
+  overflow: visible;
+}
+
+.mp-review-tape {
+  position: absolute;
+  top: -0.95rem;
+  left: 50%;
+  width: 4.2rem;
+  height: 1.75rem;
+  margin-left: -2.1rem;
+  background: rgba(250, 204, 221, 0.9);
+  transform: rotate(3deg);
+  border-radius: 0.2rem;
+}
+
+.mp-review-close {
+  position: absolute;
+  top: 0.55rem;
+  right: 0.7rem;
+  border: none;
+  background: none;
+  color: #9ca3af;
+  font-size: 2rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.mp-review-title {
+  margin: 0.6rem 0 0;
+  text-align: center;
+  font-size: 1.15rem;
+  font-weight: 900;
+  color: #111827;
+}
+
+.mp-review-sub {
+  margin: 0.35rem 0 0;
+  text-align: center;
+  font-size: 0.8rem;
+  color: #9ca3af;
+}
+
+.mp-review-stars {
+  margin-top: 0.6rem;
+  display: flex;
+  justify-content: center;
+  gap: 0.22rem;
+}
+
+.mp-review-star {
+  border: none;
+  background: none;
+  color: #d1d5db;
+  font-size: 2.15rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+}
+
+.mp-review-star.is-on {
+  color: #ef4444;
+}
+
+.mp-review-rating-label {
+  margin: 0.35rem 0 0;
+  text-align: center;
+  color: #ef4444;
+  font-size: 0.86rem;
+  font-weight: 800;
+}
+
+.mp-review-textarea {
+  margin-top: 0.7rem;
+  border-radius: 14px;
+  border-color: #e5e7eb;
+  background: #f9fafb;
+  color: #374151;
+  padding: 0.75rem 0.85rem;
+  line-height: 1.55;
+  min-height: 8.5rem;
+}
+
+.mp-review-upload-row {
+  margin-top: 0.65rem;
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+}
+
+.mp-review-upload-note {
+  font-size: 0.8rem;
+  color: #9ca3af;
+}
+
+.mp-review-submit {
+  width: 100%;
+  border-radius: 12px;
+  padding: 0.7rem 1rem;
+  font-size: 1rem;
+  font-weight: 900;
+}
+
+.mp-review-open-btn {
+  background: #fdeaf1;
+  color: #8f4664;
+  border: 1px solid #efbfd0;
+  padding: 0.58rem 1.05rem;
+}
+
+.mp-review-open-btn:hover {
+  transform: translateY(-1px);
+  background: #f8dce7;
+  border-color: #e8a8bf;
 }

--- a/frontend/src/pages/MypagePaymentsPage.jsx
+++ b/frontend/src/pages/MypagePaymentsPage.jsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useLocation } from 'react-router-dom'
 
-import { MypageDevHint } from '../components/MypageDevHint.jsx'
 import { PaymentDetailPanel } from '../components/PaymentDetailPanel.jsx'
 import { PageEmpty, PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client.js'
@@ -117,10 +116,6 @@ export function MypagePaymentsPage() {
     <div className="mp-member">
       <h1>💳 나의 결제 내역</h1>
       <p className="sub">결제·환불 상태를 확인하고, 영수증 상세를 열어 볼 수 있어요.</p>
-      <MypageDevHint>
-        목록 <code>GET /api/matching/payments/guest/list</code> · 상세{' '}
-        <code>GET /api/matching/payments/&#123;paymentId&#125;</code>
-      </MypageDevHint>
       {routeHint && (
         <p
           className="sub"

--- a/frontend/src/pages/MypagePrivacyPage.css
+++ b/frontend/src/pages/MypagePrivacyPage.css
@@ -183,6 +183,13 @@
   border: 1px solid #e8eaed;
 }
 
+.mp-privacy-dna-summary {
+  margin: -0.2rem 0 0.7rem;
+  font-size: 0.82rem;
+  color: #7a6b7b;
+  line-height: 1.5;
+}
+
 .mp-privacy-tags {
   display: flex;
   flex-wrap: wrap;
@@ -279,13 +286,20 @@
 .mp-privacy-add-row button {
   padding: 0.45rem 0.75rem;
   border-radius: 8px;
-  border: none;
-  background: #ec4899;
-  color: #fff;
+  border: 1px solid #efbfd0;
+  background: #f6d8e6;
+  color: #6d3f58;
   font-weight: 700;
   font-size: 0.78rem;
   cursor: pointer;
   font-family: inherit;
+  transition: background-color 0.18s ease, border-color 0.18s ease, transform 0.18s ease;
+}
+
+.mp-privacy-add-row button:hover:not(:disabled) {
+  background: #f2cddd;
+  border-color: #e8a8bf;
+  transform: translateY(-1px);
 }
 
 .mp-privacy-add-row button:disabled {
@@ -302,13 +316,20 @@
 .mp-privacy-save {
   padding: 0.6rem 1.35rem;
   border-radius: 999px;
-  border: none;
-  background: #1f2328;
-  color: #fff;
+  border: 1px solid #efbfd0;
+  background: #f6d8e6;
+  color: #6d3f58;
   font-weight: 700;
   font-size: 0.88rem;
   cursor: pointer;
   font-family: inherit;
+  transition: background-color 0.18s ease, border-color 0.18s ease, transform 0.18s ease;
+}
+
+.mp-privacy-save:hover:not(:disabled) {
+  background: #f2cddd;
+  border-color: #e8a8bf;
+  transform: translateY(-1px);
 }
 
 .mp-privacy-save:disabled {

--- a/frontend/src/pages/MypagePrivacyPage.jsx
+++ b/frontend/src/pages/MypagePrivacyPage.jsx
@@ -1,10 +1,10 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
-import { MypageDevHint } from '../components/MypageDevHint.jsx'
 import { apiRequest } from '../api/client.js'
 import { useAuth } from '../context/useAuth.js'
 import { loadGuestPrivacyForm, persistGuestPrivacyForm } from '../lib/guestMypagePrefs.js'
+import { buildTravelDnaPreview, loadTravelDna } from '../lib/travelDna.js'
 
 import './MypageMemberPages.css'
 import './MypagePrivacyPage.css'
@@ -40,6 +40,8 @@ export function MypagePrivacyPage() {
     setGuideMessageNotify(f.guideMessageNotify)
     setTags(f.tags)
   }, [email])
+
+  const dnaSummary = useMemo(() => buildTravelDnaPreview(loadTravelDna()), [])
 
   const handleSave = () => {
     setSaving(true)
@@ -95,12 +97,7 @@ export function MypagePrivacyPage() {
       <h1 className="mp-privacy-title">
         회원 정보 및 여행 설정 <span aria-hidden>⚙️</span>
       </h1>
-      <p className="mp-privacy-hint">
-        회원 닉네임·알림·여행 성향은 전용 서버 연동 전까지 이 브라우저에만 저장됩니다.
-      </p>
-      <MypageDevHint className="mp-privacy-hint">
-        백엔드에 <code>PATCH /members/me</code> 등이 추가되면 연동 예정입니다.
-      </MypageDevHint>
+      <p className="mp-privacy-hint">여행 성향 태그를 관리하고 알림 설정을 조정할 수 있어요.</p>
       {savedFlash && <p className="mp-privacy-banner">설정이 저장되었습니다.</p>}
 
       <section className="mp-privacy-section">
@@ -155,6 +152,9 @@ export function MypagePrivacyPage() {
 
       <section className="mp-privacy-section">
         <h2>나의 여행 성향 관리</h2>
+        <p className="mp-privacy-dna-summary">
+          {dnaSummary || '선택한 태그를 기반으로 나의 여행 성향이 요약됩니다.'}
+        </p>
         <div className="mp-privacy-tags-wrap">
           <div className="mp-privacy-tags">
             {tags.map((t) => (
@@ -213,9 +213,6 @@ export function MypagePrivacyPage() {
         <p className="mp-privacy-danger-hint">
           탈퇴 시 서비스 이용이 종료되며 복구가 어려울 수 있습니다. 로컬에만 있는 닉네임·알림 설정도 더 이상 쓰이지 않습니다.
         </p>
-        <MypageDevHint className="mp-privacy-hint">
-          API: <code>DELETE /api/members/me?role=GUEST</code>
-        </MypageDevHint>
         {withdrawErr && <p className="err">{withdrawErr}</p>}
         <button type="button" className="mp-btn mp-btn--danger" disabled={withdrawBusy} onClick={() => void onWithdraw()}>
           {withdrawBusy ? '처리 중…' : '회원 탈퇴'}

--- a/frontend/src/pages/MypageProfilePage.jsx
+++ b/frontend/src/pages/MypageProfilePage.jsx
@@ -3,8 +3,9 @@ import { Link } from 'react-router-dom'
 
 import { MypageDevHint } from '../components/MypageDevHint.jsx'
 import { useAuth } from '../context/useAuth.js'
-import { getGuestDisplayName, loadGuestPrivacyForm } from '../lib/guestMypagePrefs.js'
+import { getGuestDisplayName, loadGuestPrivacyForm, loadTravelTags } from '../lib/guestMypagePrefs.js'
 import { getEmailFromToken, getRoleFromToken, parseJwtPayload } from '../lib/jwt.js'
+import { buildTravelDnaPreview, loadTravelDna } from '../lib/travelDna.js'
 
 import './MypageMemberPages.css'
 
@@ -16,21 +17,21 @@ export function MypageProfilePage() {
   const jwtRole = useMemo(() => (token ? getRoleFromToken(token) : null), [token])
 
   const [nickname, setNickname] = useState('')
+  const [travelTags, setTravelTags] = useState([])
 
   useEffect(() => {
     const f = loadGuestPrivacyForm(email)
     setNickname(f.nickname ?? '')
+    setTravelTags(loadTravelTags())
   }, [email])
 
   const displayName = useMemo(() => getGuestDisplayName(email), [email, nickname])
+  const travelDnaPreview = useMemo(() => buildTravelDnaPreview(loadTravelDna()), [])
 
   return (
     <div className="mp-member">
       <h1>👤 프로필</h1>
-      <p className="sub">
-        계정 이메일·역할은 로그인 토큰 기준이며, 표시 이름 등은 <strong>개인정보 설정(/mypage/privacy)</strong>에 저장한 값을
-        함께 씁니다. 서버에 게스트 프로필이 없을 때 닉네임·알림 설정은 <strong>이 브라우저(로컬)에만</strong> 남습니다.
-      </p>
+      <p className="sub">내 계정 정보와 여행 성향 태그를 확인할 수 있어요.</p>
       <MypageDevHint>
         회원 API: <code>POST /members/join</code>, <code>DELETE /members/me?role=...</code> · 표시는 JWT + 로컬 prefs
       </MypageDevHint>
@@ -69,6 +70,36 @@ export function MypageProfilePage() {
             </Link>
           </div>
         </article>
+      </div>
+
+      <h2 style={{ margin: '1.1rem 0 0.75rem', fontSize: '0.95rem', fontWeight: 800 }}>내 여행 성향 태그</h2>
+      <div className="mp-scrap-hero" style={{ marginBottom: '0.75rem' }}>
+        {travelTags.length > 0 ? (
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.45rem' }}>
+            {travelTags.map((tag) => (
+              <span
+                key={tag}
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  border: '1px solid #efbfd0',
+                  borderRadius: '999px',
+                  padding: '0.22rem 0.58rem',
+                  background: '#fff7fb',
+                  color: '#7a4f68',
+                  fontSize: '0.8rem',
+                  fontWeight: 600,
+                }}
+              >
+                #{tag}
+              </span>
+            ))}
+          </div>
+        ) : (
+          <p style={{ margin: 0, color: '#5f5266', lineHeight: 1.55 }}>
+            {travelDnaPreview || '아직 저장된 여행 성향이 없습니다.'}
+          </p>
+        )}
       </div>
     </div>
   )

--- a/frontend/src/pages/MypageReviewsPage.jsx
+++ b/frontend/src/pages/MypageReviewsPage.jsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 
-import { MypageDevHint } from '../components/MypageDevHint.jsx'
 import { PageEmpty, PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client.js'
 
@@ -18,7 +17,7 @@ function formatDt(iso) {
 
 function stars(rating) {
   const n = Math.max(1, Math.min(5, Math.round(Number(rating ?? 0))))
-  return '★'.repeat(n)
+  return '🌟'.repeat(n)
 }
 
 function parseApiErrorMessage(text) {
@@ -86,14 +85,11 @@ export function MypageReviewsPage() {
 
   return (
     <div className="mp-member">
-      <h1>⭐ 내 리뷰</h1>
+      <h1>🌟 내 리뷰</h1>
       <p className="sub">
         내가 작성한 리뷰만 모아 보여 줍니다. 팀 정책상 <strong>작성 후 수정은 불가</strong>이며, 잘못 올린 경우{' '}
-        <strong>삭제</strong>만 가능합니다. 후기는 <strong>완료된 매칭(COMPLETED)</strong>에서만 작성할 수 있어요.
+        <strong>삭제</strong>만 가능합니다. 후기는 <strong>나의 여행 기록(스크랩북)</strong>에서만 작성할 수 있어요.
       </p>
-      <MypageDevHint>
-        <code>GET /reviews/me</code> (로그인 필요)
-      </MypageDevHint>
 
       {actionErr && <p className="err">{actionErr}</p>}
       {loading && <PageLoading />}
@@ -101,7 +97,7 @@ export function MypageReviewsPage() {
 
       {!loading && !error && rows.length === 0 && (
         <PageEmpty title="작성한 리뷰가 없습니다">
-          가이드 매칭이 <strong>완료(COMPLETED)</strong>된 뒤 매칭·결제 화면에서 후기를 남기면 여기에 표시됩니다.
+          나의 여행 기록(스크랩북)에서 후기를 남기면 여기에 표시됩니다.
         </PageEmpty>
       )}
 
@@ -118,20 +114,14 @@ export function MypageReviewsPage() {
                 </p>
                 <p className="mp-trip-detail" style={{ fontSize: '0.8rem', color: '#6b7280' }}>
                   작성: {formatDt(r.createdAt)}
-                  {r.guideId != null ? (
-                    <>
-                      {' · '}
-                      <Link to={`/guides/${r.guideId}`}>가이드 프로필</Link>
-                      {' · '}
-                      <Link
-                        to={`/guides/${r.guideId}/match`}
-                        state={r.matchRequestId != null ? { requestId: r.matchRequestId } : undefined}
-                      >
-                        매칭·결제
-                      </Link>
-                    </>
-                  ) : null}
                 </p>
+                {r.matchRequestId != null ? (
+                  <p className="mp-trip-detail" style={{ marginTop: '0.25rem' }}>
+                    <Link to={`/mypage/scrapbook/${r.matchRequestId}`} className="mp-review-scrap-link">
+                      작성한 스크랩북으로 이동
+                    </Link>
+                  </p>
+                ) : null}
               </div>
               <div className="mp-trip-actions" style={{ alignSelf: 'stretch' }}>
                 <button
@@ -148,7 +138,7 @@ export function MypageReviewsPage() {
         </div>
       ) : null}
 
-      {!error && (
+      {!error && rows.length > 0 && (!first || !last) && (
         <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1rem', flexWrap: 'wrap' }}>
           <button type="button" className="mp-btn mp-btn--line" disabled={first || loading} onClick={() => setPage((p) => Math.max(0, p - 1))}>
             이전

--- a/frontend/src/pages/MypageScrapbookDetailPage.jsx
+++ b/frontend/src/pages/MypageScrapbookDetailPage.jsx
@@ -1,0 +1,314 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { PageError, PageLoading } from '../components/PageStates.jsx'
+import { apiRequest } from '../api/client.js'
+import { fetchGuestMatchRequests } from '../lib/matchingGuest.js'
+
+import './MypageMemberPages.css'
+
+function parseApiErrorMessage(text) {
+  if (!text) return '요청 실패'
+  try {
+    const j = JSON.parse(text)
+    return (j.message ?? text) || '요청 실패'
+  } catch {
+    return text || '요청 실패'
+  }
+}
+
+function parseRouteStops(proposedSchedule) {
+  const raw = String(proposedSchedule ?? '').trim()
+  if (!raw) return []
+  return raw
+    .split(/->|→|\r?\n|,/g)
+    .map((s) => s.trim())
+    .filter(Boolean)
+}
+
+async function fetchMyReviewMap() {
+  const map = {}
+  let page = 0
+  while (page < 20) {
+    const res = await apiRequest(`/reviews/me?page=${page}&size=50`, { method: 'GET' })
+    const text = await res.text()
+    if (!res.ok) throw new Error(parseApiErrorMessage(text))
+    const data = text ? JSON.parse(text) : {}
+    const content = Array.isArray(data.content) ? data.content : []
+    for (const row of content) {
+      const key = Number(row?.matchRequestId)
+      if (!Number.isNaN(key) && map[key] == null) map[key] = row
+    }
+    if (data.last === true) break
+    page += 1
+  }
+  return map
+}
+
+async function loadGuideNickname(guideId) {
+  if (!guideId) return '가이드'
+  try {
+    const res = await apiRequest(`/guides/${guideId}`, { method: 'GET', skipAuth: true })
+    const text = await res.text()
+    if (!res.ok || !text) return `가이드 #${guideId}`
+    const p = JSON.parse(text)
+    return p.nickname ?? `가이드 #${guideId}`
+  } catch {
+    return `가이드 #${guideId}`
+  }
+}
+
+export function MypageScrapbookDetailPage() {
+  const { requestId } = useParams()
+  const navigate = useNavigate()
+  const [row, setRow] = useState(null)
+  const [guideName, setGuideName] = useState('가이드')
+  const [reviewByMatch, setReviewByMatch] = useState({})
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [reviewModal, setReviewModal] = useState(false)
+  const [autoOpened, setAutoOpened] = useState(false)
+  const [rating, setRating] = useState(5)
+  const [content, setContent] = useState('')
+  const [reviewBusy, setReviewBusy] = useState(false)
+  const [reviewError, setReviewError] = useState('')
+  const [reviewPhotos, setReviewPhotos] = useState([])
+  const reviewFileInputRef = useRef(null)
+
+  const load = useCallback(async () => {
+    const rid = Number(requestId)
+    if (!Number.isFinite(rid)) throw new Error('잘못된 여행 기록 ID입니다.')
+    const [all, reviews] = await Promise.all([
+      fetchGuestMatchRequests(apiRequest),
+      fetchMyReviewMap().catch(() => ({})),
+    ])
+    const found = (Array.isArray(all) ? all : []).find((r) => Number(r.requestId) === rid)
+    if (!found) throw new Error('해당 여행 기록을 찾을 수 없습니다.')
+    setRow(found)
+    setReviewByMatch(reviews)
+    const nick = await loadGuideNickname(found.guideId)
+    setGuideName(nick)
+  }, [requestId])
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      setLoading(true)
+      setError('')
+      try {
+        await load()
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : '불러오기 실패')
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [load])
+
+  const routeStops = useMemo(() => parseRouteStops(row?.proposedSchedule), [row?.proposedSchedule])
+  const fullCourseText = String(row?.proposedSchedule ?? '').trim()
+  const hasReview = reviewByMatch[Number(row?.requestId)] != null
+  const ratingLabel = useMemo(() => {
+    const labels = {
+      5: '5점 - 최고의 여행이었어요!',
+      4: '4점 - 아주 좋았어요!',
+      3: '3점 - 만족스러웠어요!',
+      2: '2점 - 아쉬운 점이 있어요',
+      1: '1점 - 기대에 못 미쳤어요',
+    }
+    return labels[rating] ?? ''
+  }, [rating])
+
+  const submitReview = async () => {
+    if (!row) return
+    const trimmed = content.trim()
+    if (trimmed.length < 10) {
+      setReviewError('후기는 10자 이상 입력해 주세요.')
+      return
+    }
+    setReviewBusy(true)
+    setReviewError('')
+    try {
+      const res = await apiRequest('/reviews', {
+        method: 'POST',
+        json: {
+          guideId: Number(row.guideId),
+          matchRequestId: Number(row.requestId),
+          rating,
+          content: trimmed,
+        },
+      })
+      const text = await res.text()
+      if (!res.ok) {
+        setReviewError(parseApiErrorMessage(text))
+        return
+      }
+      setReviewModal(false)
+      setContent('')
+      setReviewPhotos([])
+      const reviews = await fetchMyReviewMap().catch(() => ({}))
+      setReviewByMatch(reviews)
+    } catch {
+      setReviewError('리뷰 등록 중 네트워크 오류가 발생했습니다.')
+    } finally {
+      setReviewBusy(false)
+    }
+  }
+
+  useEffect(() => {
+    if (!row || autoOpened) return
+    if (!hasReview) {
+      setReviewModal(true)
+    }
+    setAutoOpened(true)
+  }, [row, hasReview, autoOpened])
+
+  if (loading) return <PageLoading />
+  if (error) return <PageError message={error} onRetry={() => void load()} />
+  if (!row) return null
+
+  return (
+    <div className="mp-member">
+      <button type="button" className="mp-back-chip" onClick={() => navigate('/mypage/scrapbook')} aria-label="스크랩북으로 돌아가기">
+        <span className="mp-back-chip__icon" aria-hidden>
+          ←
+        </span>
+        스크랩북으로 돌아가기
+      </button>
+
+      <div className="mp-scrap-detail">
+        <p className="mp-dday">
+          {row.desiredDate} ·{' '}
+          {row.guideId != null ? (
+            <Link to={`/guides/${row.guideId}`} className="mp-guide-link">
+              {guideName}
+            </Link>
+          ) : (
+            guideName
+          )}
+        </p>
+        <h1>{row.destination}</h1>
+        <p className="sub">{row.conceptSummary ?? row.concept ?? '여행 컨셉 정보가 없습니다.'}</p>
+
+        <section className="mp-route">
+          <p className="mp-route-title">확정 루트</p>
+          {routeStops.length > 0 ? (
+            <ol className="mp-route-list">
+              {routeStops.map((spot, idx) => (
+                <li key={`${row.requestId}-${idx}`}>{spot}</li>
+              ))}
+            </ol>
+          ) : (
+            <p className="mp-trip-detail">등록된 확정 루트 정보가 없습니다.</p>
+          )}
+        </section>
+
+        {fullCourseText && (
+          <section className="mp-route">
+            <p className="mp-route-title">가이드가 공유한 상세 코스</p>
+            <pre className="mp-course-full">{fullCourseText}</pre>
+          </section>
+        )}
+
+        <div className="mp-trip-actions mp-trip-actions--under-route">
+          {hasReview ? (
+            <>
+              <p className="mp-review-done">후기 작성 완료</p>
+              <Link to="/mypage/reviews" className="mp-btn mp-btn--line">내 후기 보기</Link>
+            </>
+          ) : (
+            <button
+              type="button"
+              className="mp-btn"
+              onClick={() => {
+                setReviewError('')
+                setRating(5)
+                setContent('')
+                setReviewPhotos([])
+                setReviewModal(true)
+              }}
+            >
+              후기 작성
+            </button>
+          )}
+        </div>
+      </div>
+
+      {reviewModal && (
+        <div className="mp-modal-overlay" role="dialog" aria-modal="true" aria-label="후기 작성" onClick={() => !reviewBusy && setReviewModal(false)}>
+          <div className="mp-modal mp-review-modal" onClick={(e) => e.stopPropagation()}>
+            <button type="button" className="mp-review-close" aria-label="후기 모달 닫기" onClick={() => setReviewModal(false)} disabled={reviewBusy}>
+              ×
+            </button>
+            <div className="mp-review-tape" aria-hidden />
+            <h2 className="mp-review-title">투어는 어떠셨나요? ✨</h2>
+            <p className="mp-review-sub">
+              {row.destination} ·{' '}
+              {row.guideId != null ? (
+                <Link to={`/guides/${row.guideId}`} className="mp-guide-link">
+                  {guideName}
+                </Link>
+              ) : (
+                guideName
+              )}
+              과의 추억을 남겨주세요.
+            </p>
+
+            <div className="mp-review-stars" role="radiogroup" aria-label="별점 선택">
+              {[1, 2, 3, 4, 5].map((n) => (
+                <button
+                  key={n}
+                  type="button"
+                  className={`mp-review-star${n <= rating ? ' is-on' : ''}`}
+                  aria-label={`${n}점`}
+                  aria-checked={n === rating}
+                  role="radio"
+                  onClick={() => setRating(n)}
+                  disabled={reviewBusy}
+                >
+                  🌟
+                </button>
+              ))}
+            </div>
+            <p className="mp-review-rating-label">{ratingLabel}</p>
+
+            <textarea
+              className="mp-modal-text mp-review-textarea"
+              rows={6}
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              placeholder="좋았던 점, 아쉬운 점, 다시 가고 싶은 이유를 자유롭게 남겨주세요."
+              disabled={reviewBusy}
+            />
+
+            <div className="mp-review-upload-row">
+              <input
+                ref={reviewFileInputRef}
+                type="file"
+                accept="image/*"
+                multiple
+                style={{ display: 'none' }}
+                onChange={(e) => setReviewPhotos(Array.from(e.target.files ?? []))}
+              />
+              <button type="button" className="mp-btn mp-btn--line" disabled={reviewBusy} onClick={() => reviewFileInputRef.current?.click()}>
+                📷 사진 첨부
+              </button>
+              <span className="mp-review-upload-note">
+                {reviewPhotos.length > 0 ? `${reviewPhotos.length}장의 사진이 첨부되었습니다.` : '사진을 첨부할 수 있습니다.'}
+              </span>
+            </div>
+
+            {reviewError && <p className="err" style={{ marginTop: '0.55rem', marginBottom: 0 }}>{reviewError}</p>}
+            <div className="mp-modal-actions">
+              <button type="button" className="mp-btn mp-review-submit" onClick={() => void submitReview()} disabled={reviewBusy}>
+                {reviewBusy ? '리뷰 등록 중…' : '리뷰 등록하기'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/MypageScrapbookPage.jsx
+++ b/frontend/src/pages/MypageScrapbookPage.jsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { MypageDevHint } from '../components/MypageDevHint.jsx'
+import { useNavigate } from 'react-router-dom'
 import { PageEmpty, PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client.js'
 import { daysUntil, fetchGuestMatchRequests } from '../lib/matchingGuest.js'
@@ -26,16 +26,28 @@ async function loadGuideNicknames(apiRequest, guideIds) {
   return map
 }
 
+function parseRouteStops(proposedSchedule) {
+  const raw = String(proposedSchedule ?? '').trim()
+  if (!raw) return []
+  return raw
+    .split(/->|→|\r?\n|,/g)
+    .map((s) => s.trim())
+    .filter(Boolean)
+}
+
 export function MypageScrapbookPage() {
+  const navigate = useNavigate()
   const [rows, setRows] = useState([])
   const [names, setNames] = useState({})
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(true)
+  const [tearingRequestId, setTearingRequestId] = useState(null)
 
   const loadScrapbook = useCallback(async () => {
     const all = await fetchGuestMatchRequests(apiRequest)
-    const completed = (Array.isArray(all) ? all : []).filter((r) => r.status === 'COMPLETED')
-    completed.sort((a, b) => String(b.desiredDate).localeCompare(String(a.desiredDate)))
+    const completed = (Array.isArray(all) ? all : [])
+      .filter((r) => r.status === 'COMPLETED')
+      .sort((a, b) => String(b.desiredDate).localeCompare(String(a.desiredDate)))
     setRows(completed)
     const gids = completed.map((r) => r.guideId)
     const nm = await loadGuideNicknames(apiRequest, gids)
@@ -75,24 +87,14 @@ export function MypageScrapbookPage() {
   const count = rows.length
 
   const subtitle = useMemo(() => {
-    if (count === 0) return '아직 완료된 로컬 투어 기록이 없습니다.'
+    if (count === 0) return '아직 완료된 로컬 투어 기록이 없어요!'
     return `총 ${count}번의 로컬 여행을 다녀왔어요 ✈️`
   }, [count])
 
   return (
     <div className="mp-member">
       <h1>📒 나의 여행 기록 (스크랩북)</h1>
-      <p className="sub">
-        투어가 <strong>완료</strong>된 매칭만 시간 순으로 모아 보여 줍니다. 가이드 이름은 공개 프로필에서 가져옵니다.
-      </p>
-      <MypageDevHint>
-        <code>GET /api/matching/requests/guest/list</code> 중 <strong>COMPLETED</strong> 만 표시 · 가이드 닉네임은{' '}
-        <code>GET /api/guides/&#123;guideId&#125;</code> 로 보강
-      </MypageDevHint>
-      <p className="sub mp-data-note">
-        <strong>데이터 안내:</strong> 요약 화면의 기록 카드는 <strong>스크랩북(서버 저장)</strong> 기준이라, 이 목록과 개수가
-        다를 수 있어요.
-      </p>
+      <p className="sub">투어가 완료된 매칭을 시간 순으로 모아 보여 줍니다.</p>
       {loading && <PageLoading />}
       {!loading && error && <PageError message={error} onRetry={() => void refetch()} />}
 
@@ -106,27 +108,53 @@ export function MypageScrapbookPage() {
           </div>
 
           {rows.length === 0 && (
-            <PageEmpty title="완료된 투어 기록이 없습니다">투어가 완료되면 여기에 쌓입니다.</PageEmpty>
+            <PageEmpty title="완료된 투어 기록이 아직 없어요!" className="mp-scrap-empty">
+              첫 로컬 투어가 끝나면, 추억이 이곳에 예쁘게 쌓여요.
+            </PageEmpty>
           )}
 
           {rows.length > 0 && (
             <div className="mp-cards">
-              {rows.map((r) => {
+              {rows.map((r, idx) => {
                 const d = daysUntil(r.desiredDate)
                 const nick = names[r.guideId] ?? `가이드 #${r.guideId}`
+                const tripTitle = `여행기 #${idx + 1}`
+                const routeStops = parseRouteStops(r.proposedSchedule)
+                const previewText = routeStops.slice(0, 2).join(' → ') || '등록된 확정 루트가 없습니다.'
+                const detailPreview = String(r.proposedSchedule ?? '').trim().split(/\r?\n/).filter(Boolean)[0] ?? ''
                 return (
-                  <article key={r.requestId} className="mp-trip-card mp-trip-card--past">
-                    <div className="mp-trip-card__meta">
+                  <article key={r.requestId} className="mp-scrap-ticket">
+                    <div className="mp-scrap-ticket-left">
                       <span className="mp-dday" style={{ color: d != null && d < 0 ? '#6b7280' : '#dc2626' }}>
                         {r.desiredDate} · {nick}
                       </span>
-                      <h2 className="mp-trip-title">{r.destination}</h2>
+                      <h2 className="mp-trip-title">{tripTitle}</h2>
+                      <p className="mp-trip-detail">{nick}님과 함께했어요!</p>
+                      <p className="mp-trip-detail"><strong>여행지:</strong> {r.destination}</p>
                       <p className="mp-trip-detail">{r.conceptSummary ?? r.concept ?? '—'}</p>
-                      <p className="mp-trip-detail">제시 일정: {r.proposedSchedule ?? '—'}</p>
+                      <p className="mp-trip-detail">
+                        <strong>확정 루트 미리보기:</strong> {previewText}
+                      </p>
+                      {detailPreview && (
+                        <p className="mp-trip-detail">
+                          <strong>상세 코스:</strong> {detailPreview}
+                        </p>
+                      )}
                     </div>
-                    <div className="mp-thumb" aria-hidden>
-                      Trip
-                    </div>
+                    <button
+                      type="button"
+                      className={`mp-scrap-ticket-right mp-ticket-tear-zone${Number(tearingRequestId) === Number(r.requestId) ? ' is-tearing' : ''}`}
+                      disabled={tearingRequestId != null}
+                      onClick={() => {
+                        setTearingRequestId(Number(r.requestId))
+                        window.setTimeout(() => {
+                          navigate(`/mypage/scrapbook/${r.requestId}`)
+                        }, 430)
+                      }}
+                      aria-label={`여행 기록 #${r.requestId} 상세 보기`}
+                    >
+                      <span className="mp-ticket-tear-zone-label">티켓 뜯기</span>
+                    </button>
                   </article>
                 )
               })}

--- a/frontend/src/pages/MypageScrapbookTicketDetailPage.jsx
+++ b/frontend/src/pages/MypageScrapbookTicketDetailPage.jsx
@@ -1,0 +1,473 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { PageError, PageLoading } from '../components/PageStates.jsx'
+import { apiRequest } from '../api/client.js'
+import { DEFAULT_KOREA_CENTER, getUserLatLng, resolveLatLng } from '../lib/kakaoGeocode.js'
+import { fetchGuestMatchRequests } from '../lib/matchingGuest.js'
+import { parseCourseDetail } from './GuideCoursePanel.jsx'
+
+import './GuideMatchedCoursePage.css'
+import './MypageMemberPages.css'
+
+const KAKAO_APP_KEY = import.meta.env.VITE_KAKAO_MAP_APP_KEY
+
+function parseApiErrorMessage(text) {
+  if (!text) return '요청 실패'
+  try {
+    const j = JSON.parse(text)
+    return (j.message ?? text) || '요청 실패'
+  } catch {
+    return text || '요청 실패'
+  }
+}
+
+function loadKakaoSdk(appKey) {
+  if (!appKey) return Promise.reject(new Error('카카오맵 앱 키가 없습니다.'))
+  if (window.kakao?.maps?.services) return Promise.resolve(window.kakao)
+  return new Promise((resolve, reject) => {
+    const existing = document.getElementById('kakao-map-sdk')
+    if (existing) {
+      existing.addEventListener('load', () => window.kakao.maps.load(() => resolve(window.kakao)))
+      existing.addEventListener('error', () => reject(new Error('카카오맵 SDK 로드 실패')))
+      return
+    }
+    const script = document.createElement('script')
+    script.id = 'kakao-map-sdk'
+    script.async = true
+    script.src = `https://dapi.kakao.com/v2/maps/sdk.js?appkey=${appKey}&autoload=false&libraries=services`
+    script.onload = () => window.kakao.maps.load(() => resolve(window.kakao))
+    script.onerror = () => reject(new Error('카카오맵 SDK 로드 실패'))
+    document.head.appendChild(script)
+  })
+}
+
+function fallbackLatLng(idx) {
+  const base = DEFAULT_KOREA_CENTER
+  return { lat: base.lat + idx * 0.007, lng: base.lng + (idx % 2 === 0 ? 0.009 : -0.006) }
+}
+
+function createSpotOverlay(kakao, map, latlng, idx, name) {
+  const root = document.createElement('div')
+  root.className = 'gmc-pin'
+  root.innerHTML = `<span class="gmc-pin-badge">${idx + 1}</span><span class="gmc-pin-label">${name}</span>`
+  return new kakao.maps.CustomOverlay({ map, position: latlng, yAnchor: 1.25, content: root })
+}
+
+function renderStaticFallbackMap(kakao, container, centerPoint, points) {
+  if (!container) return
+  container.innerHTML = ''
+  const center = new kakao.maps.LatLng(centerPoint.lat, centerPoint.lng)
+  const marker = points.map((p, idx) => ({
+    position: new kakao.maps.LatLng(p.lat, p.lng),
+    text: `SPOT ${idx + 1}`,
+  }))
+  new kakao.maps.StaticMap(container, {
+    center,
+    level: 5,
+    marker: marker.length > 0 ? marker : undefined,
+  })
+}
+
+async function fetchMyReviewMap() {
+  const map = {}
+  let page = 0
+  while (page < 20) {
+    const res = await apiRequest(`/reviews/me?page=${page}&size=50`, { method: 'GET' })
+    const text = await res.text()
+    if (!res.ok) throw new Error(parseApiErrorMessage(text))
+    const data = text ? JSON.parse(text) : {}
+    const content = Array.isArray(data.content) ? data.content : []
+    for (const row of content) {
+      const key = Number(row?.matchRequestId)
+      if (!Number.isNaN(key) && map[key] == null) map[key] = row
+    }
+    if (data.last === true) break
+    page += 1
+  }
+  return map
+}
+
+export function MypageScrapbookTicketDetailPage() {
+  const { requestId } = useParams()
+  const navigate = useNavigate()
+  const mapRef = useRef(null)
+  const reviewFileInputRef = useRef(null)
+
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [row, setRow] = useState(null)
+  const [profile, setProfile] = useState(null)
+  const [formData, setFormData] = useState(null)
+  const [reviewByMatch, setReviewByMatch] = useState({})
+  const [mapErr, setMapErr] = useState('')
+  const [reviewModal, setReviewModal] = useState(false)
+  const [tripOrder, setTripOrder] = useState(1)
+  const [rating, setRating] = useState(5)
+  const [content, setContent] = useState('')
+  const [reviewBusy, setReviewBusy] = useState(false)
+  const [reviewError, setReviewError] = useState('')
+  const [reviewPhotos, setReviewPhotos] = useState([])
+
+  const load = useCallback(async () => {
+    const rid = Number(requestId)
+    if (!Number.isFinite(rid)) throw new Error('잘못된 여행 기록 ID입니다.')
+    const [all, reviews] = await Promise.all([
+      fetchGuestMatchRequests(apiRequest),
+      fetchMyReviewMap().catch(() => ({})),
+    ])
+    const completed = (Array.isArray(all) ? all : [])
+      .filter((r) => r.status === 'COMPLETED')
+      .sort((a, b) => String(b.desiredDate ?? '').localeCompare(String(a.desiredDate ?? '')))
+    const found = completed.find((r) => Number(r.requestId) === rid)
+    if (!found) throw new Error('해당 여행 기록을 찾을 수 없습니다.')
+    setRow(found)
+    setReviewByMatch(reviews)
+    const idx = completed.findIndex((r) => Number(r.requestId) === rid)
+    setTripOrder(idx >= 0 ? idx + 1 : 1)
+
+    if (found.guideId != null) {
+      const detailRes = await apiRequest(`/guides/${found.guideId}/detail`, { method: 'GET', skipAuth: true })
+      const detailText = await detailRes.text()
+      if (detailRes.ok && detailText) {
+        const detail = JSON.parse(detailText)
+        setProfile(detail?.profile ?? null)
+      }
+    }
+
+    if (found.guideId != null && found.scheduleId != null) {
+      const formRes = await apiRequest(`/guides/${found.guideId}/schedules/${found.scheduleId}/form`, { method: 'GET' })
+      const formText = await formRes.text()
+      if (formRes.ok) setFormData(formText ? JSON.parse(formText) : null)
+    }
+  }, [requestId])
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      setLoading(true)
+      setError('')
+      try {
+        await load()
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : '불러오기 실패')
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [load])
+
+  const courseText = useMemo(() => {
+    return String(formData?.courseDetail ?? row?.proposedSchedule ?? '').trim()
+  }, [formData?.courseDetail, row?.proposedSchedule])
+  const spots = useMemo(() => {
+    const parsed = parseCourseDetail(courseText)
+      .map((spot) => ({
+        name: String(spot?.name ?? '').trim(),
+        time: String(spot?.time ?? '').trim(),
+        desc: String(spot?.desc ?? '').trim(),
+      }))
+      .filter((spot) => Boolean(spot.name))
+    if (parsed.length === 1 && !parsed[0].time && !parsed[0].desc) {
+      const expanded = parsed[0].name
+        .split(/->|→|,/g)
+        .map((s) => s.trim())
+        .filter(Boolean)
+      if (expanded.length > 1) {
+        return expanded.map((name) => ({ name, time: '', desc: '' }))
+      }
+    }
+    return parsed
+  }, [courseText])
+  const hasReview = reviewByMatch[Number(row?.requestId)] != null
+
+  useEffect(() => {
+    if (!mapRef.current) return
+    let cancelled = false
+
+    const drawMap = async () => {
+      try {
+        setMapErr('')
+        const kakao = await loadKakaoSdk(KAKAO_APP_KEY)
+        if (cancelled || !mapRef.current) return
+
+        let center = DEFAULT_KOREA_CENTER
+        const userPos = await getUserLatLng()
+        if (userPos) {
+          center = userPos
+        } else if (formData?.meetingPoint?.trim()) {
+          const byMeeting = await resolveLatLng(kakao, formData.meetingPoint.trim(), { regionHint: String(profile?.region ?? '').trim() })
+          if (byMeeting) center = byMeeting
+        } else if (spots[0]?.name) {
+          const firstSpot = await resolveLatLng(kakao, spots[0].name, { regionHint: String(profile?.region ?? '').trim() })
+          if (firstSpot) center = firstSpot
+        } else if (row?.destination) {
+          const byDestination = await resolveLatLng(kakao, row.destination, { regionHint: String(profile?.region ?? '').trim() })
+          if (byDestination) center = byDestination
+        }
+
+        const map = new kakao.maps.Map(mapRef.current, {
+          center: new kakao.maps.LatLng(center.lat, center.lng),
+          level: 8,
+        })
+
+        const regionHint = String(profile?.region ?? '').trim()
+        const spotNames = spots.map((spot) => spot.name).filter(Boolean)
+        if (spotNames.length === 0 && formData?.meetingPoint?.trim()) {
+          spotNames.push(formData.meetingPoint.trim())
+        } else if (spotNames.length === 0 && row?.destination) {
+          spotNames.push(String(row.destination))
+        }
+
+        const resolved = await Promise.all(
+          spotNames.map(async (name, idx) => {
+            const point = await resolveLatLng(kakao, name, { regionHint })
+            return point ?? fallbackLatLng(idx)
+          }),
+        )
+        if (cancelled || resolved.length === 0) return
+
+        const path = []
+        const bounds = new kakao.maps.LatLngBounds()
+        resolved.forEach((p, idx) => {
+          const latlng = new kakao.maps.LatLng(p.lat, p.lng)
+          path.push(latlng)
+          bounds.extend(latlng)
+          createSpotOverlay(kakao, map, latlng, idx, spotNames[idx] || `SPOT ${idx + 1}`)
+        })
+        if (path.length > 1) {
+          new kakao.maps.Polyline({ map, path, strokeWeight: 8, strokeColor: '#f9fafb', strokeOpacity: 0.95, strokeStyle: 'solid' })
+          new kakao.maps.Polyline({ map, path, strokeWeight: 3, strokeColor: '#1f2328', strokeOpacity: 0.85, strokeStyle: 'shortdash' })
+        }
+        map.setBounds(bounds)
+
+        // Some environments keep dynamic Kakao tiles gray on this page.
+        // If tiles don't load quickly, fallback to a static map image.
+        let tilesLoaded = false
+        const onTilesLoaded = () => { tilesLoaded = true }
+        kakao.maps.event.addListener(map, 'tilesloaded', onTilesLoaded)
+        window.setTimeout(() => {
+          if (cancelled || tilesLoaded || !mapRef.current) return
+          const fallbackPoints = resolved.length > 0 ? resolved : [{ lat: center.lat, lng: center.lng }]
+          renderStaticFallbackMap(kakao, mapRef.current, center, fallbackPoints)
+          setMapErr('')
+        }, 1500)
+      } catch (e) {
+        setMapErr(e instanceof Error ? e.message : '지도를 불러오지 못했습니다.')
+      }
+    }
+
+    void drawMap()
+    return () => {
+      cancelled = true
+    }
+  }, [spots, profile?.region, formData?.meetingPoint, row?.destination])
+
+  const companionName = useMemo(() => String(profile?.nickname ?? '가이드').trim() || '가이드', [profile?.nickname])
+  const tripTitle = useMemo(() => `여행기 #${tripOrder}`, [tripOrder])
+
+  const ratingLabel = useMemo(() => {
+    const labels = {
+      5: '5점 - 최고의 여행이었어요!',
+      4: '4점 - 아주 좋았어요!',
+      3: '3점 - 만족스러웠어요!',
+      2: '2점 - 아쉬운 점이 있어요',
+      1: '1점 - 기대에 못 미쳤어요',
+    }
+    return labels[rating] ?? ''
+  }, [rating])
+
+  const submitReview = async () => {
+    if (!row) return
+    const trimmed = content.trim()
+    if (trimmed.length < 10) {
+      setReviewError('후기는 10자 이상 입력해 주세요.')
+      return
+    }
+    setReviewBusy(true)
+    setReviewError('')
+    try {
+      const res = await apiRequest('/reviews', {
+        method: 'POST',
+        json: {
+          guideId: Number(row.guideId),
+          matchRequestId: Number(row.requestId),
+          rating,
+          content: trimmed,
+        },
+      })
+      const text = await res.text()
+      if (!res.ok) {
+        setReviewError(parseApiErrorMessage(text))
+        return
+      }
+      setReviewModal(false)
+      setContent('')
+      setReviewPhotos([])
+      const reviews = await fetchMyReviewMap().catch(() => ({}))
+      setReviewByMatch(reviews)
+    } catch {
+      setReviewError('리뷰 등록 중 네트워크 오류가 발생했습니다.')
+    } finally {
+      setReviewBusy(false)
+    }
+  }
+
+  if (loading) return <PageLoading />
+  if (error || !row) return <PageError message={error || '여행 기록을 찾을 수 없습니다.'} onRetry={() => void load()} />
+
+  return (
+    <div className="gmc">
+      <button type="button" className="mp-back-chip" onClick={() => navigate('/mypage/scrapbook')} aria-label="스크랩북으로 돌아가기">
+        <span className="mp-back-chip__icon" aria-hidden>
+          ←
+        </span>
+        스크랩북으로 돌아가기
+      </button>
+
+      <section className="gmc-course">
+        <h2 className="gmc-title">{tripTitle}</h2>
+        <p className="gmc-hint">
+          {row.guideId != null ? (
+            <Link to={`/guides/${row.guideId}`} className="mp-guide-link">
+              {companionName}
+            </Link>
+          ) : (
+            companionName
+          )}
+          님과 함께했어요! · {row.desiredDate}
+        </p>
+
+        {(formData?.meetingPoint || formData?.guideMessage) && (
+          <div className="gmc-pre-info">
+            {formData?.meetingPoint && (
+              <div className="gmc-pre-card">
+                <span className="gmc-pre-label">집합 장소</span>
+                <p className="gmc-pre-value">{formData.meetingPoint}</p>
+              </div>
+            )}
+            {formData?.guideMessage && (
+              <div className="gmc-pre-card">
+                <span className="gmc-pre-label">가이드 안내</span>
+                <p className="gmc-pre-value">{formData.guideMessage}</p>
+              </div>
+            )}
+          </div>
+        )}
+
+        <div className="gmc-grid">
+          <div className="gmc-map-wrap">
+            <div ref={mapRef} className="gmc-map" />
+            {mapErr && <p className="gmc-err gmc-map-err">{mapErr}</p>}
+          </div>
+
+          <aside className="gmc-timeline">
+            {spots.length > 0 ? (
+              spots.slice(0, 6).map((spot, idx) => (
+                <article key={idx} className="gmc-spot">
+                  <p className="gmc-spot-label">SPOT {idx + 1}</p>
+                  <h3 className="gmc-spot-name">{spot.name}{spot.time ? ` (${spot.time})` : ''}</h3>
+                  {spot.desc && <p className="gmc-spot-desc">{spot.desc}</p>}
+                </article>
+              ))
+            ) : (
+              <article className="gmc-spot">
+                <p className="gmc-spot-label">SPOT 1 ~ N</p>
+                <h3 className="gmc-spot-name">상세 코스가 준비 중입니다.</h3>
+              </article>
+            )}
+          </aside>
+        </div>
+      </section>
+
+      <div className="mp-trip-actions mp-trip-actions--under-route" style={{ marginTop: '1rem' }}>
+        {hasReview ? (
+          <>
+            <p className="mp-review-done">후기 작성 완료</p>
+            <Link to="/mypage/reviews" className="mp-btn mp-btn--line">내 후기 보기</Link>
+          </>
+        ) : (
+          <button
+            type="button"
+            className="mp-btn mp-review-open-btn"
+            onClick={() => {
+              setReviewError('')
+              setRating(5)
+              setContent('')
+              setReviewPhotos([])
+              setReviewModal(true)
+            }}
+          >
+            후기 작성하기
+          </button>
+        )}
+      </div>
+
+      {reviewModal && (
+        <div className="mp-modal-overlay" role="dialog" aria-modal="true" aria-label="후기 작성" onClick={() => !reviewBusy && setReviewModal(false)}>
+          <div className="mp-modal mp-review-modal" onClick={(e) => e.stopPropagation()}>
+            <button type="button" className="mp-review-close" aria-label="후기 모달 닫기" onClick={() => setReviewModal(false)} disabled={reviewBusy}>
+              ×
+            </button>
+            <div className="mp-review-tape" aria-hidden />
+            <h2 className="mp-review-title">투어는 어떠셨나요? ✨</h2>
+            <p className="mp-review-sub">{row.destination} · {companionName}님과의 추억을 남겨주세요.</p>
+
+            <div className="mp-review-stars" role="radiogroup" aria-label="별점 선택">
+              {[1, 2, 3, 4, 5].map((n) => (
+                <button
+                  key={n}
+                  type="button"
+                  className={`mp-review-star${n <= rating ? ' is-on' : ''}`}
+                  aria-label={`${n}점`}
+                  aria-checked={n === rating}
+                  role="radio"
+                  onClick={() => setRating(n)}
+                  disabled={reviewBusy}
+                >
+                  🌟
+                </button>
+              ))}
+            </div>
+            <p className="mp-review-rating-label">{ratingLabel}</p>
+
+            <textarea
+              className="mp-modal-text mp-review-textarea"
+              rows={6}
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              placeholder="좋았던 점, 아쉬운 점, 다시 가고 싶은 이유를 자유롭게 남겨주세요."
+              disabled={reviewBusy}
+            />
+
+            <div className="mp-review-upload-row">
+              <input
+                ref={reviewFileInputRef}
+                type="file"
+                accept="image/*"
+                multiple
+                style={{ display: 'none' }}
+                onChange={(e) => setReviewPhotos(Array.from(e.target.files ?? []))}
+              />
+              <button type="button" className="mp-btn mp-btn--line" disabled={reviewBusy} onClick={() => reviewFileInputRef.current?.click()}>
+                📷 사진 첨부
+              </button>
+              <span className="mp-review-upload-note">
+                {reviewPhotos.length > 0 ? `${reviewPhotos.length}장의 사진이 첨부되었습니다.` : '사진을 첨부할 수 있습니다.'}
+              </span>
+            </div>
+
+            {reviewError && <p className="err" style={{ marginTop: '0.55rem', marginBottom: 0 }}>{reviewError}</p>}
+            <div className="mp-modal-actions">
+              <button type="button" className="mp-btn mp-review-submit" onClick={() => void submitReview()} disabled={reviewBusy}>
+                {reviewBusy ? '리뷰 등록 중…' : '리뷰 등록하기'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/MypageTourPage.jsx
+++ b/frontend/src/pages/MypageTourPage.jsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
-import { Link, useLocation } from 'react-router-dom'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
 
 import { PageEmpty, PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client.js'
@@ -10,8 +10,14 @@ import './MypageMemberPages.css'
 async function tryFetchExtension(requestId) {
   const res = await apiRequest(`/matching/extensions/${requestId}`, { method: 'GET' })
   const text = await res.text()
-  if (!res.ok) return null
-  return text ? JSON.parse(text) : null
+  if (res.status === 204) {
+    return {
+      data: null,
+      reason: res.headers.get('X-Extension-Reason') || '',
+    }
+  }
+  if (!res.ok) return { data: null, reason: '' }
+  return { data: text ? JSON.parse(text) : null, reason: '' }
 }
 
 function refundDeadlineOk(p) {
@@ -66,16 +72,32 @@ function timeLeftText(v) {
   return `${h}시간 ${m}분`
 }
 
-function dday(v) {
-  if (!v) return 0
-  const t = new Date(v).getTime()
-  if (Number.isNaN(t)) return 0
-  const diff = Math.max(0, t - Date.now())
-  return Math.floor(diff / (1000 * 60 * 60 * 24))
+function todayKey() {
+  const d = new Date()
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+function dateKey(v) {
+  if (v == null) return ''
+  const s = String(v)
+  const isoLike = s.match(/^(\d{4})-(\d{2})-(\d{2})/)
+  if (isoLike) return `${isoLike[1]}-${isoLike[2]}-${isoLike[3]}`
+  const compact = s.match(/(\d{4})\D+(\d{1,2})\D+(\d{1,2})/)
+  if (compact) {
+    const y = compact[1]
+    const m = String(compact[2]).padStart(2, '0')
+    const d = String(compact[3]).padStart(2, '0')
+    return `${y}-${m}-${d}`
+  }
+  return s.length >= 10 ? s.slice(0, 10) : s
 }
 
 export function MypageTourPage() {
   const location = useLocation()
+  const navigate = useNavigate()
   const [requests, setRequests] = useState([])
   const [payments, setPayments] = useState([])
   const [extMap, setExtMap] = useState({})
@@ -88,6 +110,12 @@ export function MypageTourPage() {
   const [refundReason, setRefundReason] = useState('')
   const [refundEvidence, setRefundEvidence] = useState('')
   const [routeHint, setRouteHint] = useState('')
+  const [extensionEmptyReason, setExtensionEmptyReason] = useState('')
+  const [reasonGuideNames, setReasonGuideNames] = useState({
+    booked: '',
+    blocked: '',
+    unavailable: '',
+  })
 
   useEffect(() => {
     const h = location.state?.hint
@@ -96,21 +124,110 @@ export function MypageTourPage() {
 
   const load = useCallback(async () => {
     const [req, pay] = await Promise.all([fetchGuestMatchRequests(apiRequest), fetchGuestPayments(apiRequest)])
-    setRequests(Array.isArray(req) ? req : [])
+    const allRequests = Array.isArray(req) ? req : []
+    setRequests(allRequests)
     setPayments(Array.isArray(pay) ? pay : [])
 
-    const candidates = (Array.isArray(req) ? req : []).filter((r) => ['PAID', 'IN_PROGRESS', 'COMPLETED'].includes(r.status))
+    // 연장 레코드는 "투어 당일" 대상만 생성되므로, 같은 날 요청만 조회해 404 노이즈를 줄인다.
+    const tk = todayKey()
+    const baseCandidates = allRequests.filter((r) =>
+      ['ACCEPTED', 'PAID', 'IN_PROGRESS', 'COMPLETED'].includes(String(r.status ?? '')),
+    )
+    const candidates = baseCandidates.filter((r) => dateKey(r.desiredDate) === tk)
+    const resolvedCandidates = candidates.length > 0 ? candidates : baseCandidates
     const entries = await Promise.all(
-      candidates.map(async (r) => {
+      resolvedCandidates.map(async (r) => {
+        const guideName = r?.guideNickname?.trim() || (r?.guideId != null ? `가이드 #${r.guideId}` : '가이드')
+        if (r?.requestId == null) {
+          return { entry: null, reason: 'MISSING_REQUEST_ID', guideName }
+        }
         const ex = await tryFetchExtension(r.requestId)
-        return ex ? [r.requestId, ex] : null
+        if (!ex?.data) return { entry: null, reason: ex?.reason || '', guideName }
+        const status = String(ex.data.status ?? '')
+        if (!['REQUESTED', 'GUIDE_APPROVED'].includes(status)) {
+          const closedReason =
+            status === 'PAID'
+              ? 'ALREADY_EXTENDED_PAID'
+              : status === 'REJECTED'
+                ? 'ALREADY_DECLINED'
+                : status === 'AUTO_CANCELLED'
+                  ? 'AUTO_CANCELLED'
+                  : ''
+          return { entry: null, reason: closedReason || ex?.reason || '', guideName }
+        }
+        return { entry: [r.requestId, ex.data], reason: ex?.reason || '', guideName }
       }),
     )
     const m = {}
-    for (const e of entries) {
-      if (e) m[e[0]] = e[1]
+    let hasGuideUnavailableReason = false
+    let hasGuideBookedReason = false
+    let hasGuideBlockedReason = false
+    let hasAlreadyDecidedReason = false
+    let hasMissingRequestId = false
+    let hasNoContentWithoutReason = false
+    let bookedGuideName = ''
+    let blockedGuideName = ''
+    let unavailableGuideName = ''
+    for (const wrapped of entries) {
+      if (!wrapped) continue
+      if (wrapped.reason === 'GUIDE_NEXT_DAY_UNAVAILABLE') {
+        hasGuideUnavailableReason = true
+        if (!unavailableGuideName) unavailableGuideName = wrapped.guideName || '가이드'
+      }
+      if (wrapped.reason === 'GUIDE_NEXT_DAY_BOOKED') {
+        hasGuideBookedReason = true
+        if (!bookedGuideName) bookedGuideName = wrapped.guideName || '가이드'
+      }
+      if (wrapped.reason === 'GUIDE_NEXT_DAY_BLOCKED') {
+        hasGuideBlockedReason = true
+        if (!blockedGuideName) blockedGuideName = wrapped.guideName || '가이드'
+      }
+      if (
+        wrapped.reason === 'ALREADY_EXTENDED_PAID' ||
+        wrapped.reason === 'ALREADY_DECLINED' ||
+        wrapped.reason === 'AUTO_CANCELLED'
+      ) {
+        hasAlreadyDecidedReason = true
+      }
+      if (wrapped.reason === 'MISSING_REQUEST_ID') {
+        hasMissingRequestId = true
+      }
+      if (!wrapped.reason && !wrapped.entry) {
+        hasNoContentWithoutReason = true
+      }
+      if (wrapped.entry) m[wrapped.entry[0]] = wrapped.entry[1]
     }
+    setReasonGuideNames({
+      booked: bookedGuideName,
+      blocked: blockedGuideName,
+      unavailable: unavailableGuideName,
+    })
     setExtMap(m)
+    if (Object.keys(m).length === 0) {
+      if (hasGuideBookedReason) {
+        setExtensionEmptyReason('GUIDE_NEXT_DAY_BOOKED')
+      } else if (hasGuideBlockedReason) {
+        setExtensionEmptyReason('GUIDE_NEXT_DAY_BLOCKED')
+      } else if (hasGuideUnavailableReason) {
+        setExtensionEmptyReason('GUIDE_NEXT_DAY_UNAVAILABLE')
+      } else if (hasAlreadyDecidedReason) {
+        setExtensionEmptyReason('ALREADY_DECIDED')
+      } else if (hasMissingRequestId) {
+        setExtensionEmptyReason('MISSING_REQUEST_ID')
+      } else if (hasNoContentWithoutReason) {
+        setExtensionEmptyReason('UNSPECIFIED_NOT_AVAILABLE')
+      } else if (candidates.length === 0 && baseCandidates.length > 0) {
+        setExtensionEmptyReason('NO_TODAY_ELIGIBLE_TOUR')
+      } else if (baseCandidates.length === 0 && allRequests.length > 0) {
+        setExtensionEmptyReason('NO_ELIGIBLE_STATUS')
+      } else if (allRequests.length === 0) {
+        setExtensionEmptyReason('NO_REQUESTS')
+      } else {
+        setExtensionEmptyReason('')
+      }
+      return
+    }
+    setExtensionEmptyReason('')
   }, [])
 
   const refetch = useCallback(async () => {
@@ -162,6 +279,56 @@ export function MypageTourPage() {
     }
   }
 
+  const startExtensionPayment = async (requestId, extension) => {
+    const amount = Number(extension?.extendedPrice)
+    if (!Number.isFinite(amount) || amount <= 0) {
+      setActionApiErr('연장 결제 금액을 확인할 수 없습니다. 가이드 비용 설정 후 다시 시도해 주세요.')
+      return
+    }
+    setBusy(true)
+    setToast('')
+    setActionApiErr('')
+    try {
+      const selected = await apiRequest(`/matching/extensions/${requestId}/select`, {
+        method: 'PATCH',
+        json: { extend: true },
+      })
+      const selectedText = await selected.text()
+      if (!selected.ok) throw new Error(parseMatchingApiError(selectedText))
+
+      const res = await apiRequest('/matching/payments', {
+        method: 'POST',
+        json: {
+          matchRequestId: requestId,
+          amount,
+          paymentType: 'EXTENSION',
+        },
+      })
+      const text = await res.text()
+      if (!res.ok) throw new Error(parseMatchingApiError(text))
+      const data = text ? JSON.parse(text) : {}
+      const mr = requests.find((r) => r.requestId === requestId)
+      const qs = new URLSearchParams()
+      if (data.paymentId != null) qs.set('paymentId', String(data.paymentId))
+      if (data.amount != null) qs.set('amount', String(data.amount))
+      if (data.pgOrderNo) qs.set('pgOrderNo', String(data.pgOrderNo))
+      if (data.paymentType) qs.set('paymentType', String(data.paymentType))
+      qs.set('requestId', String(requestId))
+      if (mr?.guideId != null) qs.set('guideId', String(mr.guideId))
+      const redirect = data?.redirectUrl
+      if (redirect && String(redirect).trim() !== '') {
+        navigate(`/pay/kakao-stub?${qs.toString()}`, { state: { externalRedirect: String(redirect) } })
+        return
+      }
+      navigate(`/pay/kakao-stub?${qs.toString()}`)
+    } catch (e) {
+      setActionApiErr(e instanceof Error ? e.message : '연장 결제 요청 실패')
+      await load()
+    } finally {
+      setBusy(false)
+    }
+  }
+
   const submitRefund = async () => {
     if (refundPaymentId == null) return
     const reason = refundReason.trim()
@@ -194,7 +361,9 @@ export function MypageTourPage() {
     }
   }
 
-  const refundable = payments.filter((p) => p.status === 'COMPLETED' && refundDeadlineOk(p))
+  const refundRows = payments
+    .filter((p) => p.status === 'COMPLETED' || p.status === 'REFUNDED')
+    .sort((a, b) => Number(b.paymentId || 0) - Number(a.paymentId || 0))
 
   return (
     <div className="mp-member">
@@ -238,15 +407,35 @@ export function MypageTourPage() {
         <div className="mp-tour-shell">
           <section className="mp-tour-block">
             <h2>진행 예정 투어 연장</h2>
-            <p className="sub">투어 전날 저녁, 아쉬움이 남는다면 하루 더 로컬과 함께해요.</p>
+            <p className="sub">투어 당일 밤 9시부터 자정 전까지, 아쉬움이 남는다면 하루 더 로컬과 함께해요.</p>
             {Object.keys(extMap).length === 0 && (
-              <PageEmpty title="진행 중인 연장 요청이 없습니다">연장 안내가 오면 이 영역에 표시됩니다.</PageEmpty>
+              <PageEmpty title="진행 중인 연장 요청이 없습니다">
+                {extensionEmptyReason === 'GUIDE_NEXT_DAY_UNAVAILABLE'
+                  ? <span style={{ color: '#dc2626', fontWeight: 700 }}>{reasonGuideNames.unavailable || '가이드'}가 다음날 예약되어있거나 예약불가입니다.</span>
+                  : extensionEmptyReason === 'GUIDE_NEXT_DAY_BOOKED'
+                    ? <span style={{ color: '#dc2626', fontWeight: 700 }}>{reasonGuideNames.booked || '가이드'}가 다음날 예약되어있습니다.</span>
+                    : extensionEmptyReason === 'GUIDE_NEXT_DAY_BLOCKED'
+                      ? <span style={{ color: '#dc2626', fontWeight: 700 }}>{reasonGuideNames.blocked || '가이드'}가 다음날 예약불가입니다.</span>
+                  : extensionEmptyReason === 'ALREADY_DECIDED'
+                    ? '이미 연장 여부를 선택한 투어입니다. 연장 결제를 완료했거나, 연장 안 함을 선택해 다시 표시되지 않습니다.'
+                    : extensionEmptyReason === 'NO_TODAY_ELIGIBLE_TOUR'
+                      ? '오늘 날짜의 진행 대상 투어가 없어 연장 카드가 생성되지 않았습니다.'
+                      : extensionEmptyReason === 'NO_ELIGIBLE_STATUS'
+                        ? '현재 상태에서는 연장을 열 수 없습니다. (ACCEPTED/PAID/IN_PROGRESS/COMPLETED 상태만 대상)'
+                        : extensionEmptyReason === 'MISSING_REQUEST_ID'
+                          ? '요청 식별자(requestId) 정보가 누락되어 연장 정보를 조회할 수 없습니다.'
+                          : extensionEmptyReason === 'NO_REQUESTS'
+                            ? '게스트 계정에 연결된 매칭 요청이 아직 없어 연장 대상이 없습니다.'
+                            : extensionEmptyReason === 'UNSPECIFIED_NOT_AVAILABLE'
+                              ? '현재 투어는 연장 대상이 아니거나 이미 마감/정리되어 연장 카드를 표시할 수 없습니다.'
+                  : '연장 안내가 오면 이 영역에 표시됩니다.'}
+              </PageEmpty>
             )}
             <div className="mp-cards">
               {Object.entries(extMap).map(([requestId, ex]) => {
                 const rid = Number(requestId)
                 const mr = requests.find((r) => r.requestId === rid)
-                const open = ex.status === 'REQUESTED'
+                const open = ex.status === 'REQUESTED' || ex.status === 'GUIDE_APPROVED'
                 const left = hoursLeft(ex.deadlineAt)
                 return (
                   <article key={rid} className="mp-tour-card">
@@ -254,16 +443,16 @@ export function MypageTourPage() {
                       <div>
                         <p className="mp-tour-name">{mr?.guideNickname ?? '가이드'}와 함께하는 {mr?.destination ?? '로컬'} 투어</p>
                         <p className="mp-tour-meta">결제 일시: {formatDate(mr?.desiredDate)} · 상태: {ex.status}</p>
-                        <p className="mp-tour-extension">연장 선택 가능 (D-{dday(ex.deadlineAt)})</p>
-                        <p className="mp-tour-fee">추가 비용: {formatMoney(ex.additionalFee)} (선택 후 결제, 마감 {formatDateTime(ex.deadlineAt)})</p>
+                        <p className="mp-tour-extension">연장 선택 가능</p>
+                        <p className="mp-tour-fee">추가 비용: {formatMoney(ex.extendedPrice)} (선택 후 결제, 마감 {formatDateTime(ex.deadlineAt)})</p>
                       </div>
                       {open && (
-                        <button type="button" className="mp-btn" disabled={busy} onClick={() => void selectExtension(rid, true)}>
+                        <button type="button" className="mp-btn" disabled={busy} onClick={() => void startExtensionPayment(rid, ex)}>
                           연장 및 추가 결제하기
                         </button>
                       )}
                     </div>
-                    {open && (
+                    {ex.status === 'REQUESTED' && (
                       <button type="button" className="mp-tour-inline-link" disabled={busy} onClick={() => void selectExtension(rid, false)}>
                         연장 안 함
                       </button>
@@ -278,31 +467,47 @@ export function MypageTourPage() {
           <section className="mp-tour-block">
             <h2>투어 취소 및 환불 관리</h2>
             <p className="sub">결제 후 2시간 이내에는 조건에 따라 즉시 환불이 가능합니다.</p>
-            {refundable.length === 0 && (
+            {refundRows.length === 0 && (
               <PageEmpty title="환불 가능한 결제가 없습니다">조건을 만족하는 결제가 있으면 여기에서 신청할 수 있어요.</PageEmpty>
             )}
             <div className="mp-cards">
-              {refundable.map((p) => (
-                <article key={p.paymentId} className="mp-tour-card">
-                  <div className="mp-tour-row">
-                    <div>
-                      <p className="mp-tour-name">결제 #{p.paymentId} 완료 건 환불</p>
-                      <p className="mp-tour-meta">결제 일시: {formatDateTime(p.paidAt)} · 주문 번호: {p.pgOrderNo ?? `ORD-${p.paymentId}`}</p>
-                      <p className="mp-tour-extension">🔵 환불 가능 (남은 시간: {timeLeftText(p.refundDeadline)})</p>
+              {refundRows.map((p) => {
+                const isRefunded = p.status === 'REFUNDED'
+                const canRefundNow = p.status === 'COMPLETED' && refundDeadlineOk(p)
+                return (
+                  <article key={p.paymentId} className="mp-tour-card">
+                    <div className="mp-tour-row">
+                      <div>
+                        <p className="mp-tour-name">결제 #{p.paymentId} {isRefunded ? '환불 완료' : '완료 건 환불'}</p>
+                        <p className="mp-tour-meta">결제 일시: {formatDateTime(p.paidAt)} · 주문 번호: {p.pgOrderNo ?? `ORD-${p.paymentId}`}</p>
+                        {isRefunded ? (
+                          <p className="mp-tour-extension" style={{ color: '#059669' }}>환불 완료</p>
+                        ) : canRefundNow ? (
+                          <p className="mp-tour-extension">🔵 환불 가능 (남은 시간: {timeLeftText(p.refundDeadline)})</p>
+                        ) : (
+                          <p className="mp-tour-extension">환불 가능 시간이 종료되었습니다.</p>
+                        )}
+                      </div>
+                      {canRefundNow ? (
+                        <button type="button" className="mp-btn mp-btn--danger" onClick={() => setRefundPaymentId(p.paymentId)}>
+                          즉시 환불하기
+                        </button>
+                      ) : (
+                        <button type="button" className="mp-btn mp-btn--line" disabled>
+                          {isRefunded ? '환불 완료' : '환불 불가'}
+                        </button>
+                      )}
                     </div>
-                    <button type="button" className="mp-btn mp-btn--danger" onClick={() => setRefundPaymentId(p.paymentId)}>
-                      즉시 환불하기
-                    </button>
-                  </div>
-                </article>
-              ))}
+                  </article>
+                )
+              })}
             </div>
           </section>
 
           <article className="mp-tour-notice">
             <p className="mp-tour-notice-title">📍 투어 관리 정책 안내</p>
             <ul>
-              <li>연장 선택: 투어 시작 전날 밤 22:00까지 결제가 완료되어야 가이드에게 최종 전달됩니다.</li>
+              <li>연장 선택: 투어 당일 21:00~23:59 사이 선택 가능하며, 추가 결제 완료 시 가이드에게 최종 전달됩니다.</li>
               <li>환불 규정: 결제 시점으로부터 2시간 이내 신청 시 100% 즉시 환불되며, 이후에는 환불 정책 규정이 적용됩니다.</li>
             </ul>
           </article>

--- a/frontend/src/pages/OnboardingPage.css
+++ b/frontend/src/pages/OnboardingPage.css
@@ -40,16 +40,16 @@
 }
 
 .onb-step-circle.done {
-  background: #1f2328;
-  border-color: #1f2328;
-  color: #fff;
+  background: #f6d8e6;
+  border-color: #efbfd0;
+  color: #6d3f58;
   font-size: 0.95rem;
 }
 
 .onb-step-circle.current {
-  background: #1f2328;
-  border-color: #1f2328;
-  color: #fff;
+  background: #f8dce7;
+  border-color: #efbfd0;
+  color: #6d3f58;
 }
 
 .onb-step-label {

--- a/frontend/src/pages/PaymentKakaoStubPage.jsx
+++ b/frontend/src/pages/PaymentKakaoStubPage.jsx
@@ -48,6 +48,7 @@ export function PaymentKakaoStubPage() {
     const t = String(paymentType).toUpperCase()
     if (t === 'CHAT') return '정보만 받기 (채팅)'
     if (t === 'ACCOMPANY') return '직접 만나기 (동행)'
+    if (t === 'EXTENSION') return '투어 하루 연장'
     return 'LocalGuest 결제'
   }, [paymentType])
 

--- a/frontend/src/pages/SignupPage.css
+++ b/frontend/src/pages/SignupPage.css
@@ -8,6 +8,28 @@
   color-scheme: light;
 }
 
+.signup-wrap--wide {
+  max-width: 900px;
+}
+
+.signup-step-transition {
+  animation: signup-step-enter 320ms ease both;
+  transform-origin: center center;
+}
+
+@keyframes signup-step-enter {
+  from {
+    opacity: 0;
+    transform: scale(0.987);
+    filter: blur(1px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+    filter: none;
+  }
+}
+
 .signup-wrap a {
   color: #1f2328;
   font-weight: 700;
@@ -48,16 +70,16 @@
 }
 
 .signup-step-circle.done {
-  background: #1f2328;
-  border-color: #1f2328;
-  color: #fff;
+  background: #f6d8e6;
+  border-color: #efbfd0;
+  color: #6d3f58;
   font-size: 0.95rem;
 }
 
 .signup-step-circle.current {
-  background: #1f2328;
-  border-color: #1f2328;
-  color: #fff;
+  background: #f8dce7;
+  border-color: #efbfd0;
+  color: #6d3f58;
 }
 
 .signup-step-label {
@@ -93,6 +115,45 @@
   color-scheme: light;
 }
 
+.signup-card--verify {
+  padding-top: 1.75rem;
+}
+
+.signup-back-icon {
+  position: absolute;
+  top: 0.85rem;
+  left: -0.72rem;
+  width: 2rem;
+  height: 2rem;
+  border: 1px solid #efbfd0;
+  border-radius: 999px;
+  background: #fff7fb;
+  color: #8f4664;
+  cursor: pointer;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.18s ease, border-color 0.18s ease, transform 0.18s ease;
+}
+
+.signup-back-icon svg {
+  width: 1.05rem;
+  height: 1.05rem;
+  stroke: currentColor;
+  stroke-width: 2.35;
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.signup-back-icon:hover {
+  background: #f9e3ed;
+  border-color: #e8a8bf;
+  color: #6d3f58;
+  transform: translateY(-1px);
+}
+
 .signup-card-accent {
   position: absolute;
   top: 0;
@@ -119,8 +180,11 @@
 .signup-title {
   margin: 0 0 0.45rem;
   font-size: 1.35rem;
-  font-weight: 800;
-  letter-spacing: -0.03em;
+  font-family: 'Malgun Gothic', '맑은 고딕', var(--sans);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  word-spacing: 0;
+  line-height: 1.35;
   color: #1f2328;
 }
 
@@ -143,9 +207,16 @@
   background: #fff;
   font-size: 0.9rem;
   font-weight: 600;
-  color: #3c434d;
-  cursor: not-allowed;
-  opacity: 0.65;
+  color: #5a3c56;
+  cursor: pointer;
+  opacity: 1;
+  transition: background-color 0.18s ease, border-color 0.18s ease, transform 0.18s ease;
+}
+
+.signup-google:hover {
+  background: #fff4f8;
+  border-color: #efbfd0;
+  transform: translateY(-1px);
 }
 
 .signup-google-icon {
@@ -202,6 +273,11 @@
   margin: 0 0 0.35rem;
   font-size: 0.72rem;
   color: #9aa0a6;
+}
+
+.signup-hint--sent {
+  color: #e11d48;
+  font-weight: 700;
 }
 
 .signup-input {
@@ -331,6 +407,8 @@
 }
 
 .signup-info-box strong {
+  display: block;
+  margin-bottom: 0.2rem;
   color: #1f2328;
 }
 
@@ -366,14 +444,21 @@
   flex-shrink: 0;
   padding: 0 1rem;
   border-radius: 10px;
-  border: none;
-  background: #1f2328;
-  color: #fff;
+  border: 1px solid #efbfd0;
+  background: #f6d8e6;
+  color: #6d3f58;
   font-size: 0.78rem;
   font-weight: 700;
   cursor: pointer;
   white-space: nowrap;
   font-family: inherit;
+  transition: background-color 0.18s ease, border-color 0.18s ease, transform 0.18s ease;
+}
+
+.signup-verify-btn:hover:not(:disabled) {
+  background: #f2cddd;
+  border-color: #e8a8bf;
+  transform: translateY(-1px);
 }
 
 .signup-verify-btn:disabled {
@@ -381,61 +466,159 @@
   cursor: not-allowed;
 }
 
-.signup-demo-note {
-  margin: 0.75rem 0 0;
-  font-size: 0.78rem;
-  color: #6b7280;
-}
-
-.signup-info-sub {
-  display: block;
-  margin-top: 0.35rem;
-  color: #6b7280;
-  font-size: 0.8rem;
-}
-
-.signup-linkish {
-  border: none;
-  background: none;
-  padding: 0;
-  margin: 0;
-  font: inherit;
-  font-size: inherit;
-  color: #1f2328;
-  font-weight: 600;
-  cursor: pointer;
-  text-decoration: underline;
-}
-
 .signup-next {
   width: 100%;
   margin-top: 1.15rem;
   padding: 0.85rem 1rem;
-  border: none;
+  border: 1px solid #efbfd0;
   border-radius: 12px;
-  background: #1f2328;
-  color: #fff;
+  background: #f6d8e6;
+  color: #6d3f58;
   font-size: 0.95rem;
   font-weight: 700;
   cursor: pointer;
+  transition: background-color 0.18s ease, border-color 0.18s ease, transform 0.18s ease;
+}
+
+.signup-next:hover:not(:disabled) {
+  background: #f2cddd;
+  border-color: #e8a8bf;
+  transform: translateY(-1px);
 }
 
 .signup-next:disabled {
-  opacity: 0.45;
+  opacity: 1;
+  background: #e3dfe3;
+  border-color: #d7d1d8;
+  color: #8f8b91;
   cursor: not-allowed;
 }
 
 .signup-footer-note {
-  margin-top: 1.25rem;
+  margin: 1.25rem auto 0;
+  width: fit-content;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55rem;
+  padding: 0.5rem 0.6rem 0.5rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid #efbfd0;
+  background: #fff7fb;
   text-align: center;
-  font-size: 0.88rem;
-  color: #6b7280;
+  font-size: 0.85rem;
+  color: #7c6d81;
 }
 
-.signup-footer-note a {
-  color: #1f2328;
+.signup-footer-login-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 1.9rem;
+  padding: 0.18rem 0.72rem;
+  border-radius: 999px;
+  border: 1px solid #efbfd0;
+  background: #f6d8e6;
+  color: #6d3f58 !important;
   font-weight: 700;
+  text-decoration: none;
+  transition: background-color 0.18s ease, border-color 0.18s ease, transform 0.18s ease;
+  cursor: pointer;
+  font-family: inherit;
 }
+
+.signup-footer-login-link:hover {
+  background: #f2cddd;
+  border-color: #e8a8bf;
+  transform: translateY(-1px);
+}
+
+.signup-confirm-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 310;
+  background: rgba(44, 31, 44, 0.24);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+
+.signup-confirm-modal {
+  width: 100%;
+  max-width: 390px;
+  border-radius: 16px;
+  border: 1px solid #efbfd0;
+  background: #fff;
+  padding: 1.15rem 1.1rem 1rem;
+  box-shadow: 0 18px 46px rgba(90, 55, 83, 0.22);
+  text-align: left;
+}
+
+.signup-confirm-badge {
+  width: 1.9rem;
+  height: 1.9rem;
+  border-radius: 999px;
+  border: 1px solid #efbfd0;
+  background: #fff3f8;
+  color: #9b5476;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.95rem;
+  font-weight: 800;
+}
+
+.signup-confirm-modal h3 {
+  margin: 0.65rem 0 0.35rem;
+  font-size: 1rem;
+  color: #4e3550;
+}
+
+.signup-confirm-modal p {
+  margin: 0;
+  font-size: 0.84rem;
+  line-height: 1.55;
+  color: #7d6a7d;
+}
+
+.signup-confirm-actions {
+  margin-top: 0.95rem;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem;
+}
+
+.signup-confirm-btn {
+  min-height: 2.2rem;
+  border-radius: 10px;
+  font-size: 0.82rem;
+  font-weight: 700;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.signup-confirm-btn--ghost {
+  border: 1px solid #e5d6df;
+  background: #fff;
+  color: #7a6b7b;
+}
+
+.signup-confirm-btn--ghost:hover {
+  background: #faf8fb;
+}
+
+.signup-confirm-btn--primary {
+  border: 1px solid #efbfd0;
+  background: #f6d8e6;
+  color: #6d3f58;
+}
+
+.signup-confirm-btn--primary:hover {
+  background: #f2cddd;
+  border-color: #e8a8bf;
+}
+
 
 .signup-step2-actions {
   display: flex;
@@ -480,7 +663,7 @@
   background: #fff;
   border: 1px solid #e8eaed;
   border-radius: 18px;
-  padding: 2.25rem 1.5rem 1.75rem;
+  padding: 2.8rem 1.85rem 2.2rem;
   box-shadow: 0 14px 44px rgba(31, 35, 40, 0.08);
   overflow: hidden;
   color: #1f2328;
@@ -554,13 +737,13 @@
 .signup-complete-icon {
   font-size: 2.75rem;
   line-height: 1;
-  margin-bottom: 0.75rem;
+  margin-bottom: 1rem;
   position: relative;
   z-index: 1;
 }
 
 .signup-complete-title {
-  margin: 0 0 0.65rem;
+  margin: 0 0 0.85rem;
   font-size: 1.65rem;
   font-weight: 800;
   letter-spacing: -0.03em;
@@ -570,7 +753,7 @@
 }
 
 .signup-complete-line {
-  margin: 0 0 0.35rem;
+  margin: 0 0 0.8rem;
   font-size: 1rem;
   color: #1f2328;
   position: relative;
@@ -596,11 +779,10 @@
 }
 
 .signup-complete-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.65rem;
-  justify-content: center;
-  margin-top: 0.25rem;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.8rem;
+  margin-top: 1.35rem;
   position: relative;
   z-index: 1;
 }
@@ -609,31 +791,35 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 10.5rem;
-  padding: 0.75rem 1.25rem;
-  border-radius: 999px;
-  font-size: 0.9rem;
+  min-height: 2.9rem;
+  width: 100%;
+  padding: 0.85rem 0.9rem;
+  border-radius: 12px;
+  font-size: 0.86rem;
   font-weight: 700;
   text-decoration: none;
   box-sizing: border-box;
+  font-family: inherit;
+  cursor: pointer;
 }
 
 .signup-complete-btn--ghost {
-  background: transparent;
-  color: #1f2328;
-  border: 1.5px solid #1f2328;
+  background: #fff;
+  color: #7a6b7b;
+  border: 1px solid #e3d5de;
 }
 
 .signup-complete-btn--ghost:hover {
-  background: #f3f4f6;
+  background: #faf8fb;
 }
 
 .signup-complete-btn--dark {
-  background: #1a1a2e;
-  color: #fff;
-  border: 1px solid #1a1a2e;
+  background: #f6d8e6;
+  color: #6d3f58;
+  border: 1px solid #efbfd0;
 }
 
 .signup-complete-btn--dark:hover {
-  background: #121220;
+  background: #f2cddd;
+  border-color: #e8a8bf;
 }

--- a/frontend/src/pages/SignupPage.jsx
+++ b/frontend/src/pages/SignupPage.jsx
@@ -9,6 +9,8 @@ import {
   sendSignupEmailVerification,
   toUserErrorMessage,
 } from '../api/client'
+import { useAuth } from '../context/useAuth.js'
+import { extractTravelDnaTags } from '../lib/travelDna.js'
 
 import './SignupPage.css'
 
@@ -99,6 +101,7 @@ function Stepper({ step }) {
 }
 
 export function SignupPage() {
+  const { login } = useAuth()
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
   const [step, setStep] = useState(1)
@@ -123,12 +126,13 @@ export function SignupPage() {
   const [error, setError] = useState('')
   const [idCheckMessage, setIdCheckMessage] = useState('')
   const [loading, setLoading] = useState(false)
+  const [postSignupBusy, setPostSignupBusy] = useState(false)
   const [doneId, setDoneId] = useState(null)
   const [dupBusy, setDupBusy] = useState(false)
   const [emailSendBusy, setEmailSendBusy] = useState(false)
   const [emailConfirmBusy, setEmailConfirmBusy] = useState(false)
 
-  const [dnaModalOpen, setDnaModalOpen] = useState(false)
+  const [loginConfirmOpen, setLoginConfirmOpen] = useState(false)
   const [dnaMoments, setDnaMoments] = useState([])
   const [dnaPace, setDnaPace] = useState('')
   const [dnaWith, setDnaWith] = useState('')
@@ -136,11 +140,6 @@ export function SignupPage() {
 
   const nickname = userId.trim()
   const isPopNavRef = useRef(false)
-
-  // Step 3 진입 시 DNA 모달 자동 오픈
-  useEffect(() => {
-    if (step === 3) setDnaModalOpen(true)
-  }, [step])
 
   // 스텝 진입 시 history entry 추가 (step 1은 초기 상태이므로 skip)
   useEffect(() => {
@@ -154,7 +153,7 @@ export function SignupPage() {
     const onPop = (e) => {
       const target = typeof e.state?.signupStep === 'number' ? e.state.signupStep : 1
       isPopNavRef.current = true
-      setStep(target >= 1 && target <= 3 ? target : 1)
+      setStep(target >= 1 && target <= 4 ? target : 1)
     }
     window.addEventListener('popstate', onPop)
     return () => window.removeEventListener('popstate', onPop)
@@ -190,7 +189,7 @@ export function SignupPage() {
     setError('')
     setIdCheckMessage('')
     if (!idPatternOk(nickname)) {
-      setIdCheckMessage('아이디는 영문·숫자 2~16자여야 합니다.')
+      setIdCheckMessage('닉네임은 영문, 숫자 2~16자여야 합니다.')
       setIdFormatChecked(false)
       return
     }
@@ -199,12 +198,12 @@ export function SignupPage() {
     try {
       const available = await fetchNicknameAvailable(nickname)
       if (!available) {
-        setIdCheckMessage('이미 사용 중인 아이디(닉네임)입니다.')
+        setIdCheckMessage('이미 사용 중인 닉네임입니다.')
         setIdFormatChecked(false)
         return
       }
       setIdFormatChecked(true)
-      setIdCheckMessage('사용 가능한 아이디입니다. (최종 가입 시 서버에서 한 번 더 확인합니다.)')
+      setIdCheckMessage('사용 가능한 닉네임입니다.')
     } catch (err) {
       setError(err instanceof Error ? err.message : '중복 확인에 실패했습니다.')
       setIdFormatChecked(false)
@@ -232,11 +231,11 @@ export function SignupPage() {
       return
     }
     if (!idPatternOk(nickname)) {
-      setError('아이디는 영문·숫자 2~16자여야 합니다.')
+      setError('닉네임은 영문, 숫자 2~16자여야 합니다.')
       return
     }
     if (!idFormatChecked) {
-      setError('아이디 중복 확인(형식 검사)을 눌러 주세요.')
+      setError('닉네임 중복 확인(형식 검사)을 눌러 주세요.')
       return
     }
     if (!passwordPolicyOk(password)) {
@@ -345,52 +344,73 @@ export function SignupPage() {
         ? '00:00'
         : '03:00'
 
+  const dnaPreview = buildDnaPreview(dnaMoments, dnaPace, dnaWith, dnaExpect)
+  const dnaTotalSelected = dnaMoments.length + (dnaPace ? 1 : 0) + (dnaWith ? 1 : 0) + (dnaExpect ? 1 : 0)
+
+  const handleDnaNext = () => {
+    void finishSignupAndGoHome(true)
+  }
+
+  const toggleDnaMoment = (val) =>
+    setDnaMoments((prev) => (prev.includes(val) ? prev.filter((v) => v !== val) : [...prev, val]))
+
+  const finishSignupAndGoHome = async (saveDna) => {
+    setError('')
+    setPostSignupBusy(true)
+    try {
+      if (saveDna) {
+        const dna = { moments: dnaMoments, pace: dnaPace, travelWith: dnaWith, expect: dnaExpect }
+        localStorage.setItem(
+          'localguest_travel_dna',
+          JSON.stringify(dna),
+        )
+        localStorage.setItem('localguest_mypage_travel_tags', JSON.stringify(extractTravelDnaTags(dna)))
+      }
+      await login(email.trim(), password, 'GUEST')
+      sessionStorage.removeItem('prefill_login_email')
+      navigate('/', { replace: true })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : '자동 로그인에 실패했습니다. 로그인 화면으로 이동해 주세요.'
+      setError(message)
+      navigate('/auth/login', {
+        replace: true,
+        state: { returnTo: '/', hint: message },
+      })
+    } finally {
+      setPostSignupBusy(false)
+    }
+  }
+
+  const loginConfirmModal = loginConfirmOpen ? (
+    <div className="signup-confirm-overlay" role="dialog" aria-modal="true" aria-labelledby="signup-login-confirm-title">
+      <div className="signup-confirm-modal">
+        <div className="signup-confirm-badge" aria-hidden>
+          ⚠
+        </div>
+        <h3 id="signup-login-confirm-title">정말 로그인하러 가실까요?</h3>
+        <p>
+          지금 이동하면 회원가입 작성 내용이 초기화되어 처음부터 다시 진행해야 해요.
+        </p>
+        <div className="signup-confirm-actions">
+          <button type="button" className="signup-confirm-btn signup-confirm-btn--ghost" onClick={() => setLoginConfirmOpen(false)}>
+            계속 가입하기
+          </button>
+          <button
+            type="button"
+            className="signup-confirm-btn signup-confirm-btn--primary"
+            onClick={() => navigate('/auth/login')}
+          >
+            로그인하러 가기
+          </button>
+        </div>
+      </div>
+    </div>
+  ) : null
+
   if (step === 3) {
-    const dnaPreview = buildDnaPreview(dnaMoments, dnaPace, dnaWith, dnaExpect)
-    const dnaTotalSelected = dnaMoments.length + (dnaPace ? 1 : 0) + (dnaWith ? 1 : 0) + (dnaExpect ? 1 : 0)
-
-    const handleDnaNext = () => {
-      localStorage.setItem('localguest_travel_dna', JSON.stringify({ moments: dnaMoments, pace: dnaPace, travelWith: dnaWith, expect: dnaExpect }))
-      navigate('/ai-search', { state: { initialPrompt: buildDnaPrompt(dnaMoments, dnaPace, dnaWith, dnaExpect) } })
-    }
-
-    const toggleDnaMoment = (val) =>
-      setDnaMoments((prev) => (prev.includes(val) ? prev.filter((v) => v !== val) : [...prev, val]))
-
-    /* ── inline style tokens ── */
-    const S = {
-      overlay: { position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.52)', zIndex: 300, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '1rem', overflowY: 'auto' },
-      modal: { background: '#fff', borderRadius: 16, padding: '1.75rem 1.5rem 1.5rem', maxWidth: 560, width: '100%', maxHeight: '88vh', overflowY: 'auto', boxShadow: '0 24px 64px rgba(0,0,0,0.22)', colorScheme: 'light' },
-      banner: { display: 'flex', alignItems: 'flex-start', gap: 10, padding: '12px 14px', borderRadius: 10, background: '#ecfdf5', border: '1px solid #a7f3d0', marginBottom: '1.25rem' },
-      bannerTitle: { fontSize: '0.82rem', fontWeight: 600, color: '#065f46' },
-      bannerSub: { fontSize: '0.75rem', color: '#059669', marginTop: 2, lineHeight: 1.45 },
-      kicker: { fontSize: '0.7rem', fontWeight: 600, letterSpacing: '0.12em', color: '#9aa0a6', margin: '0 0 0.3rem' },
-      title: { fontSize: '1.25rem', fontWeight: 800, letterSpacing: '-0.03em', color: '#1f2328', margin: '0 0 0.4rem', lineHeight: 1.3 },
-      lead: { fontSize: '0.85rem', color: '#6b7280', lineHeight: 1.55, margin: '0 0 1.25rem' },
-      qBlock: { marginBottom: '1.25rem' },
-      qTitle: { fontSize: '0.85rem', fontWeight: 700, color: '#1f2328', marginBottom: '0.18rem' },
-      qDesc: { fontSize: '0.72rem', color: '#9aa0a6', marginBottom: '0.6rem' },
-      cardGrid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fill,minmax(140px,1fr))', gap: 8 },
-      card: (on) => ({ background: on ? '#fff' : '#f4f5f7', border: on ? '1.5px solid #1f2328' : '1px solid #e8eaed', borderRadius: 12, padding: '11px 11px 9px', cursor: 'pointer', position: 'relative', userSelect: 'none', transition: 'border-color .15s, background .15s' }),
-      cardIcon: { fontSize: '1.25rem', marginBottom: 6, lineHeight: 1 },
-      cardName: { fontSize: '0.8rem', fontWeight: 600, color: '#1f2328', marginBottom: 2 },
-      cardHint: { fontSize: '0.68rem', color: '#9aa0a6', lineHeight: 1.4 },
-      check: (on) => ({ position: 'absolute', top: 8, right: 8, width: 18, height: 18, borderRadius: '50%', background: '#1f2328', display: 'flex', alignItems: 'center', justifyContent: 'center', opacity: on ? 1 : 0, transform: on ? 'scale(1)' : 'scale(0.6)', transition: 'opacity .18s, transform .18s' }),
-      divider: { height: 1, background: '#e8eaed', margin: '0 0 1.25rem' },
-      pillRow: { display: 'flex', flexWrap: 'wrap', gap: 7 },
-      pill: (on) => ({ padding: '7px 13px', borderRadius: 999, border: on ? '1px solid #1f2328' : '1px solid #e8eaed', background: on ? '#1f2328' : '#f4f5f7', fontSize: '0.82rem', color: on ? '#fff' : '#4b5563', cursor: 'pointer', transition: 'all .15s', userSelect: 'none' }),
-      preview: { background: '#f4f5f7', borderRadius: 12, padding: '11px 13px', marginTop: '1.1rem', minHeight: 50, border: '1px solid #e8eaed' },
-      previewLabel: { fontSize: '0.65rem', fontWeight: 600, letterSpacing: '0.06em', color: '#9aa0a6', textTransform: 'uppercase', marginBottom: 4 },
-      previewText: (filled) => ({ fontSize: '0.82rem', color: filled ? '#1f2328' : '#9aa0a6', fontStyle: filled ? 'normal' : 'italic', lineHeight: 1.55 }),
-      counter: { fontSize: '0.7rem', color: '#9aa0a6', marginTop: '0.4rem', textAlign: 'right' },
-      btnRow: { display: 'flex', gap: 8, marginTop: '1.4rem' },
-      btnSkip: { flex: 1, padding: '0.72rem', borderRadius: 12, border: '1px solid #e8eaed', background: 'transparent', fontSize: '0.82rem', color: '#9aa0a6', cursor: 'pointer', fontFamily: 'inherit' },
-      btnNext: { flex: 2.5, padding: '0.72rem', borderRadius: 12, border: 'none', background: '#1f2328', color: '#fff', fontSize: '0.88rem', fontWeight: 700, cursor: 'pointer', fontFamily: 'inherit' },
-    }
-
     return (
       <>
-        <div className="signup-wrap">
+        <div key="signup-step-3" className="signup-wrap signup-step-transition">
           <Stepper step={3} />
 
           <div className="signup-complete">
@@ -407,128 +427,166 @@ export function SignupPage() {
             <p className="signup-complete-line">
               <strong>LocalGuest</strong> 가입이 완료되었습니다.
             </p>
-            <p className="signup-complete-sub">여행 스타일을 알려주시면 AI가 딱 맞는 가이드를 추천해드릴게요.</p>
-            {doneId != null && <p className="signup-complete-id">회원 ID: {doneId}</p>}
 
             <div className="signup-complete-actions">
-              <button type="button" className="signup-complete-btn signup-complete-btn--ghost" onClick={() => setDnaModalOpen(true)}>
-                내 여행 스타일 설정하기
-              </button>
-              <Link
-                to="/auth/login"
-                className="signup-complete-btn signup-complete-btn--dark"
-                state={{ fromSignup: true, hint: '로그인 후 상단「AI 검색」또는 /api/ai/recommend 를 이용할 수 있습니다. (현재 해당 API는 인증 필요)' }}
+              <button
+                type="button"
+                className="signup-complete-btn signup-complete-btn--ghost"
+                onClick={() => void finishSignupAndGoHome(false)}
+                disabled={postSignupBusy}
               >
-                ✨ AI 가이드 추천받기
-              </Link>
+                {postSignupBusy ? '이동 중…' : '성향 건너뛰기'}
+              </button>
+              <button
+                type="button"
+                className="signup-complete-btn signup-complete-btn--dark"
+                onClick={() => setStep(4)}
+                disabled={postSignupBusy}
+              >
+                여행 성향 입력하기
+              </button>
             </div>
           </div>
-
-          <p className="signup-footer-note">
-            <Link to="/auth/login">로그인</Link>
-          </p>
         </div>
+      </>
+    )
+  }
 
-        {dnaModalOpen && (
-          <div style={S.overlay} onClick={(e) => { if (e.target === e.currentTarget) setDnaModalOpen(false) }}>
-            <div style={S.modal}>
-              <div style={S.banner}>
-                <span style={{ fontSize: '1.1rem', lineHeight: 1.4, flexShrink: 0 }}>🎉</span>
-                <div>
-                  <div style={S.bannerTitle}>가입이 완료됐어요!</div>
-                  <div style={S.bannerSub}>마지막으로 여행 스타일만 알려주시면 AI가 바로 가이드를 찾아드려요.</div>
-                </div>
-              </div>
+  if (step === 4) {
+    const S = {
+      modal: {
+        background: '#fff',
+        borderRadius: 16,
+        padding: '1.75rem 1.5rem 1.5rem',
+        width: '100%',
+        border: '1px solid #e8eaed',
+        boxShadow: '0 12px 40px rgba(31, 35, 40, 0.08)',
+        colorScheme: 'light',
+      },
+      kicker: { fontSize: '0.7rem', fontWeight: 600, letterSpacing: '0.12em', color: '#9aa0a6', margin: '0 0 0.3rem' },
+      title: { fontSize: '1.25rem', fontWeight: 800, letterSpacing: '-0.03em', color: '#1f2328', margin: '0 0 0.4rem', lineHeight: 1.3 },
+      lead: { fontSize: '0.85rem', color: '#6b7280', lineHeight: 1.55, margin: '0 0 1.25rem' },
+      qBlock: { marginBottom: '1.25rem' },
+      qTitle: { fontSize: '0.85rem', fontWeight: 700, color: '#1f2328', marginBottom: '0.18rem' },
+      qDesc: { fontSize: '0.72rem', color: '#9aa0a6', marginBottom: '0.6rem' },
+      cardGrid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fill,minmax(160px,1fr))', gap: 10 },
+      card: (on) => ({ background: on ? '#fff8fb' : '#f4f5f7', border: on ? '1.5px solid #efbfd0' : '1px solid #e8eaed', borderRadius: 12, padding: '11px 11px 9px', cursor: 'pointer', position: 'relative', userSelect: 'none', transition: 'border-color .15s, background .15s' }),
+      cardIcon: { fontSize: '1.25rem', marginBottom: 6, lineHeight: 1 },
+      cardName: { fontSize: '0.8rem', fontWeight: 600, color: '#1f2328', marginBottom: 2 },
+      cardHint: { fontSize: '0.68rem', color: '#9aa0a6', lineHeight: 1.4 },
+      check: (on) => ({ position: 'absolute', top: 8, right: 8, width: 18, height: 18, borderRadius: '50%', background: '#cf6f95', display: 'flex', alignItems: 'center', justifyContent: 'center', opacity: on ? 1 : 0, transform: on ? 'scale(1)' : 'scale(0.6)', transition: 'opacity .18s, transform .18s' }),
+      divider: { height: 1, background: '#e8eaed', margin: '0 0 1.25rem' },
+      pillRow: { display: 'flex', flexWrap: 'wrap', gap: 7 },
+      pill: (on) => ({ padding: '7px 13px', borderRadius: 999, border: on ? '1px solid #efbfd0' : '1px solid #e8eaed', background: on ? '#f6d8e6' : '#f4f5f7', fontSize: '0.82rem', color: on ? '#6d3f58' : '#4b5563', cursor: 'pointer', transition: 'all .15s', userSelect: 'none' }),
+      preview: { background: '#f4f5f7', borderRadius: 12, padding: '11px 13px', marginTop: '1.1rem', minHeight: 50, border: '1px solid #e8eaed' },
+      previewLabel: { fontSize: '0.65rem', fontWeight: 600, letterSpacing: '0.06em', color: '#9aa0a6', textTransform: 'uppercase', marginBottom: 4 },
+      previewText: (filled) => ({ fontSize: '0.82rem', color: filled ? '#1f2328' : '#9aa0a6', fontStyle: filled ? 'normal' : 'italic', lineHeight: 1.55 }),
+      counter: { fontSize: '0.7rem', color: '#9aa0a6', marginTop: '0.4rem', textAlign: 'right' },
+      btnRow: { display: 'flex', gap: 8, marginTop: '1.4rem' },
+      btnSkip: { flex: 1, padding: '0.72rem', borderRadius: 12, border: '1px solid #e8eaed', background: 'transparent', fontSize: '0.82rem', color: '#9aa0a6', cursor: 'pointer', fontFamily: 'inherit' },
+      btnNext: { flex: 2.5, padding: '0.72rem', borderRadius: 12, border: 'none', background: '#f6d8e6', color: '#6d3f58', fontSize: '0.88rem', fontWeight: 700, cursor: 'pointer', fontFamily: 'inherit' },
+    }
 
-              <p style={S.kicker}>STEP 4 · TRAVEL DNA</p>
-              <h2 style={S.title}>당신만의 여행 DNA를<br />알려주세요</h2>
-              <p style={S.lead}>선택하신 스타일로 AI가 딱 맞는 로컬 가이드를 연결해 드려요.<br />정답은 없어요, 솔직하게 골라주세요.</p>
+    return (
+      <div key="signup-step-4" className="signup-wrap signup-wrap--wide signup-step-transition">
+        <Stepper step={4} />
+        <div style={S.modal}>
+          <p style={S.kicker}>STEP 4 · TRAVEL DNA</p>
+          <h2 style={S.title}>당신만의 여행 성향을 알려주세요</h2>
+          <p style={S.lead}>선택하신 성향으로 AI가 더 잘 맞는 가이드를 추천해드려요.</p>
 
-              <div style={S.qBlock}>
-                <div style={S.qTitle}>어떤 순간을 원하나요?</div>
-                <div style={S.qDesc}>여러 개 선택할수록 추천이 정확해져요</div>
-                <div style={S.cardGrid}>
-                  {DNA_MOMENT_OPTIONS.map((opt) => {
-                    const on = dnaMoments.includes(opt.val)
-                    return (
-                      <div key={opt.val} style={S.card(on)} onClick={() => toggleDnaMoment(opt.val)}>
-                        <div style={S.check(on)}>
-                          <svg viewBox="0 0 10 8" width="9" height="9" stroke="#fff" fill="none" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-                            <polyline points="1,4 3.5,7 9,1" />
-                          </svg>
-                        </div>
-                        <div style={S.cardIcon}>{opt.icon}</div>
-                        <div style={S.cardName}>{opt.name}</div>
-                        <div style={S.cardHint}>{opt.hint}</div>
-                      </div>
-                    )
-                  })}
-                </div>
-              </div>
-
-              <div style={S.divider} />
-
-              <div style={S.qBlock}>
-                <div style={S.qTitle}>여행 페이스는요?</div>
-                <div style={S.pillRow}>
-                  {DNA_PACE_OPTIONS.map((opt) => (
-                    <div key={opt.val} style={S.pill(dnaPace === opt.val)} onClick={() => setDnaPace(opt.val)}>{opt.label}</div>
-                  ))}
-                </div>
-              </div>
-
-              <div style={S.qBlock}>
-                <div style={S.qTitle}>함께하는 사람은요?</div>
-                <div style={S.pillRow}>
-                  {DNA_WITH_OPTIONS.map((opt) => (
-                    <div key={opt} style={S.pill(dnaWith === opt)} onClick={() => setDnaWith(opt)}>{opt}</div>
-                  ))}
-                </div>
-              </div>
-
-              <div style={S.qBlock}>
-                <div style={S.qTitle}>가이드에게 기대하는 건요?</div>
-                <div style={S.pillRow}>
-                  {DNA_EXPECT_OPTIONS.map((opt) => (
-                    <div key={opt} style={S.pill(dnaExpect === opt)} onClick={() => setDnaExpect(opt)}>{opt}</div>
-                  ))}
-                </div>
-              </div>
-
-              <div style={S.preview}>
-                <div style={S.previewLabel}>내 여행 스타일 미리보기</div>
-                <div style={S.previewText(!!dnaPreview)}>{dnaPreview || '선택할수록 나만의 여행 프로필이 완성돼요.'}</div>
-              </div>
-              <div style={S.counter}>{dnaTotalSelected > 0 ? `총 ${dnaTotalSelected}가지 선택됨` : '아직 선택 전이에요'}</div>
-
-              <div style={S.btnRow}>
-                <button style={S.btnSkip} onClick={() => setDnaModalOpen(false)}>나중에 할게요</button>
-                <button style={S.btnNext} onClick={handleDnaNext}>내 가이드 찾으러 가기 →</button>
-              </div>
+          <div style={S.qBlock}>
+            <div style={S.qTitle}>어떤 순간을 원하나요?</div>
+            <div style={S.qDesc}>여러 개 선택할수록 추천이 정확해져요</div>
+            <div style={S.cardGrid}>
+              {DNA_MOMENT_OPTIONS.map((opt) => {
+                const on = dnaMoments.includes(opt.val)
+                return (
+                  <div key={opt.val} style={S.card(on)} onClick={() => toggleDnaMoment(opt.val)}>
+                    <div style={S.check(on)}>
+                      <svg viewBox="0 0 10 8" width="9" height="9" stroke="#fff" fill="none" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                        <polyline points="1,4 3.5,7 9,1" />
+                      </svg>
+                    </div>
+                    <div style={S.cardIcon}>{opt.icon}</div>
+                    <div style={S.cardName}>{opt.name}</div>
+                    <div style={S.cardHint}>{opt.hint}</div>
+                  </div>
+                )
+              })}
             </div>
           </div>
-        )}
-      </>
+
+          <div style={S.divider} />
+
+          <div style={S.qBlock}>
+            <div style={S.qTitle}>여행 페이스는요?</div>
+            <div style={S.pillRow}>
+              {DNA_PACE_OPTIONS.map((opt) => (
+                <div key={opt.val} style={S.pill(dnaPace === opt.val)} onClick={() => setDnaPace(opt.val)}>{opt.label}</div>
+              ))}
+            </div>
+          </div>
+
+          <div style={S.qBlock}>
+            <div style={S.qTitle}>함께하는 사람은요?</div>
+            <div style={S.pillRow}>
+              {DNA_WITH_OPTIONS.map((opt) => (
+                <div key={opt} style={S.pill(dnaWith === opt)} onClick={() => setDnaWith(opt)}>{opt}</div>
+              ))}
+            </div>
+          </div>
+
+          <div style={S.qBlock}>
+            <div style={S.qTitle}>가이드에게 기대하는 건요?</div>
+            <div style={S.pillRow}>
+              {DNA_EXPECT_OPTIONS.map((opt) => (
+                <div key={opt} style={S.pill(dnaExpect === opt)} onClick={() => setDnaExpect(opt)}>{opt}</div>
+              ))}
+            </div>
+          </div>
+
+          <div style={S.preview}>
+            <div style={S.previewLabel}>내 여행 성향 미리보기</div>
+            <div style={S.previewText(!!dnaPreview)}>{dnaPreview || '선택할수록 나만의 여행 성향이 완성돼요.'}</div>
+          </div>
+          <div style={S.counter}>{dnaTotalSelected > 0 ? `총 ${dnaTotalSelected}가지 선택됨` : '아직 선택 전이에요'}</div>
+
+          <div style={S.btnRow}>
+            <button style={S.btnSkip} onClick={() => void finishSignupAndGoHome(false)} disabled={postSignupBusy}>
+              {postSignupBusy ? '이동 중…' : '성향 건너뛰고 시작하기'}
+            </button>
+            <button style={S.btnNext} onClick={handleDnaNext} disabled={postSignupBusy}>
+              {postSignupBusy ? '이동 중…' : '여행 성향 저장하고 시작하기'}
+            </button>
+          </div>
+        </div>
+      </div>
     )
   }
 
   if (step === 2) {
     return (
-      <div className="signup-wrap">
+      <div key="signup-step-2" className="signup-wrap signup-step-transition">
         <Stepper step={2} />
 
-        <div className="signup-card">
+        <div className="signup-card signup-card--verify">
           <span className="signup-card-accent signup-card-accent--lime" aria-hidden />
+          <button
+            type="button"
+            className="signup-back-icon"
+            onClick={() => setStep(1)}
+            aria-label="이전 단계로 이동"
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M14.75 5.75L8.5 12l6.25 6.25" />
+            </svg>
+          </button>
           <p className="signup-kicker">STEP 2. VERIFICATION</p>
-          <h1 className="signup-title">이메일 인증을 완료해주세요 🔒</h1>
+          <h1 className="signup-title">이메일 인증을 완료해주세요</h1>
           <p className="signup-lead">
-            안전한 서비스 이용을 위해 가입하신 이메일로 본인 인증이 필요합니다.
+            계정 보호와 원활한 이용을 위해 이메일 인증이 필요합니다.
           </p>
-
-          <div className="signup-info-box">
-            💡 <strong>왜 인증이 필요한가요?</strong> 가이드와 여행자 간의 신뢰할 수 있는 매칭을 위해 필수적인 절차입니다.
-            <span className="signup-info-sub">서버에서 인증번호를 발송·검증합니다. (백엔드 API가 준비되어 있어야 합니다.)</span>
-          </div>
 
           <div className="signup-field">
             <div className="signup-label-row">
@@ -547,7 +605,9 @@ export function SignupPage() {
                 {emailSendBusy ? '발송 중…' : codeSent ? '발송완료' : '인증번호 발송'}
               </button>
             </div>
-            <p className="signup-hint">입력하신 이메일로 6자리 인증번호가 발송됩니다.</p>
+            <p className={`signup-hint${codeSent ? ' signup-hint--sent' : ''}`}>
+              {codeSent ? '인증번호가 발송되었습니다.' : '입력하신 이메일로 6자리 인증번호가 발송됩니다.'}
+            </p>
           </div>
 
           <div className="signup-field">
@@ -600,22 +660,22 @@ export function SignupPage() {
             {loading ? '처리 중…' : '✓ 인증 완료 → 가입 완료'}
           </button>
 
-          <p className="signup-demo-note">
-            <button type="button" className="signup-linkish" onClick={() => setStep(1)}>
-              ← 이전 단계 (계정 정보)
-            </button>
-          </p>
         </div>
 
         <p className="signup-footer-note">
-          이미 계정이 있나요? <Link to="/auth/login">로그인</Link>
+          <span>이미 계정이 있으신가요?</span>
+          <button type="button" className="signup-footer-login-link" onClick={() => setLoginConfirmOpen(true)}>
+            로그인하러 가기
+          </button>
         </p>
+
+        {loginConfirmModal}
       </div>
     )
   }
 
   return (
-    <div className="signup-wrap">
+    <div key="signup-step-1" className="signup-wrap signup-step-transition">
       <Stepper step={1} />
 
       <form className="signup-card" onSubmit={(e) => void goStep2(e)}>
@@ -636,7 +696,7 @@ export function SignupPage() {
         <div className="signup-field">
           <div className="signup-label-row">
             <label className="signup-label" htmlFor="su-email">
-              이메일<span className="req">*</span>
+              이메일(아이디)<span className="req">*</span>
             </label>
           </div>
           <input
@@ -660,7 +720,6 @@ export function SignupPage() {
               이름<span className="req">*</span>
             </label>
           </div>
-          <p className="signup-hint">백엔드 회원가입 API 필수 항목입니다.</p>
           <input
             id="su-name"
             className="signup-input"
@@ -675,17 +734,17 @@ export function SignupPage() {
         <div className="signup-field">
           <div className="signup-label-row">
             <label className="signup-label" htmlFor="su-id">
-              아이디<span className="req">*</span>
+              닉네임<span className="req">*</span>
             </label>
           </div>
-          <p className="signup-hint">영문, 숫자 2~16자 · 서비스 닉네임으로 저장됩니다.</p>
+          <p className="signup-hint">영문, 숫자 2~16자</p>
           <div className="signup-input-row">
             <input
               id="su-id"
               className="signup-input"
               type="text"
               autoComplete="username"
-              placeholder="아이디를 입력해주세요"
+              placeholder="닉네임을 입력해주세요"
               value={userId}
               onChange={(ev) => {
                 setUserId(ev.target.value)
@@ -773,8 +832,13 @@ export function SignupPage() {
       </form>
 
       <p className="signup-footer-note">
-        이미 계정이 있나요? <Link to="/auth/login">로그인</Link>
+        <span>이미 계정이 있으신가요?</span>
+        <button type="button" className="signup-footer-login-link" onClick={() => setLoginConfirmOpen(true)}>
+          로그인하러 가기
+        </button>
       </p>
+
+      {loginConfirmModal}
     </div>
   )
 }

--- a/frontend/src/routes/mypageRoutes.jsx
+++ b/frontend/src/routes/mypageRoutes.jsx
@@ -9,6 +9,7 @@ import { MypagePrivacyPage } from '../pages/MypagePrivacyPage'
 import { MypageProfilePage } from '../pages/MypageProfilePage'
 import { MypageReviewsPage } from '../pages/MypageReviewsPage'
 import { MypageScrapbookPage } from '../pages/MypageScrapbookPage'
+import { MypageScrapbookTicketDetailPage } from '../pages/MypageScrapbookTicketDetailPage'
 import { MypageTourPage } from '../pages/MypageTourPage'
 
 export const mypageRoutes = [
@@ -33,6 +34,10 @@ export const mypageRoutes = [
       {
         path: 'scrapbook',
         element: <MypageScrapbookPage />,
+      },
+      {
+        path: 'scrapbook/:requestId',
+        element: <MypageScrapbookTicketDetailPage />,
       },
       {
         path: 'itinerary',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "Team6LocalGuest_6",
+  "name": "LocalGuest",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {}


### PR DESCRIPTION
# 🔗 이슈 번호
- Closes #360 

---

## 💡 주요 변경 사항
- 로그인/회원가입/온보딩/메인/마이페이지/가이드 마이페이지 UI 전역 리디자인
- 사용자 상태 문구/버튼/배지/빈 상태 메시지를 사용자 친화적으로 통일
- 여행 성향(DNA) 입력/저장/노출 흐름 정리 및 관련 화면 반영
- 스크랩북/리뷰/결제/일정/가이드 상세 페이지 동선 개선
- AI 검색 카드 해시태그를 가이드 스타일 기반으로 노출하도록 로직 조정
- 가이드 설정 화면 간소화 및 비활성화 확인 모달 추가
- 전역 스타일 수정 중 발생한 렌더 루프 등 안정성 이슈 수정

---

## ⚠️ 주의 사항 / 질문
- 수정 범위가 넓어 화면 간 스타일 영향도 확인이 필요합니다.
- 리뷰 시 페이지별 실제 사용자 시나리오(로그인→검색→매칭→마이페이지)를 순서대로 점검 부탁드립니다.
- 백엔드 응답 텍스트(정산 설명 등)에 의존하는 일부 문구는 프론트에서 방어적으로 정리했습니다.

---

## ✅ 체크리스트
- [x] 빌드가 정상적으로 되는가?
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [x] .gitignore에 설정 파일이 잘 포함되었는가? (application-local.yml 등)