### PR TITLE
Feat/fe#362: 저장/적용 안내 토스트 UI 및 위치 개선

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,54 +5,12 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="84d1b3de-8103-452e-83cf-38ecd34993e7" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/backend/module-domain/src/main/java/com/team6/domain/matching/controller/TourExtensionController.java" beforeDir="false" afterPath="$PROJECT_DIR$/backend/module-domain/src/main/java/com/team6/domain/matching/controller/TourExtensionController.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/backend/module-domain/src/main/java/com/team6/domain/matching/entity/TourExtension.java" beforeDir="false" afterPath="$PROJECT_DIR$/backend/module-domain/src/main/java/com/team6/domain/matching/entity/TourExtension.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/backend/module-domain/src/main/java/com/team6/domain/matching/exception/MatchingErrorCode.java" beforeDir="false" afterPath="$PROJECT_DIR$/backend/module-domain/src/main/java/com/team6/domain/matching/exception/MatchingErrorCode.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/backend/module-domain/src/main/java/com/team6/domain/matching/service/PaymentService.java" beforeDir="false" afterPath="$PROJECT_DIR$/backend/module-domain/src/main/java/com/team6/domain/matching/service/PaymentService.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/backend/module-domain/src/main/java/com/team6/domain/matching/service/TourExtensionService.java" beforeDir="false" afterPath="$PROJECT_DIR$/backend/module-domain/src/main/java/com/team6/domain/matching/service/TourExtensionService.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/package-lock.json" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/package-lock.json" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/components/SiteFooter.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/components/SiteFooter.css" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/index.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/index.css" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/layouts/AppLayout.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/layouts/AppLayout.css" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/layouts/AppLayout.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/layouts/AppLayout.jsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/layouts/DashboardLayout.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/layouts/DashboardLayout.css" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/layouts/DashboardLayout.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/layouts/DashboardLayout.jsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/layouts/GuideDashboardLayout.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/layouts/GuideDashboardLayout.css" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/layouts/GuideDashboardLayout.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/layouts/GuideDashboardLayout.jsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/lib/guestMypagePrefs.js" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/lib/guestMypagePrefs.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/pages/AiQuickSearchPage.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/AiQuickSearchPage.css" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/pages/AiQuickSearchPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/AiQuickSearchPage.jsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/pages/FormPage.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/FormPage.css" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuestUpcomingTripsPage.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuestUpcomingTripsPage.css" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuestUpcomingTripsPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuestUpcomingTripsPage.jsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideDetailPage.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideDetailPage.css" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideDetailPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideDetailPage.jsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideFeedTourPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideFeedTourPage.jsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideInboxPage.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideInboxPage.css" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideInboxPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideInboxPage.jsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideMatchOptionsPage.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideMatchOptionsPage.css" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideMatchOptionsPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideMatchOptionsPage.jsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideMatchedCoursePage.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideMatchedCoursePage.css" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideMatchedCoursePage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideMatchedCoursePage.jsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideMypagePages.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideMypagePages.css" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideProposalPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideProposalPage.jsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideReviewsManagePage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideReviewsManagePage.jsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/pages/HomePage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/HomePage.jsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/pages/LoginPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/LoginPage.jsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/pages/MypageMemberPages.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/MypageMemberPages.css" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/pages/MypagePrivacyPage.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/MypagePrivacyPage.css" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideFeedSchedulePage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideFeedSchedulePage.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideFeesPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideFeesPage.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideIntroEditPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideIntroEditPage.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideProfileEditPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideProfileEditPage.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/frontend/src/pages/GuideSettingsPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/GuideSettingsPage.jsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/frontend/src/pages/MypagePrivacyPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/MypagePrivacyPage.jsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/pages/MypageProfilePage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/MypageProfilePage.jsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/pages/MypageReviewsPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/MypageReviewsPage.jsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/pages/MypageScrapbookPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/MypageScrapbookPage.jsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/pages/MypageTourPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/MypageTourPage.jsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/pages/OnboardingPage.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/OnboardingPage.css" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/pages/PaymentKakaoStubPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/PaymentKakaoStubPage.jsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/pages/SignupPage.css" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/SignupPage.css" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/pages/SignupPage.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/pages/SignupPage.jsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/frontend/src/routes/mypageRoutes.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/frontend/src/routes/mypageRoutes.jsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/package-lock.json" beforeDir="false" afterPath="$PROJECT_DIR$/package-lock.json" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/frontend/src/pages/GuideFeedSchedulePage.jsx
+++ b/frontend/src/pages/GuideFeedSchedulePage.jsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 
 import { apiRequest } from '../api/client.js'
@@ -35,14 +36,32 @@ function useToast() {
 
 function Toast({ toasts }) {
   if (toasts.length === 0) return null
-  return (
-    <div style={{ position: 'fixed', bottom: '1.5rem', right: '1.5rem', zIndex: 9999, display: 'flex', flexDirection: 'column', gap: '0.5rem', pointerEvents: 'none' }}>
+  if (typeof document === 'undefined') return null
+  return createPortal(
+    <div style={{ position: 'fixed', top: '1.1rem', left: '50%', transform: 'translateX(-50%)', zIndex: 9999, display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center', pointerEvents: 'none' }}>
       {toasts.map((t) => (
-        <div key={t.id} style={{ padding: '0.7rem 1.2rem', borderRadius: 10, background: t.type === 'success' ? '#15803d' : '#b91c1c', color: '#fff', fontSize: '0.88rem', fontWeight: 600, boxShadow: '0 4px 16px rgba(0,0,0,0.18)', minWidth: 180, maxWidth: 320 }}>
+        <div
+          key={t.id}
+          style={{
+            padding: '0.74rem 0.98rem',
+            borderRadius: 12,
+            border: t.type === 'success' ? '1px solid #e7a8c2' : '1px solid #f7b4c1',
+            background: t.type === 'success' ? 'linear-gradient(180deg, #f7d9e8, #efbfd0)' : 'linear-gradient(180deg, #ffe8ee, #ffd8e1)',
+            color: t.type === 'success' ? '#5a2f45' : '#9f274c',
+            fontSize: '0.86rem',
+            fontWeight: 700,
+            boxShadow: '0 14px 28px rgba(15, 23, 42, 0.16)',
+            textAlign: 'center',
+            letterSpacing: '-0.01em',
+            minWidth: 240,
+            maxWidth: 420,
+          }}
+        >
           {t.message}
         </div>
       ))}
-    </div>
+    </div>,
+    document.body,
   )
 }
 

--- a/frontend/src/pages/GuideFeesPage.jsx
+++ b/frontend/src/pages/GuideFeesPage.jsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
 
 import { apiRequest } from '../api/client'
 import { resolveGuideId } from '../lib/guideId.js'
@@ -17,14 +18,32 @@ function useToast() {
 
 function Toast({ toasts }) {
   if (toasts.length === 0) return null
-  return (
-    <div style={{ position: 'fixed', bottom: '1.5rem', right: '1.5rem', zIndex: 9999, display: 'flex', flexDirection: 'column', gap: '0.5rem', pointerEvents: 'none' }}>
+  if (typeof document === 'undefined') return null
+  return createPortal(
+    <div style={{ position: 'fixed', top: '1.1rem', left: '50%', transform: 'translateX(-50%)', zIndex: 9999, display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center', pointerEvents: 'none' }}>
       {toasts.map((t) => (
-        <div key={t.id} style={{ padding: '0.7rem 1.2rem', borderRadius: 10, background: t.type === 'success' ? '#15803d' : '#b91c1c', color: '#fff', fontSize: '0.88rem', fontWeight: 600, boxShadow: '0 4px 16px rgba(0,0,0,0.18)', minWidth: 180, maxWidth: 320 }}>
+        <div
+          key={t.id}
+          style={{
+            padding: '0.74rem 0.98rem',
+            borderRadius: 12,
+            border: t.type === 'success' ? '1px solid #e7a8c2' : '1px solid #f7b4c1',
+            background: t.type === 'success' ? 'linear-gradient(180deg, #f7d9e8, #efbfd0)' : 'linear-gradient(180deg, #ffe8ee, #ffd8e1)',
+            color: t.type === 'success' ? '#5a2f45' : '#9f274c',
+            fontSize: '0.86rem',
+            fontWeight: 700,
+            boxShadow: '0 14px 28px rgba(15, 23, 42, 0.16)',
+            textAlign: 'center',
+            letterSpacing: '-0.01em',
+            minWidth: 240,
+            maxWidth: 420,
+          }}
+        >
           {t.message}
         </div>
       ))}
-    </div>
+    </div>,
+    document.body,
   )
 }
 
@@ -159,7 +178,7 @@ export function GuideFeesPage() {
       }
       const updated = text ? JSON.parse(text) : null
       setProfile(updated)
-      addToast('저장되었습니다.')
+      addToast('변경사항이 반영됐어요.')
     } catch {
       addToast('네트워크 오류가 발생했습니다.', 'error')
     } finally {

--- a/frontend/src/pages/GuideIntroEditPage.jsx
+++ b/frontend/src/pages/GuideIntroEditPage.jsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
 
 import { apiRequest } from '../api/client.js'
 import { useResolvedGuideId } from '../hooks/useResolvedGuideId.js'
@@ -19,14 +20,32 @@ function useToast() {
 
 function Toast({ toasts }) {
   if (toasts.length === 0) return null
-  return (
-    <div style={{ position: 'fixed', bottom: '1.5rem', right: '1.5rem', zIndex: 9999, display: 'flex', flexDirection: 'column', gap: '0.5rem', pointerEvents: 'none' }}>
+  if (typeof document === 'undefined') return null
+  return createPortal(
+    <div style={{ position: 'fixed', top: '1.1rem', left: '50%', transform: 'translateX(-50%)', zIndex: 9999, display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center', pointerEvents: 'none' }}>
       {toasts.map((t) => (
-        <div key={t.id} style={{ padding: '0.7rem 1.2rem', borderRadius: 10, background: t.type === 'success' ? '#15803d' : '#b91c1c', color: '#fff', fontSize: '0.88rem', fontWeight: 600, boxShadow: '0 4px 16px rgba(0,0,0,0.18)', minWidth: 180, maxWidth: 320 }}>
+        <div
+          key={t.id}
+          style={{
+            padding: '0.74rem 0.98rem',
+            borderRadius: 12,
+            border: t.type === 'success' ? '1px solid #e7a8c2' : '1px solid #f7b4c1',
+            background: t.type === 'success' ? 'linear-gradient(180deg, #f7d9e8, #efbfd0)' : 'linear-gradient(180deg, #ffe8ee, #ffd8e1)',
+            color: t.type === 'success' ? '#5a2f45' : '#9f274c',
+            fontSize: '0.86rem',
+            fontWeight: 700,
+            boxShadow: '0 14px 28px rgba(15, 23, 42, 0.16)',
+            textAlign: 'center',
+            letterSpacing: '-0.01em',
+            minWidth: 240,
+            maxWidth: 420,
+          }}
+        >
           {t.message}
         </div>
       ))}
-    </div>
+    </div>,
+    document.body,
   )
 }
 
@@ -112,7 +131,7 @@ export function GuideIntroEditPage() {
       setLanguage(p?.language ?? '')
       setGuideStyle(p?.guideStyle ?? '')
       setDefaultCourse(p?.defaultCourse ?? '')
-      addToast('저장되었습니다.')
+      addToast('변경사항이 반영됐어요.')
     } catch {
       addToast('네트워크 오류', 'error')
     } finally {

--- a/frontend/src/pages/GuideProfileEditPage.jsx
+++ b/frontend/src/pages/GuideProfileEditPage.jsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 
 import { apiRequest } from '../api/client.js'
 import { useResolvedGuideId } from '../hooks/useResolvedGuideId.js'
@@ -21,14 +22,32 @@ function useToast() {
 
 function Toast({ toasts }) {
   if (toasts.length === 0) return null
-  return (
-    <div style={{ position: 'fixed', bottom: '1.5rem', right: '1.5rem', zIndex: 9999, display: 'flex', flexDirection: 'column', gap: '0.5rem', pointerEvents: 'none' }}>
+  if (typeof document === 'undefined') return null
+  return createPortal(
+    <div style={{ position: 'fixed', top: '1.1rem', left: '50%', transform: 'translateX(-50%)', zIndex: 9999, display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center', pointerEvents: 'none' }}>
       {toasts.map((t) => (
-        <div key={t.id} style={{ padding: '0.7rem 1.2rem', borderRadius: 10, background: t.type === 'success' ? '#15803d' : '#b91c1c', color: '#fff', fontSize: '0.88rem', fontWeight: 600, boxShadow: '0 4px 16px rgba(0,0,0,0.18)', minWidth: 180, maxWidth: 320 }}>
+        <div
+          key={t.id}
+          style={{
+            padding: '0.74rem 0.98rem',
+            borderRadius: 12,
+            border: t.type === 'success' ? '1px solid #e7a8c2' : '1px solid #f7b4c1',
+            background: t.type === 'success' ? 'linear-gradient(180deg, #f7d9e8, #efbfd0)' : 'linear-gradient(180deg, #ffe8ee, #ffd8e1)',
+            color: t.type === 'success' ? '#5a2f45' : '#9f274c',
+            fontSize: '0.86rem',
+            fontWeight: 700,
+            boxShadow: '0 14px 28px rgba(15, 23, 42, 0.16)',
+            textAlign: 'center',
+            letterSpacing: '-0.01em',
+            minWidth: 240,
+            maxWidth: 420,
+          }}
+        >
           {t.message}
         </div>
       ))}
-    </div>
+    </div>,
+    document.body,
   )
 }
 
@@ -212,7 +231,7 @@ export function GuideProfileEditPage() {
       setPreviewUrl(null)
       setPendingUploadFile(null)
       setImageDeleted(false)
-      addToast('저장되었습니다.')
+      addToast('변경사항이 반영됐어요.')
     } catch {
       addToast('네트워크 오류', 'error')
     } finally {

--- a/frontend/src/pages/GuideSettingsPage.jsx
+++ b/frontend/src/pages/GuideSettingsPage.jsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { createPortal } from 'react-dom'
 
 import { PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client.js'
@@ -20,14 +21,32 @@ function useToast() {
 
 function Toast({ toasts }) {
   if (toasts.length === 0) return null
-  return (
-      <div style={{ position: 'fixed', bottom: '1.5rem', right: '1.5rem', zIndex: 9999, display: 'flex', flexDirection: 'column', gap: '0.5rem', pointerEvents: 'none' }}>
+  if (typeof document === 'undefined') return null
+  return createPortal(
+      <div style={{ position: 'fixed', top: '1.1rem', left: '50%', transform: 'translateX(-50%)', zIndex: 9999, display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center', pointerEvents: 'none' }}>
         {toasts.map((t) => (
-            <div key={t.id} style={{ padding: '0.7rem 1.2rem', borderRadius: 10, background: t.type === 'success' ? '#15803d' : '#b91c1c', color: '#fff', fontSize: '0.88rem', fontWeight: 600, boxShadow: '0 4px 16px rgba(0,0,0,0.18)', minWidth: 180, maxWidth: 320 }}>
+            <div
+              key={t.id}
+              style={{
+                padding: '0.74rem 0.98rem',
+                borderRadius: 12,
+                border: t.type === 'success' ? '1px solid #e7a8c2' : '1px solid #f7b4c1',
+                background: t.type === 'success' ? 'linear-gradient(180deg, #f7d9e8, #efbfd0)' : 'linear-gradient(180deg, #ffe8ee, #ffd8e1)',
+                color: t.type === 'success' ? '#5a2f45' : '#9f274c',
+                fontSize: '0.86rem',
+                fontWeight: 700,
+                boxShadow: '0 14px 28px rgba(15, 23, 42, 0.16)',
+                textAlign: 'center',
+                letterSpacing: '-0.01em',
+                minWidth: 240,
+                maxWidth: 420,
+              }}
+            >
               {t.message}
             </div>
         ))}
-      </div>
+      </div>,
+      document.body,
   )
 }
 
@@ -162,7 +181,7 @@ export function GuideSettingsPage() {
         return
       }
       setProfile(text ? JSON.parse(text) : profile)
-      addToast('비용/알림 설정이 저장되었습니다.')
+      addToast('설정이 반영됐어요.')
     } catch {
       addToast('네트워크 오류가 발생했습니다.', 'error')
     } finally {

--- a/frontend/src/pages/MypagePrivacyPage.jsx
+++ b/frontend/src/pages/MypagePrivacyPage.jsx
@@ -1,5 +1,6 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { createPortal } from 'react-dom'
 
 import { apiRequest } from '../api/client.js'
 import { useAuth } from '../context/useAuth.js'
@@ -19,16 +20,57 @@ function parseApiErrorMessage(text) {
   }
 }
 
+function useToast() {
+  const [toasts, setToasts] = useState([])
+  const addToast = useCallback((message, type = 'success') => {
+    const id = Date.now() + Math.random()
+    setToasts((prev) => [...prev, { id, message, type }])
+    setTimeout(() => setToasts((prev) => prev.filter((t) => t.id !== id)), 2000)
+  }, [])
+  return { toasts, addToast }
+}
+
+function Toast({ toasts }) {
+  if (toasts.length === 0) return null
+  if (typeof document === 'undefined') return null
+  return createPortal(
+    <div style={{ position: 'fixed', top: '1.1rem', left: '50%', transform: 'translateX(-50%)', zIndex: 9999, display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center', pointerEvents: 'none' }}>
+      {toasts.map((t) => (
+        <div
+          key={t.id}
+          style={{
+            padding: '0.74rem 0.98rem',
+            borderRadius: 12,
+            border: t.type === 'success' ? '1px solid #e7a8c2' : '1px solid #f7b4c1',
+            background: t.type === 'success' ? 'linear-gradient(180deg, #f7d9e8, #efbfd0)' : 'linear-gradient(180deg, #ffe8ee, #ffd8e1)',
+            color: t.type === 'success' ? '#5a2f45' : '#9f274c',
+            fontSize: '0.86rem',
+            fontWeight: 700,
+            boxShadow: '0 14px 28px rgba(15, 23, 42, 0.16)',
+            textAlign: 'center',
+            letterSpacing: '-0.01em',
+            minWidth: 240,
+            maxWidth: 420,
+          }}
+        >
+          {t.message}
+        </div>
+      ))}
+    </div>,
+    document.body,
+  )
+}
+
 export function MypagePrivacyPage() {
   const { email, logout } = useAuth()
   const navigate = useNavigate()
+  const { toasts, addToast } = useToast()
   const [nickname, setNickname] = useState('')
   const [bookingNotify, setBookingNotify] = useState(true)
   const [guideMessageNotify, setGuideMessageNotify] = useState(true)
   const [tags, setTags] = useState([])
   const [prefsOpen, setPrefsOpen] = useState(false)
   const [newTag, setNewTag] = useState('')
-  const [savedFlash, setSavedFlash] = useState(false)
   const [saving, setSaving] = useState(false)
   const [withdrawBusy, setWithdrawBusy] = useState(false)
   const [withdrawErr, setWithdrawErr] = useState('')
@@ -52,9 +94,8 @@ export function MypagePrivacyPage() {
         guideMessageNotify,
         tags,
       })
-      setSavedFlash(true)
-      window.setTimeout(() => setSavedFlash(false), 3200)
       window.dispatchEvent(new Event('localguest_mypage_prefs_updated'))
+      addToast('설정이 반영됐어요.')
     } finally {
       setSaving(false)
     }
@@ -98,7 +139,6 @@ export function MypagePrivacyPage() {
         회원 정보 및 여행 설정 <span aria-hidden>⚙️</span>
       </h1>
       <p className="mp-privacy-hint">여행 성향 태그를 관리하고 알림 설정을 조정할 수 있어요.</p>
-      {savedFlash && <p className="mp-privacy-banner">설정이 저장되었습니다.</p>}
 
       <section className="mp-privacy-section">
         <h2>기본 정보</h2>
@@ -218,6 +258,7 @@ export function MypagePrivacyPage() {
           {withdrawBusy ? '처리 중…' : '회원 탈퇴'}
         </button>
       </section>
+      <Toast toasts={toasts} />
     </div>
   )
 }


### PR DESCRIPTION
# 🔗 이슈 번호
- Closes #362 

---

## 💡 주요 변경 사항
- 저장/적용 안내 UI를 토스트로 통일
- 토스트를 상단 중앙 고정으로 변경
- `createPortal` 적용으로 스크롤/레이아웃 영향 없이 항상 화면 상단 중앙 표시
- 토스트 문구 가운데 정렬
- 성공/오류 토스트 배경색 및 가독성(보더/그림자/폭) 개선
- 페이지 내 `alert`/배너성 저장 안내 제거

---

## ⚠️ 주의 사항 / 질문
- 토스트 자동 닫힘 시간(현재 2초)이 짧거나 길면 조정 필요
- 모바일 뷰에서 상단 헤더와 시각적 겹침 여부 확인 필요


---

## ✅ 체크리스트
- [x] 빌드가 정상적으로 되는가?
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [x] .gitignore에 설정 파일이 잘 포함되었는가? (application-local.yml 등)