### PR TITLE
Feat/be#377: Logback 설정

### DIFF
--- a/backend/api-server/src/main/resources/logback-spring.xml
+++ b/backend/api-server/src/main/resources/logback-spring.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+
+    <!-- 로그를 저장할 경로 -->
+    <property name="LOG_DIR" value="./logs"/>
+    <property name="LOG_FILE_NAME" value="waition-api-log"/>
+
+    <!-- 로그를 출력할 곳을 정하는 appender -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %highlight(%-5level) [%X{traceId}] %cyan(%logger{36}) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_DIR}/${LOG_FILE_NAME}.log</file>
+
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%X{traceId}] %logger{36} - %msg%n</pattern>
+        </encoder>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <!-- 압축해서 저장하도록 .log.gz로 저장 -->
+            <fileNamePattern>${LOG_DIR}/${LOG_FILE_NAME}-%d{yyy-MM-dd}.log.gz</fileNamePattern>
+            <!-- 최대 30개 저장. 즉, 30일만 저장 -->
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE" />
+        <appender-ref ref="FILE" />
+    </root>
+
+</configuration>

--- a/backend/module-common/src/main/java/com/team6/module/common/global/filter/MdcLoggingFilter.java
+++ b/backend/module-common/src/main/java/com/team6/module/common/global/filter/MdcLoggingFilter.java
@@ -1,0 +1,39 @@
+package com.team6.module.common.global.filter;
+
+import jakarta.servlet.*;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Component
+public class MdcLoggingFilter implements Filter {
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException{
+        Filter.super.init(filterConfig);
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+        throws IOException, ServletException {
+
+        //1. 요청이 들어오면 고유한 8자리 글자 Trace ID를 생성
+        String traceId = UUID.randomUUID().toString().substring(0,8);
+        //2. MDC 라는 곳에 해당 아이디를 보관
+        MDC.put("traceId", traceId);
+        try{
+            //3. Controller에 요청을 넘김
+            chain.doFilter(request,response);
+        }finally {
+            //요청 처리가 끝나면 반드시 비워줘야 한다.
+            MDC.clear();
+        }
+    }
+
+    @Override
+    public void destroy(){
+        Filter.super.destroy();
+    }
+}


### PR DESCRIPTION
# 🔗 이슈 번호
- Closes #377 

---

## 💡 주요 변경 사항
1. MDC 기반 로깅 필터 (MdcLoggingFilter) 구현
모든 HTTP 요청 진입 시 고유한 8자리 UUID를 생성하여 MDC(Mapped Diagnostic Context)에 저장합니다.
ThreadLocal을 사용하여 각 요청 쓰레드별로 독립적인 ID를 유지합니다.
finally 블록을 통해 요청 종료 시 MDC.clear()를 수행하여 쓰레드 재사용 시 발생할 수 있는 데이터 오염(Memory Leak)을 방지했습니다.

2. Logback 설정 최적화 및 파일 로깅 전략 수립
콘솔 로깅: %X{traceId} 패턴을 추가하여 모든 로그에 요청 ID가 자동으로 찍히도록 설정했습니다. 가독성을 위해 컬러 하이라이팅을 적용했습니다.
파일 로깅: 운영 환경을 고려하여 ./logs 경로에 로그를 저장하며, 파일 로그에서는 가독성 저해를 막기 위해 ANSI 컬러 코드를 제거했습니다.
아카이빙 전략: 일 단위로 로그를 롤링하며, 저장 공간 절약을 위해 .gz 압축 방식을 적용했습니다. (최근 30일 데이터 보관)

---

## ⚠️ 주의 사항 / 질문
리뷰어가 중점적으로 봐주었으면 하는 부분이나 고민되는 지점을 적어주세요.

---

## ✅ 체크리스트
- [ ] 빌드가 정상적으로 되는가?
- [ ] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [ ] .gitignore에 설정 파일이 잘 포함되었는가? (application-local.yml 등)