### PR TITLE
Feat/be#369 AI 프롬프트 예산 상한을 0~상한 원으로 파싱

### DIFF
--- a/backend/module-ai/src/main/java/com/team6/module/ai/parser/PromptParser.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/parser/PromptParser.java
@@ -62,6 +62,23 @@ public class PromptParser {
     );
     private static final Pattern BUDGET_MANWON_BAND = Pattern.compile("(\\d+)\\s*만원\\s*대");
     private static final Pattern BUDGET_MANWON_RANGE = Pattern.compile("(\\d+)\\s*[~-]\\s*(\\d+)\\s*만(?:원)?");
+    /** "20만 이하", "20만원 이내", "8만 안으로" 등 상한만 있는 표현 → 0원 ~ 상한. */
+    private static final Pattern BUDGET_CEILING_MANWON_SUFFIX = Pattern.compile(
+            "(\\d{1,3}(?:,\\d{3})+|\\d+)\\s*만(?:원)?\\s*(이하|이내|까지|안(?:으로)?)"
+    );
+    /** "최대 20만", "상한 15만원" 등 (이하/이내 생략). */
+    private static final Pattern BUDGET_MAX_ONLY_MANWON = Pattern.compile(
+            "(?:최대|상한|최고)\\s*(\\d{1,3}(?:,\\d{3})+|\\d+)\\s*만(?:원)?\\b"
+    );
+    private static final Pattern BUDGET_CEILING_WON_SUFFIX = Pattern.compile(
+            "(\\d{1,3}(?:,\\d{3})+|\\d+)\\s*원\\s*(이하|이내|까지|under|below|at\\s+most)"
+    );
+    private static final Pattern BUDGET_CEILING_WON_ENGLISH_FIRST = Pattern.compile(
+            "(?:below|under|at\\s+most)\\s*(\\d{1,3}(?:,\\d{3})+|\\d+)\\s*원\\b"
+    );
+    private static final Pattern BUDGET_MAX_ONLY_WON = Pattern.compile(
+            "(?:최대|상한|최고)\\s*(\\d{1,3}(?:,\\d{3})+|\\d+)\\s*원\\b"
+    );
     private static final Pattern HEADCOUNT = Pattern.compile("(\\d+)\\s*(명|인)");
     private static final Pattern DURATION_NIGHTS_DAYS = Pattern.compile("(\\d+)\\s*박\\s*(\\d+)\\s*일");
     private static final Pattern DURATION_NIGHTS_ONLY = Pattern.compile("(\\d+)\\s*박(?!\\s*\\d)");
@@ -200,6 +217,43 @@ public class PromptParser {
                 return null;
             }
         }
+
+        Matcher ceilingManSuffix = BUDGET_CEILING_MANWON_SUFFIX.matcher(prompt);
+        if (ceilingManSuffix.find()) {
+            Integer cap = manWonDigitsToWon(ceilingManSuffix.group(1));
+            if (cap != null && cap > 0) {
+                return new BudgetRange(0, cap);
+            }
+        }
+        Matcher ceilingMaxMan = BUDGET_MAX_ONLY_MANWON.matcher(prompt);
+        if (ceilingMaxMan.find()) {
+            Integer cap = manWonDigitsToWon(ceilingMaxMan.group(1));
+            if (cap != null && cap > 0) {
+                return new BudgetRange(0, cap);
+            }
+        }
+        Matcher ceilingWonEnglishFirst = BUDGET_CEILING_WON_ENGLISH_FIRST.matcher(prompt);
+        if (ceilingWonEnglishFirst.find()) {
+            Integer cap = convertWon(ceilingWonEnglishFirst.group(1), "원");
+            if (cap != null && cap > 0) {
+                return new BudgetRange(0, cap);
+            }
+        }
+        Matcher ceilingWonSuffix = BUDGET_CEILING_WON_SUFFIX.matcher(prompt);
+        if (ceilingWonSuffix.find()) {
+            Integer cap = convertWon(ceilingWonSuffix.group(1), "원");
+            if (cap != null && cap > 0) {
+                return new BudgetRange(0, cap);
+            }
+        }
+        Matcher ceilingMaxWon = BUDGET_MAX_ONLY_WON.matcher(prompt);
+        if (ceilingMaxWon.find()) {
+            Integer cap = convertWon(ceilingMaxWon.group(1), "원");
+            if (cap != null && cap > 0) {
+                return new BudgetRange(0, cap);
+            }
+        }
+
         // "예산 하루 10만원" 같이 단일 금액 표현도 범위(min=max)로 보존한다.
         Integer single = extractBudgetAmount(prompt);
         if (single != null && single >= 0) {
@@ -704,20 +758,7 @@ public class PromptParser {
         if (!m.find()) {
             return null;
         }
-        String number = m.group(1).replace(",", "");
-        try {
-            long man = Long.parseLong(number);
-            if (man <= 0L || man > 1_000_000L) {
-                return null;
-            }
-            long value = man * 10_000L;
-            if (value > Integer.MAX_VALUE) {
-                return null;
-            }
-            return (int) value;
-        } catch (NumberFormatException e) {
-            return null;
-        }
+        return manWonDigitsToWon(m.group(1));
     }
 
     private String extractCompanionType(String prompt) {
@@ -1020,6 +1061,27 @@ public class PromptParser {
                 value *= 10_000L;
             }
             if (value <= 0L || value > Integer.MAX_VALUE) {
+                return null;
+            }
+            return (int) value;
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /** {@code N}만 / {@code N}만원 숫자부만 원화 상한으로 변환 (예: 20 → 200_000). */
+    private static Integer manWonDigitsToWon(String rawNumber) {
+        if (rawNumber == null) {
+            return null;
+        }
+        String number = rawNumber.replace(",", "");
+        try {
+            long man = Long.parseLong(number);
+            if (man <= 0L || man > 1_000_000L) {
+                return null;
+            }
+            long value = man * 10_000L;
+            if (value > Integer.MAX_VALUE) {
                 return null;
             }
             return (int) value;

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationTuning.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationTuning.java
@@ -19,7 +19,7 @@ public final class AiRecommendationTuning {
     /**
      * 룰/스코어/Reason/응답 계약이 바뀔 때마다 올린다. 로그·API에서 동일 프롬프트 비교 시 정책 변경 여부를 구분하는 데 쓴다.
      */
-    public static final String POLICY_VERSION = "2026.04.29";
+    public static final String POLICY_VERSION = "2026.04.30";
 
     public static final int DEFAULT_TOP_N = 3;
 

--- a/backend/module-ai/src/test/java/com/team6/module/ai/parser/PromptParserTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/parser/PromptParserTest.java
@@ -52,6 +52,26 @@ class PromptParserTest {
     }
 
     @Test
+    void parse_should_map_budget_ceiling_phrases_to_zero_through_cap() {
+        GuideRecommendRequest r1 = promptParser.parse("부산 여행 예산 20만원 이하로 코스 추천", 3, List.of());
+        assertThat(r1.getRegion()).isEqualTo("부산");
+        assertThat(r1.getBudgetMinWon()).isZero();
+        assertThat(r1.getBudgetMaxWon()).isEqualTo(200_000);
+
+        GuideRecommendRequest r2 = promptParser.parse("제주 15만 이내 맛집 위주", 3, List.of());
+        assertThat(r2.getBudgetMinWon()).isZero();
+        assertThat(r2.getBudgetMaxWon()).isEqualTo(150_000);
+
+        GuideRecommendRequest r3 = promptParser.parse("강릉 최대 12만원 배낭여행", 3, List.of());
+        assertThat(r3.getBudgetMinWon()).isZero();
+        assertThat(r3.getBudgetMaxWon()).isEqualTo(120_000);
+
+        GuideRecommendRequest r4 = promptParser.parse("경주 예산 below 300000원 커플", 3, List.of());
+        assertThat(r4.getBudgetMinWon()).isZero();
+        assertThat(r4.getBudgetMaxWon()).isEqualTo(300_000);
+    }
+
+    @Test
     void extractDesiredTourDateRange_should_parse_single_and_ranges() {
         int y = LocalDate.now().getYear();
 


### PR DESCRIPTION
## 🔗 이슈 번호

Closes #369

## 💡 주요 변경 사항

- `PromptParser`: `N만원 이하/이내/까지/안으로`, `최대 N만(원)`, `N원 이하`·`below/under N원` 등을 **`budgetMinWon=0`, `budgetMaxWon=상한`**으로 해석해 `matchRequestDraft`·매칭 폼 기본값이 0~상한으로 채워지도록 함
- 단일 금액(`20만원 정도`)·명시 구간(`10~20만`) 기존 동작 유지
- 파서 변경에 맞춰 `AiRecommendationTuning.POLICY_VERSION` → `2026.04.30`

## ⚠️ 주의 사항 / 질문

- `…까지`는 문맥에 따라 다르게 읽힐 수 있으나, **금액+원/만+까지** 형태만 상한으로 처리

## ✅ 체크리스트

- [x] 빌드가 정상적으로 되는가? (`./gradlew :module-ai:test`)
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [x] `.gitignore`에 설정 파일(비밀·로컬 전용)이 잘 제외되었는가? 해당 없음

Made with [Cursor](https://cursor.com)