### PR TITLE
Feat/be#375 채팅방 퇴장 — 마지막 참가자만 DB·메시지 삭제

### DIFF
--- a/backend/module-chat/src/main/java/com/team6/module/chat/config/PresenceInterceptor.java
+++ b/backend/module-chat/src/main/java/com/team6/module/chat/config/PresenceInterceptor.java
@@ -1,12 +1,12 @@
 package com.team6.module.chat.config;
 
 import com.team6.module.chat.service.ChatRoomService;
+import com.team6.module.chat.support.ChatPresenceRedisKeys;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.ObjectProvider; // 추가
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -39,9 +39,6 @@ public class PresenceInterceptor implements ChannelInterceptor {
         this.chatRoomService = chatRoomService;
     }
 
-    private static final String ROOM_PARTICIPANTS = "CHAT_ROOM_PARTICIPANTS:";
-    private static final String USER_SESSION = "USER_SESSION:";
-
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
         StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
@@ -53,9 +50,9 @@ public class PresenceInterceptor implements ChannelInterceptor {
         if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
             String roomId = getRoomId(accessor.getDestination());
             if (roomId != null && userEmail != null) {
-                redisTemplate.opsForSet().add(ROOM_PARTICIPANTS + roomId, userEmail);
+                redisTemplate.opsForSet().add(ChatPresenceRedisKeys.roomParticipantsKey(roomId), userEmail);
                 Map<String, String> sessionData = Map.of("email", userEmail, "roomId", roomId);
-                redisTemplate.opsForHash().putAll(USER_SESSION + sessionId, sessionData);
+                redisTemplate.opsForHash().putAll(ChatPresenceRedisKeys.userSessionKey(sessionId), sessionData);
 
                 chatRoomService.updateLastReadAt(roomId, userEmail);
                 sendReadUpdate(roomId, userEmail);
@@ -63,15 +60,15 @@ public class PresenceInterceptor implements ChannelInterceptor {
             }
         }
         else if (StompCommand.DISCONNECT.equals(accessor.getCommand())) {
-            Map<Object, Object> sessionData = redisTemplate.opsForHash().entries(USER_SESSION + sessionId);
+            Map<Object, Object> sessionData = redisTemplate.opsForHash().entries(ChatPresenceRedisKeys.userSessionKey(sessionId));
             if (!sessionData.isEmpty()) {
                 String email = (String) sessionData.get("email");
                 String roomId = (String) sessionData.get("roomId");
 
                 chatRoomService.updateLastReadAt(roomId, email);
 
-                redisTemplate.opsForSet().remove(ROOM_PARTICIPANTS + roomId, email);
-                redisTemplate.delete(USER_SESSION + sessionId);
+                redisTemplate.opsForSet().remove(ChatPresenceRedisKeys.roomParticipantsKey(roomId), email);
+                redisTemplate.delete(ChatPresenceRedisKeys.userSessionKey(sessionId));
                 log.info("[Presence] User {} left room {}", email, roomId);
             }
         }

--- a/backend/module-chat/src/main/java/com/team6/module/chat/controller/ChatRoomController.java
+++ b/backend/module-chat/src/main/java/com/team6/module/chat/controller/ChatRoomController.java
@@ -39,4 +39,12 @@ public class ChatRoomController {
         return ResponseEntity.ok(response);
     }
 
+    /** 참여자 퇴장. 마지막 참가자가 나가면 MySQL 방·참가자 및 Mongo 메시지를 삭제한다. */
+    @DeleteMapping("/{roomId}")
+    public ResponseEntity<Void> leaveRoom(@PathVariable String roomId) {
+        String userEmail = SecurityUtil.getCurrentUserEmail();
+        chatRoomService.leaveChatRoomAsParticipant(roomId, userEmail);
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/backend/module-chat/src/main/java/com/team6/module/chat/controller/ChatRoomController.java
+++ b/backend/module-chat/src/main/java/com/team6/module/chat/controller/ChatRoomController.java
@@ -4,6 +4,8 @@ package com.team6.module.chat.controller;
 import com.team6.module.chat.dto.chatRoom.ChatRoomCreateRequest;
 import com.team6.module.chat.dto.chatRoom.ChatRoomResponse;
 import com.team6.module.chat.dto.chatRoom.ChatRoomsResponse;
+import com.team6.module.chat.dto.chatRoom.LeaveChatRoomRequest;
+import com.team6.module.chat.dto.chatRoom.LeaveChatRoomResponse;
 import com.team6.module.chat.service.ChatRoomService;
 import com.team6.module.common.global.util.SecurityUtil;
 import jakarta.validation.Valid;
@@ -11,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequestMapping("/chat/rooms")
@@ -39,12 +42,21 @@ public class ChatRoomController {
         return ResponseEntity.ok(response);
     }
 
-    /** 참여자 퇴장. 마지막 참가자가 나가면 MySQL 방·참가자 및 Mongo 메시지를 삭제한다. */
-    @DeleteMapping("/{roomId}")
-    public ResponseEntity<Void> leaveRoom(@PathVariable String roomId) {
+    /**
+     * 참여자 퇴장. 요청 본문에 roomId를 담는다.
+     * 마지막 참가자가 나가면 MySQL 방·참가자 및 Mongo 메시지를 삭제하고, Redis 알림으로 클라이언트 목록을 갱신한다.
+     */
+    @PostMapping("/leave")
+    public ResponseEntity<LeaveChatRoomResponse> leaveRoom(@Valid @RequestBody LeaveChatRoomRequest request) {
         String userEmail = SecurityUtil.getCurrentUserEmail();
-        chatRoomService.leaveChatRoomAsParticipant(roomId, userEmail);
-        return ResponseEntity.noContent().build();
+        boolean roomDeleted = chatRoomService.leaveChatRoomAsParticipant(request.roomId(), userEmail);
+        return ResponseEntity.ok(LeaveChatRoomResponse.ok(roomDeleted));
+    }
+
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<LeaveChatRoomResponse> handleLeaveRoomConflict(ResponseStatusException ex) {
+        String message = ex.getReason() != null ? ex.getReason() : "요청을 처리할 수 없습니다.";
+        return ResponseEntity.status(ex.getStatusCode()).body(LeaveChatRoomResponse.fail(message));
     }
 
 }

--- a/backend/module-chat/src/main/java/com/team6/module/chat/dto/chatRoom/LeaveChatRoomRequest.java
+++ b/backend/module-chat/src/main/java/com/team6/module/chat/dto/chatRoom/LeaveChatRoomRequest.java
@@ -1,0 +1,9 @@
+package com.team6.module.chat.dto.chatRoom;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LeaveChatRoomRequest(
+        @NotBlank(message = "채팅방 ID는 필수입니다.")
+        String roomId
+) {
+}

--- a/backend/module-chat/src/main/java/com/team6/module/chat/dto/chatRoom/LeaveChatRoomResponse.java
+++ b/backend/module-chat/src/main/java/com/team6/module/chat/dto/chatRoom/LeaveChatRoomResponse.java
@@ -1,0 +1,19 @@
+package com.team6.module.chat.dto.chatRoom;
+
+/**
+ * 채팅방 퇴장 API 응답. HTTP 4xx 시에도 동일 필드로 실패 사유를 전달한다.
+ */
+public record LeaveChatRoomResponse(
+        boolean success,
+        String message,
+        /** 퇴장 처리 후 서버에서 방·메시지가 완전히 삭제됐는지 */
+        boolean roomDeleted
+) {
+    public static LeaveChatRoomResponse ok(boolean roomDeleted) {
+        return new LeaveChatRoomResponse(true, "채팅방에서 퇴장했습니다.", roomDeleted);
+    }
+
+    public static LeaveChatRoomResponse fail(String message) {
+        return new LeaveChatRoomResponse(false, message, false);
+    }
+}

--- a/backend/module-chat/src/main/java/com/team6/module/chat/dto/notification/ChatNotificationResponse.java
+++ b/backend/module-chat/src/main/java/com/team6/module/chat/dto/notification/ChatNotificationResponse.java
@@ -4,7 +4,7 @@ import lombok.Builder;
 
 @Builder
 public record ChatNotificationResponse(
-        String type,          // CONNECT, NEW_ROOM, NEW_MESSAGE
+        String type,          // CONNECT, NEW_ROOM, NEW_MESSAGE, ROOM_LEFT
         String roomId,        // 이벤트 발생 방 ID
         String senderEmail,   // 메시지 발신자 (본인 제외용)
         String receiverEmail, // 특정 수신자 (초대 시 사용)

--- a/backend/module-chat/src/main/java/com/team6/module/chat/entity/mysql/ChatRoom.java
+++ b/backend/module-chat/src/main/java/com/team6/module/chat/entity/mysql/ChatRoom.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 
@@ -54,6 +55,24 @@ public class ChatRoom extends BaseTimeEntity {
     public void addParticipant(ChatParticipant participant) {
         this.participants.add(participant);
         this.participantCount = this.participants.size();
+    }
+
+    /**
+     * 참가자 목록에서 해당 이메일을 제거한다. orphanRemoval으로 DB 행도 삭제된다.
+     *
+     * @return 제거 성공 여부
+     */
+    public boolean removeParticipantByEmail(String userEmail) {
+        Iterator<ChatParticipant> it = this.participants.iterator();
+        while (it.hasNext()) {
+            ChatParticipant p = it.next();
+            if (userEmail.equals(p.getUserEmail())) {
+                it.remove();
+                this.participantCount = this.participants.size();
+                return true;
+            }
+        }
+        return false;
     }
 
     public void updateLastMessage(String message, LocalDateTime sentAt) {

--- a/backend/module-chat/src/main/java/com/team6/module/chat/repository/mongodb/ChatMessageRepository.java
+++ b/backend/module-chat/src/main/java/com/team6/module/chat/repository/mongodb/ChatMessageRepository.java
@@ -13,4 +13,6 @@ public interface ChatMessageRepository extends MongoRepository<ChatMessage, Stri
 
     // 특정 채팅방의 메시지를 페이지 단위로 조회 (Slice 사용으로 count 쿼리 생략)
     Slice<ChatMessage> findByRoomIdOrderByCreatedAtDesc(String roomId, Pageable pageable);
+
+    void deleteByRoomId(String roomId);
 }

--- a/backend/module-chat/src/main/java/com/team6/module/chat/service/ChatMessageService.java
+++ b/backend/module-chat/src/main/java/com/team6/module/chat/service/ChatMessageService.java
@@ -10,6 +10,7 @@ import com.team6.module.chat.entity.mysql.ChatParticipant;
 import com.team6.module.chat.entity.mysql.ChatRoom;
 import com.team6.module.chat.repository.mongodb.ChatMessageRepository;
 import com.team6.module.chat.repository.mysql.ChatRoomRepository;
+import com.team6.module.chat.support.ChatPresenceRedisKeys;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.ObjectProvider;
@@ -48,7 +49,7 @@ public class ChatMessageService {
         ChatRoom chatRoom = chatRoomRepository.findByRoomId(request.roomId())
                 .orElseThrow(() -> new RuntimeException("채팅방을 찾을 수 없습니다: " + request.roomId()));
 
-        String activeUsersKey = "CHAT_ROOM_PARTICIPANTS:" + request.roomId();
+        String activeUsersKey = ChatPresenceRedisKeys.roomParticipantsKey(request.roomId());
         Long activeCount = redisTemplate.opsForSet().size(activeUsersKey);
         int currentActive = (activeCount != null) ? activeCount.intValue() : 0;
 

--- a/backend/module-chat/src/main/java/com/team6/module/chat/service/ChatPresenceRedisService.java
+++ b/backend/module-chat/src/main/java/com/team6/module/chat/service/ChatPresenceRedisService.java
@@ -1,0 +1,65 @@
+package com.team6.module.chat.service;
+
+import com.team6.module.chat.support.ChatPresenceRedisKeys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.stereotype.Service;
+
+/**
+ * 채팅 STOMP presence용 Redis 키 정리.
+ * MySQL 참가자 제거·방 삭제와 동기화해 오래된 세트/세션 키가 남지 않게 한다.
+ */
+@Slf4j
+@Service
+public class ChatPresenceRedisService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public ChatPresenceRedisService(
+            @Qualifier("memberRedisTemplate") RedisTemplate<String, String> redisTemplate
+    ) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    /** HTTP 퇴장 등으로 DB에서만 나간 경우, 실시간 세트에서도 이메일을 제거한다. */
+    public void removeUserFromRoomParticipants(String roomId, String userEmail) {
+        String key = ChatPresenceRedisKeys.roomParticipantsKey(roomId);
+        Long removed = redisTemplate.opsForSet().remove(key, userEmail);
+        log.info("[CHAT_PRESENCE] Redis SREM roomId={} email={} removedMembers={}", roomId, userEmail, removed);
+    }
+
+    /**
+     * 방이 완전히 삭제될 때: 참가자 세트 삭제 + 해당 방을 가리키는 USER_SESSION 해시 키 삭제.
+     */
+    public void purgeRoomPresence(String roomId) {
+        String setKey = ChatPresenceRedisKeys.roomParticipantsKey(roomId);
+        Boolean setDeleted = redisTemplate.delete(setKey);
+        log.info("[CHAT_PRESENCE] Redis DEL room participants key={}, existed={}", setKey, Boolean.TRUE.equals(setDeleted));
+
+        int sessionKeysRemoved = deleteUserSessionsForRoom(roomId);
+        log.info("[CHAT_PRESENCE] Redis USER_SESSION purge for roomId={} removedKeys={}", roomId, sessionKeysRemoved);
+    }
+
+    private int deleteUserSessionsForRoom(String roomId) {
+        ScanOptions options = ScanOptions.scanOptions()
+                .match(ChatPresenceRedisKeys.USER_SESSION_PREFIX + "*")
+                .count(200)
+                .build();
+        int removed = 0;
+        try (Cursor<String> cursor = redisTemplate.scan(options)) {
+            while (cursor.hasNext()) {
+                String key = cursor.next();
+                Object ridObj = redisTemplate.opsForHash().get(key, "roomId");
+                String rid = ridObj != null ? ridObj.toString() : null;
+                if (roomId.equals(rid)) {
+                    redisTemplate.delete(key);
+                    removed++;
+                }
+            }
+        }
+        return removed;
+    }
+}

--- a/backend/module-chat/src/main/java/com/team6/module/chat/service/ChatRoomService.java
+++ b/backend/module-chat/src/main/java/com/team6/module/chat/service/ChatRoomService.java
@@ -25,6 +25,7 @@ public class ChatRoomService {
     private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageRepository chatMessageRepository;
     private final NotificationService notificationService;
+    private final ChatPresenceRedisService chatPresenceRedisService;
 
     //채팅방 생성
     @Transactional
@@ -115,8 +116,10 @@ public class ChatRoomService {
         if (room.getParticipants().isEmpty()) {
             chatMessageRepository.deleteByRoomId(roomId);
             chatRoomRepository.delete(room);
+            chatPresenceRedisService.purgeRoomPresence(roomId);
         } else {
             chatRoomRepository.save(room);
+            chatPresenceRedisService.removeUserFromRoomParticipants(roomId, userEmail);
         }
     }
 

--- a/backend/module-chat/src/main/java/com/team6/module/chat/service/ChatRoomService.java
+++ b/backend/module-chat/src/main/java/com/team6/module/chat/service/ChatRoomService.java
@@ -14,9 +14,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -105,21 +109,53 @@ public class ChatRoomService {
     /**
      * 참여자가 채팅방에서 퇴장한다. 본인 행만 제거하며,
      * 마지막 참가자가 퇴장한 경우에만 MySQL 방·참가자와 Mongo 메시지를 삭제한다.
+     *
+     * @return 방이 서버에서 완전히 삭제됐는지 여부
      */
     @Transactional
-    public void leaveChatRoomAsParticipant(String roomId, String userEmail) {
+    public boolean leaveChatRoomAsParticipant(String roomId, String userEmail) {
         ChatRoom room = chatRoomRepository.findByRoomIdWithParticipants(roomId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "채팅방을 찾을 수 없습니다."));
+        List<String> sseRecipients = room.getParticipants().stream()
+                .map(ChatParticipant::getUserEmail)
+                .toList();
         if (!room.removeParticipantByEmail(userEmail)) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "채팅방 참여자만 퇴장할 수 있습니다.");
         }
-        if (room.getParticipants().isEmpty()) {
+        boolean roomDeleted = room.getParticipants().isEmpty();
+        if (roomDeleted) {
             chatMessageRepository.deleteByRoomId(roomId);
             chatRoomRepository.delete(room);
             chatPresenceRedisService.purgeRoomPresence(roomId);
         } else {
             chatRoomRepository.save(room);
             chatPresenceRedisService.removeUserFromRoomParticipants(roomId, userEmail);
+        }
+        publishRoomLeftAfterCommit(roomId, userEmail, roomDeleted, sseRecipients);
+        return roomDeleted;
+    }
+
+    private void publishRoomLeftAfterCommit(String roomId, String userEmail, boolean roomDeleted, List<String> sseRecipients) {
+        Map<String, Object> payload = Map.of(
+                "roomDeleted", roomDeleted,
+                "leftUserEmail", userEmail
+        );
+        Runnable publish = () -> {
+            for (String recipient : sseRecipients) {
+                notificationService.broadcast(ChatNotificationResponse.of(
+                        "ROOM_LEFT", roomId, userEmail, recipient, payload
+                ));
+            }
+        };
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    publish.run();
+                }
+            });
+        } else {
+            publish.run();
         }
     }
 

--- a/backend/module-chat/src/main/java/com/team6/module/chat/service/ChatRoomService.java
+++ b/backend/module-chat/src/main/java/com/team6/module/chat/service/ChatRoomService.java
@@ -9,8 +9,10 @@ import com.team6.module.chat.entity.mysql.ChatRoom;
 import com.team6.module.chat.repository.mongodb.ChatMessageRepository;
 import com.team6.module.chat.repository.mysql.ChatRoomRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDateTime;
 import java.util.Comparator;
@@ -97,6 +99,25 @@ public class ChatRoomService {
                 .findFirst()
                 .ifPresent(ChatParticipant::updateLastReadAt);
 
+    }
+
+    /**
+     * 참여자가 채팅방에서 퇴장한다. 본인 행만 제거하며,
+     * 마지막 참가자가 퇴장한 경우에만 MySQL 방·참가자와 Mongo 메시지를 삭제한다.
+     */
+    @Transactional
+    public void leaveChatRoomAsParticipant(String roomId, String userEmail) {
+        ChatRoom room = chatRoomRepository.findByRoomIdWithParticipants(roomId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "채팅방을 찾을 수 없습니다."));
+        if (!room.removeParticipantByEmail(userEmail)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "채팅방 참여자만 퇴장할 수 있습니다.");
+        }
+        if (room.getParticipants().isEmpty()) {
+            chatMessageRepository.deleteByRoomId(roomId);
+            chatRoomRepository.delete(room);
+        } else {
+            chatRoomRepository.save(room);
+        }
     }
 
 }

--- a/backend/module-chat/src/main/java/com/team6/module/chat/service/NotificationService.java
+++ b/backend/module-chat/src/main/java/com/team6/module/chat/service/NotificationService.java
@@ -53,6 +53,10 @@ public class NotificationService {
                     }
                 });
             });
+        } else if ("ROOM_LEFT".equals(res.type())) {
+            if (res.receiverEmail() != null && emitters.containsKey(res.receiverEmail())) {
+                sendToLocalEmitter(res.receiverEmail(), res);
+            }
         } else {
             // 초대(NEW_ROOM) 등 특정 수신자가 명시된 경우
             if (res.receiverEmail() != null && emitters.containsKey(res.receiverEmail())) {

--- a/backend/module-chat/src/main/java/com/team6/module/chat/support/ChatPresenceRedisKeys.java
+++ b/backend/module-chat/src/main/java/com/team6/module/chat/support/ChatPresenceRedisKeys.java
@@ -1,0 +1,22 @@
+package com.team6.module.chat.support;
+
+/**
+ * STOMP presence({@code PresenceInterceptor})와 메시지 unread 계산({@code ChatMessageService})이
+ * 동일한 Redis 키를 쓰도록 prefix를 한곳에서 관리한다.
+ */
+public final class ChatPresenceRedisKeys {
+
+    private ChatPresenceRedisKeys() {
+    }
+
+    public static final String ROOM_PARTICIPANTS_PREFIX = "CHAT_ROOM_PARTICIPANTS:";
+    public static final String USER_SESSION_PREFIX = "USER_SESSION:";
+
+    public static String roomParticipantsKey(String roomId) {
+        return ROOM_PARTICIPANTS_PREFIX + roomId;
+    }
+
+    public static String userSessionKey(String sessionId) {
+        return USER_SESSION_PREFIX + sessionId;
+    }
+}

--- a/frontend/src/pages/MessagesPage.css
+++ b/frontend/src/pages/MessagesPage.css
@@ -134,14 +134,6 @@
   color: #6b7280;
 }
 
-.msg-copy-hint {
-  display: block;
-  margin-top: 0.28rem;
-  font-size: 0.72rem;
-  font-weight: 600;
-  color: #15803d;
-}
-
 .msg-header-actions {
   position: relative;
   margin-left: auto;

--- a/frontend/src/pages/MessagesPage.css
+++ b/frontend/src/pages/MessagesPage.css
@@ -134,13 +134,93 @@
   color: #6b7280;
 }
 
-.msg-dot {
+.msg-copy-hint {
+  display: block;
+  margin-top: 0.28rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: #15803d;
+}
+
+.msg-header-actions {
+  position: relative;
   margin-left: auto;
+  flex-shrink: 0;
+}
+
+.msg-menu-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  margin: 0;
+  padding: 0;
+  border: none;
+  border-radius: 10px;
+  background: transparent;
+  cursor: pointer;
+  color: #6b7280;
+}
+
+.msg-menu-trigger:hover:not(:disabled) {
+  background: #f3f4f6;
+  color: #111827;
+}
+
+.msg-menu-trigger:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.msg-menu-dots {
+  display: block;
   width: 3px;
   height: 3px;
   border-radius: 50%;
-  background: #9ca3af;
-  box-shadow: 0 6px 0 #9ca3af, 0 12px 0 #9ca3af;
+  background: currentColor;
+  box-shadow: 0 6px 0 currentColor, 0 12px 0 currentColor;
+}
+
+.msg-room-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 30;
+  min-width: 12.5rem;
+  padding: 0.35rem;
+  border-radius: 12px;
+  border: 1px solid #e5e7eb;
+  background: #fff;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.12);
+}
+
+.msg-room-menu-item {
+  display: block;
+  width: 100%;
+  margin: 0;
+  padding: 0.55rem 0.65rem;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  font: inherit;
+  font-size: 0.86rem;
+  font-weight: 600;
+  color: #374151;
+  text-align: left;
+  cursor: pointer;
+}
+
+.msg-room-menu-item:hover {
+  background: #f9fafb;
+}
+
+.msg-room-menu-item--danger {
+  color: #b91c1c;
+}
+
+.msg-room-menu-item--danger:hover {
+  background: #fef2f2;
 }
 
 .msg-body {

--- a/frontend/src/pages/MessagesPage.jsx
+++ b/frontend/src/pages/MessagesPage.jsx
@@ -1,6 +1,6 @@
 import { Client } from '@stomp/stompjs'
 import SockJS from 'sockjs-client/dist/sockjs'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
 
 import { PageEmpty, PageError, PageLoading } from '../components/PageStates.jsx'
@@ -54,6 +54,23 @@ export function MessagesPage() {
   const readUpdateTimerRef = useRef(/** @type {ReturnType<typeof setTimeout> | null} */ (null))
   const autoReadTimerRef = useRef(/** @type {ReturnType<typeof setTimeout> | null} */ (null))
   const roomMenuRef = useRef(/** @type {HTMLDivElement | null} */ (null))
+  const selectedRoomIdRef = useRef(selectedRoomId)
+
+  useEffect(() => {
+    selectedRoomIdRef.current = selectedRoomId
+  }, [selectedRoomId])
+
+  const removeRoomFromList = useCallback((rid) => {
+    setRooms((prev) => {
+      const next = prev.filter((r) => r.roomId !== rid)
+      setSelectedRoomId((cur) => {
+        if (cur !== rid) return cur
+        setMessages([])
+        return next[0]?.roomId ?? ''
+      })
+      return next
+    })
+  }, [])
 
   const myNickname = useMemo(() => {
     const fromClaims =
@@ -89,7 +106,8 @@ export function MessagesPage() {
       refreshTimer = setTimeout(async () => {
         try {
           const list = await fetchChatRooms()
-          setRooms(list.map((r) => (selectedRoomId && r.roomId === selectedRoomId ? { ...r, unreadCount: 0 } : r)))
+          const sid = selectedRoomIdRef.current
+          setRooms(list.map((r) => (sid && r.roomId === sid ? { ...r, unreadCount: 0 } : r)))
         } catch {
           /* ignore */
         }
@@ -99,8 +117,28 @@ export function MessagesPage() {
     es.addEventListener('chat-event', (evt) => {
       try {
         const payload = JSON.parse(String(/** @type {MessageEvent} */ (evt).data || '{}'))
+        if (payload?.type === 'ROOM_LEFT' && payload.roomId) {
+          const rid = payload.roomId
+          const roomDeleted = Boolean(payload.data?.roomDeleted)
+          const leftUser =
+            typeof payload.data?.leftUserEmail === 'string'
+              ? payload.data.leftUserEmail
+              : typeof payload.senderEmail === 'string'
+                ? payload.senderEmail
+                : ''
+          if (roomDeleted) {
+            removeRoomFromList(rid)
+            return
+          }
+          if (leftUser && leftUser === email) {
+            removeRoomFromList(rid)
+            return
+          }
+          scheduleRefreshRooms()
+          return
+        }
         // 현재 보고 있는 방에서의 NEW_MESSAGE는 unreadCount 갱신 대상이 아니다(0 유지).
-        if (payload?.type === 'NEW_MESSAGE' && payload?.roomId && payload.roomId === selectedRoomId) {
+        if (payload?.type === 'NEW_MESSAGE' && payload?.roomId && payload.roomId === selectedRoomIdRef.current) {
           return
         }
         if (payload?.type === 'NEW_MESSAGE' || payload?.type === 'NEW_ROOM') {
@@ -120,7 +158,7 @@ export function MessagesPage() {
       es.close()
       if (sseRef.current === es) sseRef.current = null
     }
-  }, [isAuthenticated, token])
+  }, [isAuthenticated, token, email, removeRoomFromList])
 
   const onPickRoom = (roomId) => {
     setRoomMenuOpen(false)
@@ -150,25 +188,27 @@ export function MessagesPage() {
     setRoomMenuOpen(false)
     setError('')
     try {
-      const res = await apiRequest(`/chat/rooms/${encodeURIComponent(selectedRoomId)}`, { method: 'DELETE' })
+      const res = await apiRequest('/chat/rooms/leave', {
+        method: 'POST',
+        json: { roomId: selectedRoomId },
+      })
       const text = await res.text()
-      if (!res.ok && res.status !== 204) {
-        let msg = text || '퇴장에 실패했습니다.'
-        try {
-          const j = JSON.parse(text)
-          if (j?.message) msg = String(j.message)
-        } catch {
-          /* ignore */
-        }
+      /** @type {{ success?: boolean, message?: string, roomDeleted?: boolean }} */
+      let parsed = {}
+      try {
+        if (text.startsWith('{') || text.startsWith('[')) parsed = JSON.parse(text)
+      } catch {
+        /* ignore */
+      }
+      if (!res.ok) {
+        const msg = typeof parsed.message === 'string' && parsed.message.trim() ? parsed.message.trim() : '퇴장에 실패했습니다.'
         throw new Error(msg)
       }
+      if (parsed.success === false) {
+        throw new Error(typeof parsed.message === 'string' && parsed.message ? parsed.message : '퇴장에 실패했습니다.')
+      }
       const rid = selectedRoomId
-      setRooms((prev) => {
-        const next = prev.filter((r) => r.roomId !== rid)
-        setSelectedRoomId(next[0]?.roomId ?? '')
-        setMessages([])
-        return next
-      })
+      removeRoomFromList(rid)
     } catch (e) {
       setError(e instanceof Error ? e.message : '퇴장에 실패했습니다.')
     }

--- a/frontend/src/pages/MessagesPage.jsx
+++ b/frontend/src/pages/MessagesPage.jsx
@@ -1,7 +1,7 @@
 import { Client } from '@stomp/stompjs'
 import SockJS from 'sockjs-client/dist/sockjs'
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { Link, useSearchParams } from 'react-router-dom'
+import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 
 import { PageEmpty, PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client'
@@ -37,6 +37,7 @@ function nicknameFromEmail(email) {
 
 export function MessagesPage() {
   const { isAuthenticated, email, token, claims } = useAuth()
+  const navigate = useNavigate()
   const [searchParams] = useSearchParams()
   const chatBodyRef = useRef(null)
   const stompRef = useRef(/** @type {Client | null} */ (null))
@@ -50,8 +51,11 @@ export function MessagesPage() {
   const [loadingMessages, setLoadingMessages] = useState(false)
   const [error, setError] = useState('')
   const [sending, setSending] = useState(false)
+  const [roomMenuOpen, setRoomMenuOpen] = useState(false)
+  const [copyHint, setCopyHint] = useState('')
   const readUpdateTimerRef = useRef(/** @type {ReturnType<typeof setTimeout> | null} */ (null))
   const autoReadTimerRef = useRef(/** @type {ReturnType<typeof setTimeout> | null} */ (null))
+  const roomMenuRef = useRef(/** @type {HTMLDivElement | null} */ (null))
 
   const myNickname = useMemo(() => {
     const fromClaims =
@@ -121,9 +125,68 @@ export function MessagesPage() {
   }, [isAuthenticated, token])
 
   const onPickRoom = (roomId) => {
+    setRoomMenuOpen(false)
     setSelectedRoomId(roomId)
     // 읽음 처리 요청은 별도로 보내지만, UI는 즉시 0으로 내려 카톡처럼 반응하게 한다.
     setRooms((prev) => prev.map((r) => (r.roomId === roomId ? { ...r, unreadCount: 0 } : r)))
+  }
+
+  useEffect(() => {
+    if (!roomMenuOpen) return
+    const onDocMouseDown = (e) => {
+      const el = roomMenuRef.current
+      if (el && !el.contains(/** @type {Node} */ (e.target))) {
+        setRoomMenuOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', onDocMouseDown)
+    return () => document.removeEventListener('mousedown', onDocMouseDown)
+  }, [roomMenuOpen])
+
+  const copyRoomId = async () => {
+    if (!selectedRoomId) return
+    try {
+      await navigator.clipboard.writeText(selectedRoomId)
+      setCopyHint('채팅방 ID를 복사했어요.')
+      window.setTimeout(() => setCopyHint(''), 2000)
+    } catch {
+      setCopyHint('복사에 실패했어요.')
+      window.setTimeout(() => setCopyHint(''), 2000)
+    }
+    setRoomMenuOpen(false)
+  }
+
+  const leaveSelectedRoom = async () => {
+    if (!selectedRoomId) return
+    const ok = window.confirm(
+      '채팅방에서 나갑니다. 다른 참가자가 남아 있으면 대화와 방은 그대로 유지되고, 마지막 사람이 나가면 서버에서 방과 메시지가 삭제돼요. 계속할까요?',
+    )
+    if (!ok) return
+    setRoomMenuOpen(false)
+    setError('')
+    try {
+      const res = await apiRequest(`/chat/rooms/${encodeURIComponent(selectedRoomId)}`, { method: 'DELETE' })
+      const text = await res.text()
+      if (!res.ok && res.status !== 204) {
+        let msg = text || '퇴장에 실패했습니다.'
+        try {
+          const j = JSON.parse(text)
+          if (j?.message) msg = String(j.message)
+        } catch {
+          /* ignore */
+        }
+        throw new Error(msg)
+      }
+      const rid = selectedRoomId
+      setRooms((prev) => {
+        const next = prev.filter((r) => r.roomId !== rid)
+        setSelectedRoomId(next[0]?.roomId ?? '')
+        setMessages([])
+        return next
+      })
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '퇴장에 실패했습니다.')
+    }
   }
 
   const bumpRoomPreview = (roomId, message, createdAt) => {
@@ -373,8 +436,42 @@ export function MessagesPage() {
             <span>
               {selectedRoom?.participantCount ? `참여자 ${selectedRoom.participantCount}명` : '채팅방을 선택해 주세요'}
             </span>
+            {copyHint ? <span className="msg-copy-hint">{copyHint}</span> : null}
           </div>
-          <span className="msg-dot" />
+          <div className="msg-header-actions" ref={roomMenuRef}>
+            <button
+              type="button"
+              className="msg-menu-trigger"
+              aria-expanded={roomMenuOpen}
+              aria-haspopup="true"
+              aria-label="채팅방 메뉴"
+              disabled={!selectedRoomId}
+              onClick={() => setRoomMenuOpen((o) => !o)}
+            >
+              <span className="msg-menu-dots" aria-hidden />
+            </button>
+            {roomMenuOpen && selectedRoomId ? (
+              <div className="msg-room-menu" role="menu">
+                <button type="button" className="msg-room-menu-item" role="menuitem" onClick={() => void copyRoomId()}>
+                  채팅방 ID 복사
+                </button>
+                <button
+                  type="button"
+                  className="msg-room-menu-item"
+                  role="menuitem"
+                  onClick={() => {
+                    setRoomMenuOpen(false)
+                    navigate('/mypage/scrapbook')
+                  }}
+                >
+                  나의 여행 기록 열기
+                </button>
+                <button type="button" className="msg-room-menu-item msg-room-menu-item--danger" role="menuitem" onClick={() => void leaveSelectedRoom()}>
+                  채팅방 퇴장하기
+                </button>
+              </div>
+            ) : null}
+          </div>
         </header>
 
         <div ref={chatBodyRef} className="msg-body">

--- a/frontend/src/pages/MessagesPage.jsx
+++ b/frontend/src/pages/MessagesPage.jsx
@@ -1,7 +1,7 @@
 import { Client } from '@stomp/stompjs'
 import SockJS from 'sockjs-client/dist/sockjs'
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { Link, useNavigate, useSearchParams } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router-dom'
 
 import { PageEmpty, PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client'
@@ -37,7 +37,6 @@ function nicknameFromEmail(email) {
 
 export function MessagesPage() {
   const { isAuthenticated, email, token, claims } = useAuth()
-  const navigate = useNavigate()
   const [searchParams] = useSearchParams()
   const chatBodyRef = useRef(null)
   const stompRef = useRef(/** @type {Client | null} */ (null))
@@ -52,7 +51,6 @@ export function MessagesPage() {
   const [error, setError] = useState('')
   const [sending, setSending] = useState(false)
   const [roomMenuOpen, setRoomMenuOpen] = useState(false)
-  const [copyHint, setCopyHint] = useState('')
   const readUpdateTimerRef = useRef(/** @type {ReturnType<typeof setTimeout> | null} */ (null))
   const autoReadTimerRef = useRef(/** @type {ReturnType<typeof setTimeout> | null} */ (null))
   const roomMenuRef = useRef(/** @type {HTMLDivElement | null} */ (null))
@@ -142,19 +140,6 @@ export function MessagesPage() {
     document.addEventListener('mousedown', onDocMouseDown)
     return () => document.removeEventListener('mousedown', onDocMouseDown)
   }, [roomMenuOpen])
-
-  const copyRoomId = async () => {
-    if (!selectedRoomId) return
-    try {
-      await navigator.clipboard.writeText(selectedRoomId)
-      setCopyHint('채팅방 ID를 복사했어요.')
-      window.setTimeout(() => setCopyHint(''), 2000)
-    } catch {
-      setCopyHint('복사에 실패했어요.')
-      window.setTimeout(() => setCopyHint(''), 2000)
-    }
-    setRoomMenuOpen(false)
-  }
 
   const leaveSelectedRoom = async () => {
     if (!selectedRoomId) return
@@ -436,7 +421,6 @@ export function MessagesPage() {
             <span>
               {selectedRoom?.participantCount ? `참여자 ${selectedRoom.participantCount}명` : '채팅방을 선택해 주세요'}
             </span>
-            {copyHint ? <span className="msg-copy-hint">{copyHint}</span> : null}
           </div>
           <div className="msg-header-actions" ref={roomMenuRef}>
             <button
@@ -452,20 +436,6 @@ export function MessagesPage() {
             </button>
             {roomMenuOpen && selectedRoomId ? (
               <div className="msg-room-menu" role="menu">
-                <button type="button" className="msg-room-menu-item" role="menuitem" onClick={() => void copyRoomId()}>
-                  채팅방 ID 복사
-                </button>
-                <button
-                  type="button"
-                  className="msg-room-menu-item"
-                  role="menuitem"
-                  onClick={() => {
-                    setRoomMenuOpen(false)
-                    navigate('/mypage/scrapbook')
-                  }}
-                >
-                  나의 여행 기록 열기
-                </button>
                 <button type="button" className="msg-room-menu-item msg-room-menu-item--danger" role="menuitem" onClick={() => void leaveSelectedRoom()}>
                   채팅방 퇴장하기
                 </button>


### PR DESCRIPTION
## 🔗 이슈 번호

Closes #375

## 💡 주요 변경 사항

### 채팅방 퇴장 (DB·Mongo·Redis)

- **`POST /chat/rooms/leave`** + **`LeaveChatRoomRequest`** `{ roomId }` / **`LeaveChatRoomResponse`** `{ success, message, roomDeleted }`  
  - 성공: `200` + `success: true`, `roomDeleted`는 마지막 참가자 퇴장으로 방·메시지가 삭제됐는지 여부  
  - 실패: `404` / `403` 등 + 동일 DTO 형태로 `success: false`, `message`에 사유 (컨트롤러 `@ExceptionHandler(ResponseStatusException.class)`)
- ~~`DELETE /chat/rooms/{roomId}`~~ **제거** — 클라이언트는 위 POST만 사용 (브레이킹 변경)
- 현재 사용자만 `chat_participants`에서 제거, **참가자가 0명일 때만** Mongo 메시지·MySQL `chat_rooms` 삭제
- `ChatRoom.removeParticipantByEmail`로 `participantCount`와 orphanRemoval 일관 유지

### Redis presence (STOMP 구독 집합)

- **`ChatPresenceRedisService`** (`memberRedisTemplate`): 마지막 퇴장 시 `CHAT_ROOM_PARTICIPANTS:{roomId}` 삭제 + `USER_SESSION:*` SCAN 후 해당 `roomId` 세션 키 삭제. 일반 퇴장 시에는 세트에서 본인 이메일만 SREM
- **`ChatPresenceRedisKeys`** — `PresenceInterceptor` / `ChatMessageService`와 동일 prefix

### 실시간 목록 (Redis pub/sub → SSE)

- 퇴장 처리 **커밋 이후** `ROOM_LEFT` 이벤트를 Redis `chat-notifications`로 브로드캐스트 (`TransactionSynchronization.afterCommit`)
- 페이로드: `data: { roomDeleted, leftUserEmail }`, `receiverEmail`에 당시 참가자 전원(퇴장한 사람 포함) → `NotificationService` → SSE `chat-event`
- **프론트** (`MessagesPage`): `ROOM_LEFT` 수신 시 방 제거 또는 목록 재조회(`fetchChatRooms`), `selectedRoomIdRef`로 SSE 클로저 정합

### UI

- 헤더 점 메뉴: **채팅방 퇴장하기**만 (ID 복사·스크랩북 제거)
- 퇴장 확인 문구: 다른 참가자가 남아 있으면 방 유지, 마지막 퇴장 시 서버에서 방·메시지 삭제 안내

## Redis에 쓰이던 것

`PresenceInterceptor` / `ChatMessageService`가 같은 키를 씁니다.

- **`CHAT_ROOM_PARTICIPANTS:{roomId}`** — STOMP로 방을 구독 중인 이메일 집합
- **`USER_SESSION:{sessionId}`** — 해시에 `email`, `roomId`

## 동작 (presence 정리)

- **`ChatPresenceRedisKeys`** — prefix 단일 정의
- **`ChatPresenceRedisService`**
  - **방만 삭제되는 경우(마지막 참가자 퇴장)**  
    - `DEL CHAT_ROOM_PARTICIPANTS:{roomId}`  
    - `SCAN USER_SESSION:*` 후 `roomId`가 일치하는 세션 키 `DEL`
  - **상대가 남은 퇴장**  
    - `SREM CHAT_ROOM_PARTICIPANTS:{roomId} {userEmail}`
- **`ChatRoomService.leaveChatRoomAsParticipant`**에서 MySQL/Mongo 처리 직후 presence Redis 정리, 커밋 후 `ROOM_LEFT` 알림

## ⚠️ 주의 사항 / 질문

- 한 명이 나가면 전체 삭제가 아니라, **마지막 참가자**가 나갈 때만 방·메시지가 삭제됩니다.
- 퇴장 API는 **`POST /chat/rooms/leave`** + JSON 본문만 지원합니다.

## ✅ 체크리스트

- [x] 빌드가 정상적으로 되는가? (`./gradlew :module-chat:compileJava :api-server:compileJava`, `npm run build`)
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [x] `.gitignore`에 설정 파일(비밀·로컬 전용)이 잘 제외되었는가? (해당 없음)
