### PR TITLE
[Feat/fe#379] 로그인 폼 비밀번호·로그인 버튼 간격

### DIFF
--- a/frontend/src/pages/FormPage.css
+++ b/frontend/src/pages/FormPage.css
@@ -152,7 +152,7 @@
 
 /* 비밀번호 입력란과 로그인 버튼 사이 여유 */
 button[type='submit'].form-login-submit.form-auth-primary-btn {
-  margin-top: 0.65rem;
+  margin-top: 0.75rem;
 }
 
 .form-social--inside {


### PR DESCRIPTION
## 🔗 이슈 번호

Closes #379

## 💡 주요 변경 사항

- 로그인 폼: 비밀번호 필드와 **로그인** 제출 버튼 사이 `margin-top`을 **0.65rem → 0.75rem**으로 미세 조정 (가독·터치 여유)

## ⚠️ 주의 사항 / 질문

- 회원가입 인증 문구 색·로그인/구글 버튼 정렬·아이디·비밀번호 찾기 API/페이지는 이미 `main`에 머지된 커밋(`840516d`, `f23497e`)에 포함되어 있습니다. 이 PR은 그 위에 간격만 한 단계 조정합니다.

## ✅ 체크리스트

- [x] 빌드가 정상적으로 되는가? (`npm run build`)
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [x] `.gitignore`에 설정 파일(비밀·로컬 전용)이 잘 제외되었는가? (해당 없음)
