### PR TITLE
Feat/be#382 회원가입 인증 색·로그인 UX·아이디/비번 찾기 (+간격)

### DIFF
--- a/backend/api-server/src/main/java/com/team6/apiserver/auth/config/SecurityConfig.java
+++ b/backend/api-server/src/main/java/com/team6/apiserver/auth/config/SecurityConfig.java
@@ -55,6 +55,8 @@ public class SecurityConfig {
                         // 1. 누구나 접근 가능한 경로 (화이트리스트)
                         .requestMatchers("/auth/**", "/members/join").permitAll()
                         .requestMatchers(HttpMethod.POST, "/members/email-verification/**").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/members/find-id").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/members/password-reset/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/members/nickname-availability").permitAll()
                         // 인증 인가 경로는 비로그인 유저도 접근 가능
                         .requestMatchers("/oauth2/**").permitAll()

--- a/backend/module-domain/src/main/java/com/team6/domain/member/controller/MemberController.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/member/controller/MemberController.java
@@ -1,15 +1,22 @@
 package com.team6.domain.member.controller;
 
+import com.team6.domain.member.dto.request.FindIdRequest;
 import com.team6.domain.member.dto.request.MemberJoinRequest;
+import com.team6.domain.member.dto.request.PasswordResetConfirmRequest;
+import com.team6.domain.member.dto.request.PasswordResetSendRequest;
 import com.team6.domain.member.entity.Role;
+import com.team6.domain.member.service.AccountRecoveryService;
 import com.team6.domain.member.service.MemberService;
 import com.team6.domain.member.service.SignupEmailVerificationService;
 import com.team6.domain.member.dto.request.EmailVerificationSendRequest;
 import com.team6.domain.member.dto.request.EmailVerificationConfirmRequest;
 import com.team6.domain.member.dto.response.EmailVerificationSendResponse;
+import com.team6.domain.member.dto.response.FindIdResponse;
 import com.team6.domain.member.dto.response.NicknameAvailabilityResponse;
+import com.team6.module.common.global.exception.ExceptionResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,6 +26,7 @@ import org.springframework.web.bind.annotation.*;
 public class MemberController {
     private final MemberService memberService;
     private final SignupEmailVerificationService signupEmailVerificationService;
+    private final AccountRecoveryService accountRecoveryService;
 
     // 가입
     @PostMapping("/join")
@@ -63,5 +71,44 @@ public class MemberController {
         }
         boolean taken = memberService.existsByNickname(nickname.trim());
         return ResponseEntity.ok(new NicknameAvailabilityResponse(!taken));
+    }
+
+    /** 가입 시 입력한 이름·닉네임·역할로 로그인 아이디(이메일) 일부를 확인합니다. */
+    @PostMapping("/find-id")
+    public ResponseEntity<?> findLoginId(@Valid @RequestBody FindIdRequest body) {
+        try {
+            FindIdResponse res = accountRecoveryService.findMaskedEmail(body.getName(), body.getNickname(), body.getRole());
+            return ResponseEntity.ok(res);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest()
+                    .body(ExceptionResponse.of(HttpStatus.BAD_REQUEST, "FIND_ID_FAILED", e.getMessage()));
+        }
+    }
+
+    @PostMapping("/password-reset/send")
+    public ResponseEntity<?> sendPasswordResetCode(@Valid @RequestBody PasswordResetSendRequest body) {
+        try {
+            int sec = accountRecoveryService.sendPasswordResetCode(body.getEmail(), body.getRole());
+            return ResponseEntity.ok(new EmailVerificationSendResponse(sec));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest()
+                    .body(ExceptionResponse.of(HttpStatus.BAD_REQUEST, "PWD_RESET_SEND_FAILED", e.getMessage()));
+        }
+    }
+
+    @PostMapping("/password-reset/confirm")
+    public ResponseEntity<?> confirmPasswordReset(@Valid @RequestBody PasswordResetConfirmRequest body) {
+        try {
+            accountRecoveryService.resetPasswordAfterVerification(
+                    body.getEmail(),
+                    body.getRole(),
+                    body.getCode(),
+                    body.getNewPassword()
+            );
+            return ResponseEntity.ok().build();
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest()
+                    .body(ExceptionResponse.of(HttpStatus.BAD_REQUEST, "PWD_RESET_CONFIRM_FAILED", e.getMessage()));
+        }
     }
 }

--- a/backend/module-domain/src/main/java/com/team6/domain/member/dto/request/FindIdRequest.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/member/dto/request/FindIdRequest.java
@@ -1,0 +1,21 @@
+package com.team6.domain.member.dto.request;
+
+import com.team6.domain.member.entity.Role;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FindIdRequest {
+
+    @NotBlank(message = "이름을 입력해 주세요.")
+    private String name;
+
+    @NotBlank(message = "닉네임을 입력해 주세요.")
+    private String nickname;
+
+    @NotNull(message = "가입 유형을 선택해 주세요.")
+    private Role role;
+}

--- a/backend/module-domain/src/main/java/com/team6/domain/member/dto/request/PasswordResetConfirmRequest.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/member/dto/request/PasswordResetConfirmRequest.java
@@ -1,0 +1,30 @@
+package com.team6.domain.member.dto.request;
+
+import com.team6.domain.member.entity.Role;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+@NoArgsConstructor
+public class PasswordResetConfirmRequest {
+
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "이메일 형식이 아닙니다.")
+    private String email;
+
+    @NotNull(message = "가입 유형을 선택해 주세요.")
+    private Role role;
+
+    @NotBlank(message = "인증번호를 입력해 주세요.")
+    @Size(min = 6, max = 6, message = "인증번호는 6자리입니다.")
+    private String code;
+
+    @NotBlank(message = "새 비밀번호를 입력해 주세요.")
+    @Length(min = 8, max = 16, message = "비밀번호는 8~16자 사이여야 합니다.")
+    private String newPassword;
+}

--- a/backend/module-domain/src/main/java/com/team6/domain/member/dto/request/PasswordResetSendRequest.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/member/dto/request/PasswordResetSendRequest.java
@@ -1,0 +1,20 @@
+package com.team6.domain.member.dto.request;
+
+import com.team6.domain.member.entity.Role;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PasswordResetSendRequest {
+
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "이메일 형식이 아닙니다.")
+    private String email;
+
+    @NotNull(message = "가입 유형을 선택해 주세요.")
+    private Role role;
+}

--- a/backend/module-domain/src/main/java/com/team6/domain/member/dto/response/FindIdResponse.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/member/dto/response/FindIdResponse.java
@@ -1,0 +1,4 @@
+package com.team6.domain.member.dto.response;
+
+public record FindIdResponse(String maskedEmail) {
+}

--- a/backend/module-domain/src/main/java/com/team6/domain/member/repository/MemberRepository.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/member/repository/MemberRepository.java
@@ -20,7 +20,5 @@ public interface MemberRepository extends JpaRepository <Member, Long>{
     boolean existsByNicknameAndStatus(String nickname, Status status);
     boolean existsByNickname(String nickname);
 
-
-
-    Role role(Role role);
+    Optional<Member> findByNameAndNicknameAndRoleAndStatus(String name, String nickname, Role role, Status status);
 }

--- a/backend/module-domain/src/main/java/com/team6/domain/member/service/AccountRecoveryService.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/member/service/AccountRecoveryService.java
@@ -5,7 +5,6 @@ import com.team6.domain.member.entity.Member;
 import com.team6.domain.member.entity.Role;
 import com.team6.domain.member.entity.Status;
 import com.team6.domain.member.repository.MemberRepository;
-import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -20,7 +19,6 @@ import java.security.SecureRandom;
 import java.util.concurrent.TimeUnit;
 
 @Service
-@RequiredArgsConstructor
 public class AccountRecoveryService {
 
     private static final int TTL_SEC = 180;
@@ -28,7 +26,6 @@ public class AccountRecoveryService {
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
-    @Qualifier("memberRedisTemplate")
     private final RedisTemplate<String, String> redisTemplate;
     @Nullable
     private final JavaMailSender mailSender;
@@ -36,6 +33,18 @@ public class AccountRecoveryService {
 
     @Value("${spring.profiles.active:prod}")
     private String activeProfile;
+
+    public AccountRecoveryService(
+            MemberRepository memberRepository,
+            PasswordEncoder passwordEncoder,
+            @Qualifier("memberRedisTemplate") RedisTemplate<String, String> redisTemplate,
+            @Nullable JavaMailSender mailSender
+    ) {
+        this.memberRepository = memberRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.redisTemplate = redisTemplate;
+        this.mailSender = mailSender;
+    }
 
     @Transactional(readOnly = true)
     public FindIdResponse findMaskedEmail(String name, String nickname, Role role) {

--- a/backend/module-domain/src/main/java/com/team6/domain/member/service/AccountRecoveryService.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/member/service/AccountRecoveryService.java
@@ -1,0 +1,133 @@
+package com.team6.domain.member.service;
+
+import com.team6.domain.member.dto.response.FindIdResponse;
+import com.team6.domain.member.entity.Member;
+import com.team6.domain.member.entity.Role;
+import com.team6.domain.member.entity.Status;
+import com.team6.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.lang.Nullable;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class AccountRecoveryService {
+
+    private static final int TTL_SEC = 180;
+    private static final String DEV_BYPASS_CODE = "000000";
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+    @Qualifier("memberRedisTemplate")
+    private final RedisTemplate<String, String> redisTemplate;
+    @Nullable
+    private final JavaMailSender mailSender;
+    private final SecureRandom random = new SecureRandom();
+
+    @Value("${spring.profiles.active:prod}")
+    private String activeProfile;
+
+    @Transactional(readOnly = true)
+    public FindIdResponse findMaskedEmail(String name, String nickname, Role role) {
+        String n = name.trim();
+        String nick = nickname.trim();
+        Member member = memberRepository
+                .findByNameAndNicknameAndRoleAndStatus(n, nick, role, Status.ACTIVE)
+                .orElseThrow(() -> new IllegalArgumentException("입력하신 정보와 일치하는 계정을 찾을 수 없습니다."));
+        return new FindIdResponse(maskEmail(member.getEmail()));
+    }
+
+    public int sendPasswordResetCode(String email, Role role) {
+        String normalized = email.trim().toLowerCase();
+        Member member = memberRepository.findByEmailAndRole(normalized, role)
+                .orElseThrow(() -> new IllegalArgumentException("등록된 계정을 찾을 수 없습니다."));
+        if (member.getStatus() != Status.ACTIVE) {
+            throw new IllegalArgumentException("사용할 수 없는 계정입니다.");
+        }
+        if (member.getPassword() == null || member.getPassword().isBlank()) {
+            throw new IllegalArgumentException("소셜 로그인으로 가입된 계정입니다. 구글 로그인을 이용해 주세요.");
+        }
+
+        String code = String.format("%06d", random.nextInt(1_000_000));
+        redisTemplate.opsForValue().set(pwdResetKey(normalized, role), code, TTL_SEC, TimeUnit.SECONDS);
+
+        if (mailSender != null) {
+            SimpleMailMessage message = new SimpleMailMessage();
+            message.setTo(normalized);
+            message.setSubject("[LocalGuest] 비밀번호 재설정 인증번호");
+            message.setText("인증번호는 [" + code + "] 입니다. 3분 이내에 입력해 주세요.");
+            mailSender.send(message);
+        } else if (isLocalProfile()) {
+            System.out.println("========================================");
+            System.out.println("📧 [개발용] 비밀번호 재설정 인증번호");
+            System.out.println("이메일: " + normalized + " / 역할: " + role);
+            System.out.println("인증번호: " + code);
+            System.out.println("또는 만능 코드: " + DEV_BYPASS_CODE);
+            System.out.println("========================================");
+        }
+
+        return TTL_SEC;
+    }
+
+    @Transactional
+    public void resetPasswordAfterVerification(String email, Role role, String code, String newPassword) {
+        String normalized = email.trim().toLowerCase();
+        verifyPwdResetCode(normalized, role, code.trim());
+
+        Member member = memberRepository.findByEmailAndRole(normalized, role)
+                .orElseThrow(() -> new IllegalArgumentException("등록된 계정을 찾을 수 없습니다."));
+        if (member.getStatus() != Status.ACTIVE) {
+            throw new IllegalArgumentException("사용할 수 없는 계정입니다.");
+        }
+        if (member.getPassword() == null || member.getPassword().isBlank()) {
+            throw new IllegalArgumentException("소셜 로그인으로 가입된 계정입니다. 구글 로그인을 이용해 주세요.");
+        }
+
+        member.updatePassword(passwordEncoder.encode(newPassword));
+    }
+
+    private void verifyPwdResetCode(String normalizedEmail, Role role, String trimmedCode) {
+        if (isLocalProfile() && DEV_BYPASS_CODE.equals(trimmedCode)) {
+            return;
+        }
+        String key = pwdResetKey(normalizedEmail, role);
+        String stored = redisTemplate.opsForValue().get(key);
+        if (stored == null || !stored.equals(trimmedCode)) {
+            throw new IllegalArgumentException("인증번호가 올바르지 않거나 만료되었습니다.");
+        }
+        redisTemplate.delete(key);
+    }
+
+    private String pwdResetKey(String normalizedEmail, Role role) {
+        return "pwdreset:email:code:" + normalizedEmail + ":" + role.name();
+    }
+
+    private boolean isLocalProfile() {
+        return "local".equals(activeProfile);
+    }
+
+    private static String maskEmail(String email) {
+        if (email == null || email.isBlank()) {
+            return "***";
+        }
+        String e = email.trim();
+        int at = e.indexOf('@');
+        if (at < 1 || at == e.length() - 1) {
+            return "***";
+        }
+        String local = e.substring(0, at);
+        String domain = e.substring(at + 1);
+        int show = Math.min(2, local.length());
+        return local.substring(0, show) + "***@" + domain;
+    }
+}

--- a/frontend/src/pages/FindIdPage.jsx
+++ b/frontend/src/pages/FindIdPage.jsx
@@ -1,0 +1,135 @@
+import { useMemo, useState } from 'react'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
+
+import { apiRequest } from '../api/client'
+
+import './FormPage.css'
+
+function parseErrorMessage(text) {
+  if (!text?.trim()) return '요청을 처리할 수 없습니다.'
+  try {
+    const j = JSON.parse(text)
+    if (typeof j.message === 'string' && j.message.trim()) return j.message.trim()
+  } catch {
+    /* ignore */
+  }
+  return text.trim()
+}
+
+export function FindIdPage() {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const initialRole =
+    String(location.state?.role ?? '').toUpperCase() === 'GUIDE' ? 'GUIDE' : 'GUEST'
+
+  const [role, setRole] = useState(initialRole)
+  const [name, setName] = useState('')
+  const [nickname, setNickname] = useState('')
+  const [maskedEmail, setMaskedEmail] = useState('')
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  const roleLabel = useMemo(() => (role === 'GUIDE' ? '가이드' : '여행자'), [role])
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setError('')
+    setMaskedEmail('')
+    setLoading(true)
+    try {
+      const res = await apiRequest('/members/find-id', {
+        method: 'POST',
+        json: { name: name.trim(), nickname: nickname.trim(), role },
+      })
+      const text = await res.text()
+      if (!res.ok) {
+        throw new Error(parseErrorMessage(text))
+      }
+      const data = text ? JSON.parse(text) : {}
+      if (typeof data.maskedEmail === 'string' && data.maskedEmail) {
+        setMaskedEmail(data.maskedEmail)
+      } else {
+        throw new Error('응답 형식이 올바르지 않습니다.')
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '오류가 발생했습니다.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="form-page">
+      <h1>아이디(이메일) 찾기</h1>
+      <p className="form-hint">가입 시 입력한 이름·닉네임·{roleLabel} 유형이 일치하면 이메일 일부를 안내합니다.</p>
+
+      <form className="form-card" onSubmit={(e) => void handleSubmit(e)}>
+        <div className="form-role-switch" role="tablist" aria-label="가입 유형">
+          <button
+            type="button"
+            className={`form-role-btn${role === 'GUEST' ? ' is-on' : ''}`}
+            onClick={() => setRole('GUEST')}
+            role="tab"
+            aria-selected={role === 'GUEST'}
+          >
+            여행자
+          </button>
+          <button
+            type="button"
+            className={`form-role-btn${role === 'GUIDE' ? ' is-on' : ''}`}
+            onClick={() => setRole('GUIDE')}
+            role="tab"
+            aria-selected={role === 'GUIDE'}
+          >
+            가이드
+          </button>
+        </div>
+
+        <label className="field">
+          <span>이름</span>
+          <input value={name} onChange={(ev) => setName(ev.target.value)} required autoComplete="name" />
+        </label>
+        <label className="field">
+          <span>닉네임</span>
+          <input value={nickname} onChange={(ev) => setNickname(ev.target.value)} required autoComplete="nickname" />
+        </label>
+
+        {error && <p className="form-error">{error}</p>}
+        {maskedEmail && (
+          <div className="form-success">
+            <p style={{ margin: 0 }}>등록된 이메일(일부만 표시)</p>
+            <p style={{ margin: '0.35rem 0 0', fontWeight: 800, fontSize: '1.05rem' }}>{maskedEmail}</p>
+          </div>
+        )}
+
+        <button type="submit" className="submit form-login-submit form-auth-primary-btn" disabled={loading}>
+          {loading ? '확인 중…' : '확인'}
+        </button>
+
+        <nav className="form-account-links" aria-label="다른 메뉴">
+          <Link to="/auth/login" className="form-text-link">
+            로그인
+          </Link>
+          <span className="form-account-links__sep" aria-hidden>
+            ·
+          </span>
+          <Link to="/auth/forgot-password" className="form-text-link">
+            비밀번호 찾기
+          </Link>
+          <span className="form-account-links__sep" aria-hidden>
+            ·
+          </span>
+          <Link to="/auth/signup" className="form-text-link">
+            회원가입
+          </Link>
+        </nav>
+      </form>
+
+      <p className="form-footer" style={{ marginTop: '1rem' }}>
+        <button type="button" className="form-text-link" onClick={() => navigate(-1)}>
+          이전 페이지
+        </button>
+      </p>
+    </div>
+  )
+}

--- a/frontend/src/pages/ForgotPasswordPage.jsx
+++ b/frontend/src/pages/ForgotPasswordPage.jsx
@@ -1,0 +1,215 @@
+import { useMemo, useState } from 'react'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
+
+import { apiRequest } from '../api/client'
+
+import './FormPage.css'
+
+function parseErrorMessage(text) {
+  if (!text?.trim()) return '요청을 처리할 수 없습니다.'
+  try {
+    const j = JSON.parse(text)
+    if (typeof j.message === 'string' && j.message.trim()) return j.message.trim()
+  } catch {
+    /* ignore */
+  }
+  return text.trim()
+}
+
+export function ForgotPasswordPage() {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const initialRole =
+    String(location.state?.role ?? '').toUpperCase() === 'GUIDE' ? 'GUIDE' : 'GUEST'
+
+  const [role, setRole] = useState(initialRole)
+  const [email, setEmail] = useState('')
+  const [code, setCode] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [newPassword2, setNewPassword2] = useState('')
+  const [codeSent, setCodeSent] = useState(false)
+  const [done, setDone] = useState(false)
+  const [error, setError] = useState('')
+  const [sendBusy, setSendBusy] = useState(false)
+  const [submitBusy, setSubmitBusy] = useState(false)
+
+  const roleLabel = useMemo(() => (role === 'GUIDE' ? '가이드' : '여행자'), [role])
+
+  const handleSend = async () => {
+    setError('')
+    setSendBusy(true)
+    try {
+      const res = await apiRequest('/members/password-reset/send', {
+        method: 'POST',
+        json: { email: email.trim(), role },
+      })
+      const text = await res.text()
+      if (!res.ok) throw new Error(parseErrorMessage(text))
+      setCodeSent(true)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '발송에 실패했습니다.')
+    } finally {
+      setSendBusy(false)
+    }
+  }
+
+  const handleReset = async (e) => {
+    e.preventDefault()
+    setError('')
+    if (newPassword !== newPassword2) {
+      setError('새 비밀번호가 서로 다릅니다.')
+      return
+    }
+    setSubmitBusy(true)
+    try {
+      const res = await apiRequest('/members/password-reset/confirm', {
+        method: 'POST',
+        json: {
+          email: email.trim(),
+          role,
+          code: code.replace(/\D/g, '').slice(0, 6),
+          newPassword,
+        },
+      })
+      const text = await res.text()
+      if (!res.ok) throw new Error(parseErrorMessage(text))
+      setDone(true)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '처리에 실패했습니다.')
+    } finally {
+      setSubmitBusy(false)
+    }
+  }
+
+  return (
+    <div className="form-page">
+      <h1>비밀번호 찾기</h1>
+      <p className="form-hint">
+        {roleLabel} 계정의 가입 이메일로 인증번호를 보낸 뒤, 새 비밀번호를 설정합니다. (소셜 전용 계정은 구글 로그인을 이용해 주세요.)
+      </p>
+
+      <form className="form-card" onSubmit={(e) => void handleReset(e)}>
+        <div className="form-role-switch" role="tablist" aria-label="가입 유형">
+          <button
+            type="button"
+            className={`form-role-btn${role === 'GUEST' ? ' is-on' : ''}`}
+            onClick={() => setRole('GUEST')}
+            role="tab"
+            aria-selected={role === 'GUEST'}
+          >
+            여행자
+          </button>
+          <button
+            type="button"
+            className={`form-role-btn${role === 'GUIDE' ? ' is-on' : ''}`}
+            onClick={() => setRole('GUIDE')}
+            role="tab"
+            aria-selected={role === 'GUIDE'}
+          >
+            가이드
+          </button>
+        </div>
+
+        <label className="field">
+          <span>이메일</span>
+          <input
+            type="email"
+            value={email}
+            onChange={(ev) => setEmail(ev.target.value)}
+            required
+            autoComplete="email"
+          />
+        </label>
+
+        <div className="field">
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: '0.5rem' }}>
+            <span>인증번호</span>
+            <button
+              type="button"
+              className="submit ghost"
+              style={{ padding: '0.35rem 0.65rem', fontSize: '0.82rem' }}
+              onClick={() => void handleSend()}
+              disabled={sendBusy || !email.trim()}
+            >
+              {sendBusy ? '발송 중…' : codeSent ? '재발송' : '인증번호 발송'}
+            </button>
+          </div>
+          <input
+            inputMode="numeric"
+            autoComplete="one-time-code"
+            placeholder="6자리"
+            maxLength={6}
+            value={code}
+            onChange={(ev) => setCode(ev.target.value.replace(/\D/g, '').slice(0, 6))}
+          />
+        </div>
+        {codeSent && (
+          <p className="form-hint" style={{ marginTop: '-0.35rem', color: '#047857', fontWeight: 700 }}>
+            인증번호가 발송되었습니다.
+          </p>
+        )}
+
+        <label className="field">
+          <span>새 비밀번호</span>
+          <input
+            type="password"
+            autoComplete="new-password"
+            value={newPassword}
+            onChange={(ev) => setNewPassword(ev.target.value)}
+            minLength={8}
+            maxLength={16}
+            required
+          />
+        </label>
+        <label className="field">
+          <span>새 비밀번호 확인</span>
+          <input
+            type="password"
+            autoComplete="new-password"
+            value={newPassword2}
+            onChange={(ev) => setNewPassword2(ev.target.value)}
+            minLength={8}
+            maxLength={16}
+            required
+          />
+        </label>
+
+        {error && <p className="form-error">{error}</p>}
+        {done && (
+          <div className="form-success">
+            <p style={{ margin: 0 }}>비밀번호가 변경되었습니다. 로그인해 주세요.</p>
+          </div>
+        )}
+
+        {!done && (
+          <button type="submit" className="submit form-login-submit form-auth-primary-btn" disabled={submitBusy}>
+            {submitBusy ? '처리 중…' : '비밀번호 변경'}
+          </button>
+        )}
+        {done && (
+          <button type="button" className="submit form-login-submit form-auth-primary-btn" onClick={() => navigate('/auth/login')}>
+            로그인으로 이동
+          </button>
+        )}
+
+        <nav className="form-account-links" aria-label="다른 메뉴">
+          <Link to="/auth/login" className="form-text-link">
+            로그인
+          </Link>
+          <span className="form-account-links__sep" aria-hidden>
+            ·
+          </span>
+          <Link to="/auth/find-id" className="form-text-link">
+            아이디 찾기
+          </Link>
+          <span className="form-account-links__sep" aria-hidden>
+            ·
+          </span>
+          <Link to="/auth/signup" className="form-text-link">
+            회원가입
+          </Link>
+        </nav>
+      </form>
+    </div>
+  )
+}

--- a/frontend/src/pages/FormPage.css
+++ b/frontend/src/pages/FormPage.css
@@ -142,9 +142,23 @@
   background: #f2cddd;
 }
 
+/* 로그인 / 구글 로그인 동일 폭·블록 버튼 */
+.form-auth-primary-btn {
+  width: 100%;
+  box-sizing: border-box;
+  margin-top: 0;
+  min-height: 2.65rem;
+}
+
 .form-social--inside {
   margin-top: 0.1rem;
   padding-top: 0.25rem;
+}
+
+.form-social--after-login {
+  margin-top: 0.35rem;
+  padding-top: 0.35rem;
+  border-top: none;
 }
 
 .form-google-login {
@@ -195,4 +209,49 @@
 .form-footer a {
   color: #0d47a1;
   font-weight: 600;
+}
+
+.form-account-links {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.2rem 0.35rem;
+  margin-top: 0.15rem;
+  padding-top: 0.15rem;
+  font-size: 0.82rem;
+  color: #6b7280;
+}
+
+.form-account-links__sep {
+  color: #d1d5db;
+  user-select: none;
+}
+
+.form-text-link {
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: none;
+  font: inherit;
+  font-size: inherit;
+  color: #6b7280;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+
+.form-text-link:hover {
+  color: #374151;
+}
+
+a.form-text-link {
+  color: #6b7280;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  font-weight: inherit;
+}
+
+a.form-text-link:hover {
+  color: #374151;
 }

--- a/frontend/src/pages/FormPage.css
+++ b/frontend/src/pages/FormPage.css
@@ -152,7 +152,7 @@
 
 /* 비밀번호 입력란과 로그인 버튼 사이 여유 */
 button[type='submit'].form-login-submit.form-auth-primary-btn {
-  margin-top: 0.65rem;
+  margin-top: 0.75rem;
 }
 
 .form-social--inside {

--- a/frontend/src/pages/FormPage.css
+++ b/frontend/src/pages/FormPage.css
@@ -150,6 +150,11 @@
   min-height: 2.65rem;
 }
 
+/* 비밀번호 입력란과 로그인 버튼 사이 여유 */
+button[type='submit'].form-login-submit.form-auth-primary-btn {
+  margin-top: 0.65rem;
+}
+
 .form-social--inside {
   margin-top: 0.1rem;
   padding-top: 0.25rem;

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -126,10 +126,16 @@ export function LoginPage() {
           />
         </label>
 
-        <div className="form-social form-social--inside">
+        {error && <p className="form-error">{error}</p>}
+
+        <button type="submit" className="submit form-login-submit form-auth-primary-btn" disabled={loading}>
+          {loading ? '처리 중…' : '로그인'}
+        </button>
+
+        <div className="form-social form-social--inside form-social--after-login">
           <button
             type="button"
-            className="submit ghost form-google-login"
+            className="submit ghost form-google-login form-auth-primary-btn"
             onClick={() => beginGoogleOAuth(role, returnTo)}
             title="Google OAuth2 로그인"
           >
@@ -140,11 +146,27 @@ export function LoginPage() {
           </button>
         </div>
 
-        {error && <p className="form-error">{error}</p>}
-
-        <button type="submit" className="submit form-login-submit" disabled={loading}>
-          {loading ? '처리 중…' : '로그인'}
-        </button>
+        <nav className="form-account-links" aria-label="계정 찾기 및 가입">
+          <button type="button" className="form-text-link" onClick={() => navigate('/auth/find-id', { state: { role } })}>
+            아이디(이메일) 찾기
+          </button>
+          <span className="form-account-links__sep" aria-hidden>
+            ·
+          </span>
+          <button
+            type="button"
+            className="form-text-link"
+            onClick={() => navigate('/auth/forgot-password', { state: { role } })}
+          >
+            비밀번호 찾기
+          </button>
+          <span className="form-account-links__sep" aria-hidden>
+            ·
+          </span>
+          <button type="button" className="form-text-link" onClick={() => navigate('/auth/signup')}>
+            회원가입
+          </button>
+        </nav>
       </form>
 
       {roleMismatch && (

--- a/frontend/src/pages/SignupPage.css
+++ b/frontend/src/pages/SignupPage.css
@@ -276,7 +276,7 @@
 }
 
 .signup-hint--sent {
-  color: #e11d48;
+  color: #047857;
   font-weight: 700;
 }
 

--- a/frontend/src/pages/SignupPage.jsx
+++ b/frontend/src/pages/SignupPage.jsx
@@ -639,11 +639,7 @@ export function SignupPage() {
                 {emailConfirmBusy ? '확인 중…' : '확인'}
               </button>
             </div>
-            {emailVerified && (
-              <p className="signup-hint" style={{ color: '#047857' }}>
-                인증이 완료되었습니다.
-              </p>
-            )}
+            {emailVerified && <p className="signup-hint signup-hint--sent">인증이 완료되었습니다.</p>}
           </div>
 
           {error && <p className="signup-error">{error}</p>}

--- a/frontend/src/routes/authRoutes.jsx
+++ b/frontend/src/routes/authRoutes.jsx
@@ -2,6 +2,8 @@ import { useEffect } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 
 import { useAuth } from '../context/useAuth.js'
+import { FindIdPage } from '../pages/FindIdPage'
+import { ForgotPasswordPage } from '../pages/ForgotPasswordPage'
 import { LoginPage } from '../pages/LoginPage'
 import { OnboardingPage } from '../pages/OnboardingPage'
 import { SignupPage } from '../pages/SignupPage'
@@ -44,6 +46,8 @@ function OAuth2CallbackPage() {
 
 export const authRoutes = [
   { path: 'auth/login', element: <LoginPage /> },
+  { path: 'auth/find-id', element: <FindIdPage /> },
+  { path: 'auth/forgot-password', element: <ForgotPasswordPage /> },
   { path: 'auth/signup', element: <SignupPage /> },
   { path: 'oauth2/callback', element: <OAuth2CallbackPage /> },
   { path: 'onboarding', element: <OnboardingPage /> },


### PR DESCRIPTION
## 🔗 이슈 번호

Closes #382

## 💡 주요 변경 사항

- 회원가입 STEP2: '인증번호가 발송되었습니다.' 안내 색상을 '인증이 완료되었습니다'와 동일 톤으로 통일
- 로그인: 로그인 버튼을 구글 버튼 위로 배치 + 두 버튼 동일 폭/높이
- 로그인 하단 텍스트 링크: 아이디(이메일) 찾기 · 비밀번호 찾기 · 회원가입
- 아이디 찾기/비밀번호 재설정 기능 구현
  - POST /members/find-id
  - POST /members/password-reset/send
  - POST /members/password-reset/confirm
  - SecurityConfig permitAll 반영
- PR #381(간격 미세 조정) 내용 포함: 비밀번호 입력란과 로그인 버튼 사이 여백 조정

## ✅ 체크리스트

- [x] 빌드가 정상적으로 되는가? (./gradlew :module-domain:compileJava :api-server:compileJava, npm run build)


Made with [Cursor](https://cursor.com)