### PR TITLE
[Feat/fe#365] 가이드 매칭 확인 모달 뷰포트 중앙 표시

### DIFF
--- a/frontend/src/pages/GuideDetailPage.css
+++ b/frontend/src/pages/GuideDetailPage.css
@@ -562,7 +562,8 @@
 .gdp-confirm-overlay {
   position: fixed;
   inset: 0;
-  z-index: 90;
+  /* shell-route-transition(transform) 밖(body)에 포털되므로 앱 헤더 위로 올라오도록 여유 있게 */
+  z-index: 2000;
   background: rgba(2, 6, 23, 0.55);
   backdrop-filter: blur(2px);
   display: grid;

--- a/frontend/src/pages/GuideDetailPage.jsx
+++ b/frontend/src/pages/GuideDetailPage.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { Link, useParams, useLocation, useNavigate } from 'react-router-dom'
 
 import { PageEmpty, PageError, PageLoading } from '../components/PageStates.jsx'
@@ -909,73 +910,76 @@ export function GuideDetailPage() {
         </section>
       )}
 
-      {confirmModal && (
-        <div
-          className="gdp-confirm-overlay"
-          role="dialog"
-          aria-modal="true"
-          aria-label="매칭 요청 확인"
-          onClick={(e) => {
-            if (e.target === e.currentTarget && !submitting) setConfirmModal(null)
-          }}
-        >
-          <div className="gdp-confirm">
-            <p className="gdp-confirm-kicker">Final Check</p>
-            <h3>{p.nickname} 가이드에게 매칭 요청을 보낼까요?</h3>
-            <p className="gdp-confirm-sub">아래 정보가 그대로 전달됩니다. 맞으면 전송해 주세요.</p>
-            <dl className="gdp-confirm-list">
-              <div>
-                <dt>목적지</dt>
-                <dd>{confirmModal.destination}</dd>
-              </div>
-              <div>
-                <dt>날짜</dt>
-                <dd>{confirmModal.desiredDate || '미정'}</dd>
-              </div>
-              <div>
-                <dt>하고 싶은 일</dt>
-                <dd>{confirmModal.concept || '입력 없음'}</dd>
-              </div>
-              {confirmModal.payload?.budgetMinWon != null && confirmModal.payload?.budgetMaxWon != null ? (
+      {confirmModal &&
+        typeof document !== 'undefined' &&
+        createPortal(
+          <div
+            className="gdp-confirm-overlay"
+            role="dialog"
+            aria-modal="true"
+            aria-label="매칭 요청 확인"
+            onClick={(e) => {
+              if (e.target === e.currentTarget && !submitting) setConfirmModal(null)
+            }}
+          >
+            <div className="gdp-confirm">
+              <p className="gdp-confirm-kicker">Final Check</p>
+              <h3>{p.nickname} 가이드에게 매칭 요청을 보낼까요?</h3>
+              <p className="gdp-confirm-sub">아래 정보가 그대로 전달됩니다. 맞으면 전송해 주세요.</p>
+              <dl className="gdp-confirm-list">
                 <div>
-                  <dt>예산</dt>
-                  <dd>
-                    {Number(confirmModal.payload.budgetMinWon).toLocaleString('ko-KR')}~
-                    {Number(confirmModal.payload.budgetMaxWon).toLocaleString('ko-KR')}원
-                  </dd>
+                  <dt>목적지</dt>
+                  <dd>{confirmModal.destination}</dd>
                 </div>
-              ) : confirmModal.payload?.desiredBudget != null && (
                 <div>
-                  <dt>예산</dt>
-                  <dd>{Number(confirmModal.payload.desiredBudget).toLocaleString('ko-KR')}원</dd>
+                  <dt>날짜</dt>
+                  <dd>{confirmModal.desiredDate || '미정'}</dd>
                 </div>
-              )}
-            </dl>
-            <div className="gdp-confirm-actions">
-              <button
-                type="button"
-                className="gdp-confirm-btn gdp-confirm-btn--line"
-                onClick={() => setConfirmModal(null)}
-                disabled={submitting}
-              >
-                수정할게요
-              </button>
-              <button
-                type="button"
-                className="gdp-confirm-btn gdp-confirm-btn--solid"
-                disabled={submitting}
-                onClick={() => {
-                  const payload = confirmModal.payload
-                  setConfirmModal(null)
-                  void sendMatchRequest(payload)
-                }}
-              >
-                {submitting ? '전송 중…' : '요청 전송'}
-              </button>
+                <div>
+                  <dt>하고 싶은 일</dt>
+                  <dd>{confirmModal.concept || '입력 없음'}</dd>
+                </div>
+                {confirmModal.payload?.budgetMinWon != null && confirmModal.payload?.budgetMaxWon != null ? (
+                  <div>
+                    <dt>예산</dt>
+                    <dd>
+                      {Number(confirmModal.payload.budgetMinWon).toLocaleString('ko-KR')}~
+                      {Number(confirmModal.payload.budgetMaxWon).toLocaleString('ko-KR')}원
+                    </dd>
+                  </div>
+                ) : confirmModal.payload?.desiredBudget != null && (
+                  <div>
+                    <dt>예산</dt>
+                    <dd>{Number(confirmModal.payload.desiredBudget).toLocaleString('ko-KR')}원</dd>
+                  </div>
+                )}
+              </dl>
+              <div className="gdp-confirm-actions">
+                <button
+                  type="button"
+                  className="gdp-confirm-btn gdp-confirm-btn--line"
+                  onClick={() => setConfirmModal(null)}
+                  disabled={submitting}
+                >
+                  수정할게요
+                </button>
+                <button
+                  type="button"
+                  className="gdp-confirm-btn gdp-confirm-btn--solid"
+                  disabled={submitting}
+                  onClick={() => {
+                    const payload = confirmModal.payload
+                    setConfirmModal(null)
+                    void sendMatchRequest(payload)
+                  }}
+                >
+                  {submitting ? '전송 중…' : '요청 전송'}
+                </button>
+              </div>
             </div>
-          </div>
-        </div>
-      )}
+          </div>,
+          document.body,
+        )}
     </div>
   )
 }


### PR DESCRIPTION
## 🔗 이슈 번호

Closes #365

## 💡 주요 변경 사항

- `GuideDetailPage` 매칭 요청 확인 UI를 `createPortal(..., document.body)`로 렌더링해, `AppLayout`의 `shell-route-transition`(`transform` 애니메이션) 때문에 `position: fixed`가 문서/래퍼 기준으로 깨지던 문제를 제거함
- 오버레이 `z-index`를 상향해 포털 노드가 헤더 등 앱 크롬 위에 안정적으로 보이도록 조정

## ⚠️ 주의 사항 / 질문

- 동일 레이아웃 안의 다른 `fixed` 모달이 있다면 같은 패턴 적용 여지 있음 (이번 PR 범위는 가이드 상세 확인 모달만)

## ✅ 체크리스트

- [x] 빌드가 정상적으로 되는가? (`cd frontend && npm run build`)
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [x] `.gitignore`에 설정 파일(비밀·로컬 전용)이 잘 제외되었는가? 해당 없음

Made with [Cursor](https://cursor.com)