### PR TITLE
Feat/be#373 스크랩북 지도 연결·상세 지도 초기화 수정

### DIFF
--- a/frontend/src/lib/kakaoMapSdk.js
+++ b/frontend/src/lib/kakaoMapSdk.js
@@ -1,0 +1,24 @@
+/**
+ * 카카오맵 JS SDK 동적 로드 (여러 페이지 공통).
+ * @param {string} appKey
+ * @returns {Promise<typeof window.kakao>}
+ */
+export function loadKakaoSdk(appKey) {
+  if (!appKey) return Promise.reject(new Error('카카오맵 앱 키가 없습니다.'))
+  if (window.kakao?.maps?.services) return Promise.resolve(window.kakao)
+  return new Promise((resolve, reject) => {
+    const existing = document.getElementById('kakao-map-sdk')
+    if (existing) {
+      existing.addEventListener('load', () => window.kakao.maps.load(() => resolve(window.kakao)))
+      existing.addEventListener('error', () => reject(new Error('카카오맵 SDK 로드 실패')))
+      return
+    }
+    const script = document.createElement('script')
+    script.id = 'kakao-map-sdk'
+    script.async = true
+    script.src = `https://dapi.kakao.com/v2/maps/sdk.js?appkey=${appKey}&autoload=false&libraries=services`
+    script.onload = () => window.kakao.maps.load(() => resolve(window.kakao))
+    script.onerror = () => reject(new Error('카카오맵 SDK 로드 실패'))
+    document.head.appendChild(script)
+  })
+}

--- a/frontend/src/pages/GuideCoursePanel.jsx
+++ b/frontend/src/pages/GuideCoursePanel.jsx
@@ -1,30 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { apiRequest } from '../api/client.js'
 import { DEFAULT_KOREA_CENTER, geocodeAddressOnly, getUserLatLng, resolveLatLng } from '../lib/kakaoGeocode.js'
+import { loadKakaoSdk } from '../lib/kakaoMapSdk.js'
 import './GuideCoursePanel.css'
 
 const KAKAO_APP_KEY = import.meta.env.VITE_KAKAO_MAP_APP_KEY
-
-// ── 카카오맵 SDK 로드 (GuideMatchedCoursePage와 동일 패턴) ──────────────
-function loadKakaoSdk(appKey) {
-  if (!appKey) return Promise.reject(new Error('카카오맵 앱 키가 없습니다.'))
-  if (window.kakao?.maps?.services) return Promise.resolve(window.kakao)
-  return new Promise((resolve, reject) => {
-    const existing = document.getElementById('kakao-map-sdk')
-    if (existing) {
-      existing.addEventListener('load', () => window.kakao.maps.load(() => resolve(window.kakao)))
-      existing.addEventListener('error', () => reject(new Error('SDK 로드 실패')))
-      return
-    }
-    const script = document.createElement('script')
-    script.id = 'kakao-map-sdk'
-    script.async = true
-    script.src = `https://dapi.kakao.com/v2/maps/sdk.js?appkey=${appKey}&autoload=false&libraries=services`
-    script.onload = () => window.kakao.maps.load(() => resolve(window.kakao))
-    script.onerror = () => reject(new Error('SDK 로드 실패'))
-    document.head.appendChild(script)
-  })
-}
 
 function createPinOverlay(kakao, map, latlng, idx, name) {
   const root = document.createElement('div')

--- a/frontend/src/pages/GuideMatchOptionsPage.jsx
+++ b/frontend/src/pages/GuideMatchOptionsPage.jsx
@@ -4,32 +4,13 @@ import { Link, useLocation, useNavigate, useParams } from 'react-router-dom'
 import { PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client'
 import { fetchGuestPayments, pickLatestCompletedPaymentIdForRequest } from '../lib/matchingGuest.js'
+import { loadKakaoSdk } from '../lib/kakaoMapSdk.js'
 
 import './GuideMatchOptionsPage.css'
 
 /** 가이드 마이페이지 「종일 패키지」와 동일: 서버 `pricePerHour` × 8 (`GuideFeesPage`와 맞춤) */
 const FULL_DAY_HOURS = 8
 const KAKAO_APP_KEY = import.meta.env.VITE_KAKAO_MAP_APP_KEY
-
-function loadKakaoSdk(appKey) {
-  if (!appKey) return Promise.reject(new Error('카카오맵 앱 키가 없습니다.'))
-  if (window.kakao?.maps?.services) return Promise.resolve(window.kakao)
-  return new Promise((resolve, reject) => {
-    const existing = document.getElementById('kakao-map-sdk')
-    if (existing) {
-      existing.addEventListener('load', () => window.kakao.maps.load(() => resolve(window.kakao)))
-      existing.addEventListener('error', () => reject(new Error('카카오맵 SDK 로드 실패')))
-      return
-    }
-    const script = document.createElement('script')
-    script.id = 'kakao-map-sdk'
-    script.async = true
-    script.src = `https://dapi.kakao.com/v2/maps/sdk.js?appkey=${appKey}&autoload=false&libraries=services`
-    script.onload = () => window.kakao.maps.load(() => resolve(window.kakao))
-    script.onerror = () => reject(new Error('카카오맵 SDK 로드 실패'))
-    document.head.appendChild(script)
-  })
-}
 
 function geocodeAddress(kakao, query) {
   return new Promise((resolve) => {

--- a/frontend/src/pages/GuideMatchedCoursePage.jsx
+++ b/frontend/src/pages/GuideMatchedCoursePage.jsx
@@ -4,33 +4,13 @@ import { Link, useLocation, useNavigate, useParams, useSearchParams } from 'reac
 import { PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client'
 import { DEFAULT_KOREA_CENTER, getUserLatLng, resolveLatLng } from '../lib/kakaoGeocode.js'
+import { loadKakaoSdk } from '../lib/kakaoMapSdk.js'
 import { parseCourseDetail } from './GuideCoursePanel.jsx'
 
 import './GuideMatchedCoursePage.css'
 
 // ── 상수 ──────────────────────────────────────────────────────────────────
 const KAKAO_APP_KEY = import.meta.env.VITE_KAKAO_MAP_APP_KEY
-
-// ── 유틸 (기존 GuideMatchedCoursePage와 동일) ─────────────────────────────
-function loadKakaoSdk(appKey) {
-  if (!appKey) return Promise.reject(new Error('카카오맵 앱 키가 없습니다.'))
-  if (window.kakao?.maps?.services) return Promise.resolve(window.kakao)
-  return new Promise((resolve, reject) => {
-    const existing = document.getElementById('kakao-map-sdk')
-    if (existing) {
-      existing.addEventListener('load', () => window.kakao.maps.load(() => resolve(window.kakao)))
-      existing.addEventListener('error', () => reject(new Error('카카오맵 SDK 로드 실패')))
-      return
-    }
-    const script = document.createElement('script')
-    script.id = 'kakao-map-sdk'
-    script.async = true
-    script.src = `https://dapi.kakao.com/v2/maps/sdk.js?appkey=${appKey}&autoload=false&libraries=services`
-    script.onload = () => window.kakao.maps.load(() => resolve(window.kakao))
-    script.onerror = () => reject(new Error('카카오맵 SDK 로드 실패'))
-    document.head.appendChild(script)
-  })
-}
 
 function fallbackLatLng(idx) {
   const base = DEFAULT_KOREA_CENTER

--- a/frontend/src/pages/GuideProfileEditPage.jsx
+++ b/frontend/src/pages/GuideProfileEditPage.jsx
@@ -4,6 +4,7 @@ import { createPortal } from 'react-dom'
 import { apiRequest } from '../api/client.js'
 import { useResolvedGuideId } from '../hooks/useResolvedGuideId.js'
 import { buildGuidePutBody } from '../lib/guideProfilePayload.js'
+import { loadKakaoSdk } from '../lib/kakaoMapSdk.js'
 
 import '../layouts/GuideDashboardLayout.css'
 import './GuideMypagePages.css'
@@ -58,26 +59,6 @@ async function readJsonError(res, text) {
   } catch {
     return text || '요청 실패'
   }
-}
-
-function loadKakaoSdk(appKey) {
-  if (!appKey) return Promise.reject(new Error('카카오맵 앱 키가 없습니다.'))
-  if (window.kakao?.maps?.services) return Promise.resolve(window.kakao)
-  return new Promise((resolve, reject) => {
-    const existing = document.getElementById('kakao-map-sdk')
-    if (existing) {
-      existing.addEventListener('load', () => window.kakao.maps.load(() => resolve(window.kakao)))
-      existing.addEventListener('error', () => reject(new Error('카카오맵 SDK 로드 실패')))
-      return
-    }
-    const script = document.createElement('script')
-    script.id = 'kakao-map-sdk'
-    script.async = true
-    script.src = `https://dapi.kakao.com/v2/maps/sdk.js?appkey=${appKey}&autoload=false&libraries=services`
-    script.onload = () => window.kakao.maps.load(() => resolve(window.kakao))
-    script.onerror = () => reject(new Error('카카오맵 SDK 로드 실패'))
-    document.head.appendChild(script)
-  })
 }
 
 function detectRegionByCurrentLocation(kakao) {

--- a/frontend/src/pages/MypageMemberPages.css
+++ b/frontend/src/pages/MypageMemberPages.css
@@ -354,6 +354,44 @@ button.mp-thumb--match:focus-visible {
   color: #6b7280;
 }
 
+.mp-scrap-map-block {
+  margin-bottom: 1.25rem;
+}
+
+.mp-scrap-map-title {
+  margin: 0 0 0.35rem;
+  font-size: 1rem;
+  font-weight: 800;
+  color: #111827;
+}
+
+.mp-scrap-map-desc {
+  margin: 0 0 0.6rem;
+  font-size: 0.86rem;
+  color: #6b7280;
+}
+
+.mp-scrap-map-wrap {
+  position: relative;
+  background: #fff;
+  border: 1px solid #e8eaed;
+  border-radius: 14px;
+  padding: 0.45rem;
+}
+
+.mp-scrap-overview-map {
+  width: 100%;
+  height: 300px;
+  border-radius: 10px;
+  background: linear-gradient(160deg, #f3f4f6, #e5e7eb);
+}
+
+.mp-scrap-map-err {
+  margin: 0.45rem 0 0;
+  font-size: 0.82rem;
+  color: #b91c1c;
+}
+
 .mp-scrap-empty {
   border: 1px dashed #efbfd0;
   background: linear-gradient(180deg, #fff9fc, #fffdfd);

--- a/frontend/src/pages/MypageScrapbookPage.jsx
+++ b/frontend/src/pages/MypageScrapbookPage.jsx
@@ -1,10 +1,14 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { PageEmpty, PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client.js'
+import { DEFAULT_KOREA_CENTER, resolveLatLng } from '../lib/kakaoGeocode.js'
+import { loadKakaoSdk } from '../lib/kakaoMapSdk.js'
 import { daysUntil, fetchGuestMatchRequests } from '../lib/matchingGuest.js'
 
 import './MypageMemberPages.css'
+
+const KAKAO_APP_KEY = import.meta.env.VITE_KAKAO_MAP_APP_KEY
 
 async function loadGuideNicknames(apiRequest, guideIds) {
   const map = {}
@@ -42,6 +46,8 @@ export function MypageScrapbookPage() {
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(true)
   const [tearingRequestId, setTearingRequestId] = useState(null)
+  const overviewMapRef = useRef(null)
+  const [overviewMapErr, setOverviewMapErr] = useState('')
 
   const loadScrapbook = useCallback(async () => {
     const all = await fetchGuestMatchRequests(apiRequest)
@@ -84,6 +90,70 @@ export function MypageScrapbookPage() {
     }
   }, [loadScrapbook])
 
+  useEffect(() => {
+    if (loading || error || rows.length === 0) return
+    if (!overviewMapRef.current) return
+    let cancelled = false
+
+    const drawOverview = async () => {
+      try {
+        setOverviewMapErr('')
+        const el = overviewMapRef.current
+        if (!el) return
+        el.innerHTML = ''
+        const kakao = await loadKakaoSdk(KAKAO_APP_KEY)
+        if (cancelled || !overviewMapRef.current) return
+
+        const dests = [...new Set(rows.map((r) => String(r.destination ?? '').trim()).filter(Boolean))].slice(0, 15)
+        const hint = dests[0] ?? ''
+        const points =
+          dests.length > 0
+            ? await Promise.all(
+                dests.map(async (d, idx) => {
+                  const p = await resolveLatLng(kakao, d, { regionHint: hint || d })
+                  return (
+                    p ?? {
+                      lat: DEFAULT_KOREA_CENTER.lat + idx * 0.04,
+                      lng: DEFAULT_KOREA_CENTER.lng + (idx % 2 === 0 ? 0.03 : -0.03),
+                    }
+                  )
+                }),
+              )
+            : [{ ...DEFAULT_KOREA_CENTER }]
+
+        const center = points[0]
+        const map = new kakao.maps.Map(el, {
+          center: new kakao.maps.LatLng(center.lat, center.lng),
+          level: 10,
+        })
+        const bounds = new kakao.maps.LatLngBounds()
+        points.forEach((p, idx) => {
+          const latlng = new kakao.maps.LatLng(p.lat, p.lng)
+          bounds.extend(latlng)
+          const marker = new kakao.maps.Marker({
+            map,
+            position: latlng,
+            title: dests[idx] ? `${dests[idx]} · 여행 ${idx + 1}` : `여행 ${idx + 1}`,
+          })
+          void marker
+        })
+        if (points.length > 1) {
+          map.setBounds(bounds)
+        }
+      } catch (e) {
+        if (!cancelled) setOverviewMapErr(e instanceof Error ? e.message : '지도를 불러오지 못했습니다.')
+      }
+    }
+
+    void drawOverview()
+    return () => {
+      cancelled = true
+      if (overviewMapRef.current) {
+        overviewMapRef.current.innerHTML = ''
+      }
+    }
+  }, [loading, error, rows])
+
   const count = rows.length
 
   const subtitle = useMemo(() => {
@@ -106,6 +176,19 @@ export function MypageScrapbookPage() {
               <p>{subtitle}</p>
             </div>
           </div>
+
+          {rows.length > 0 && (
+            <section className="mp-scrap-map-block" aria-labelledby="mp-scrap-map-title">
+              <h2 id="mp-scrap-map-title" className="mp-scrap-map-title">
+                여행 지도
+              </h2>
+              <p className="mp-scrap-map-desc">완료된 여행의 목적지를 한 지도에 모았어요.</p>
+              <div className="mp-scrap-map-wrap">
+                <div ref={overviewMapRef} className="mp-scrap-overview-map" />
+                {overviewMapErr && <p className="mp-scrap-map-err">{overviewMapErr}</p>}
+              </div>
+            </section>
+          )}
 
           {rows.length === 0 && (
             <PageEmpty title="완료된 투어 기록이 아직 없어요!" className="mp-scrap-empty">

--- a/frontend/src/pages/MypageScrapbookTicketDetailPage.jsx
+++ b/frontend/src/pages/MypageScrapbookTicketDetailPage.jsx
@@ -3,6 +3,7 @@ import { Link, useNavigate, useParams } from 'react-router-dom'
 import { PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client.js'
 import { DEFAULT_KOREA_CENTER, getUserLatLng, resolveLatLng } from '../lib/kakaoGeocode.js'
+import { loadKakaoSdk } from '../lib/kakaoMapSdk.js'
 import { fetchGuestMatchRequests } from '../lib/matchingGuest.js'
 import { parseCourseDetail } from './GuideCoursePanel.jsx'
 
@@ -19,26 +20,6 @@ function parseApiErrorMessage(text) {
   } catch {
     return text || '요청 실패'
   }
-}
-
-function loadKakaoSdk(appKey) {
-  if (!appKey) return Promise.reject(new Error('카카오맵 앱 키가 없습니다.'))
-  if (window.kakao?.maps?.services) return Promise.resolve(window.kakao)
-  return new Promise((resolve, reject) => {
-    const existing = document.getElementById('kakao-map-sdk')
-    if (existing) {
-      existing.addEventListener('load', () => window.kakao.maps.load(() => resolve(window.kakao)))
-      existing.addEventListener('error', () => reject(new Error('카카오맵 SDK 로드 실패')))
-      return
-    }
-    const script = document.createElement('script')
-    script.id = 'kakao-map-sdk'
-    script.async = true
-    script.src = `https://dapi.kakao.com/v2/maps/sdk.js?appkey=${appKey}&autoload=false&libraries=services`
-    script.onload = () => window.kakao.maps.load(() => resolve(window.kakao))
-    script.onerror = () => reject(new Error('카카오맵 SDK 로드 실패'))
-    document.head.appendChild(script)
-  })
 }
 
 function fallbackLatLng(idx) {
@@ -184,12 +165,16 @@ export function MypageScrapbookTicketDetailPage() {
   const hasReview = reviewByMatch[Number(row?.requestId)] != null
 
   useEffect(() => {
+    if (loading || !row) return
     if (!mapRef.current) return
     let cancelled = false
 
     const drawMap = async () => {
       try {
         setMapErr('')
+        const el = mapRef.current
+        if (!el) return
+        el.innerHTML = ''
         const kakao = await loadKakaoSdk(KAKAO_APP_KEY)
         if (cancelled || !mapRef.current) return
 
@@ -208,7 +193,7 @@ export function MypageScrapbookTicketDetailPage() {
           if (byDestination) center = byDestination
         }
 
-        const map = new kakao.maps.Map(mapRef.current, {
+        const map = new kakao.maps.Map(el, {
           center: new kakao.maps.LatLng(center.lat, center.lng),
           level: 8,
         })
@@ -262,8 +247,11 @@ export function MypageScrapbookTicketDetailPage() {
     void drawMap()
     return () => {
       cancelled = true
+      if (mapRef.current) {
+        mapRef.current.innerHTML = ''
+      }
     }
-  }, [spots, profile?.region, formData?.meetingPoint, row?.destination])
+  }, [loading, row, spots, profile?.region, formData?.meetingPoint, row?.destination])
 
   const companionName = useMemo(() => String(profile?.nickname ?? '가이드').trim() || '가이드', [profile?.nickname])
   const tripTitle = useMemo(() => `여행기 #${tripOrder}`, [tripOrder])


### PR DESCRIPTION
## 🔗 이슈 번호

Closes #373

## 💡 주요 변경 사항

- **목록(`/mypage/scrapbook`)**: 완료 건의 `destination`을 모아 카카오맵에 마커로 표시하는 **여행 지도** 블록 추가. `VITE_KAKAO_MAP_APP_KEY` 없으면 에러 문구로 안내
- **티켓 상세**: 데이터 로드 전에는 `mapRef`가 없어 지도 이펙트가 빠르게 종료되던 경우를 막기 위해 `loading`/`row` 준비 후에만 그리고, 이펙트 정리 시 컨테이너 비우기
- **공통**: `loadKakaoSdk`를 `frontend/src/lib/kakaoMapSdk.js`로 분리해 코스/매칭/프로필 등 기존 페이지와 동일 스크립트 로드 경로 유지

## ✅ 체크리스트

- [x] `cd frontend && npm run build`
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [x] `.gitignore` 해당 없음

Made with [Cursor](https://cursor.com)