### PR TITLE
Feat/be#387 코스 스팟 시간 드롭다운 선택

### DIFF
--- a/frontend/src/pages/GuideCoursePanel.css
+++ b/frontend/src/pages/GuideCoursePanel.css
@@ -277,6 +277,15 @@
   background: #fff;
 }
 
+.gcp-input.gcp-select {
+  cursor: pointer;
+  appearance: auto;
+}
+
+.gcp-select--time {
+  min-width: 0;
+}
+
 .gcp-textarea {
   width: 100%;
   padding: 9px 12px;

--- a/frontend/src/pages/GuideCoursePanel.css
+++ b/frontend/src/pages/GuideCoursePanel.css
@@ -277,13 +277,87 @@
   background: #fff;
 }
 
-.gcp-input.gcp-select {
-  cursor: pointer;
-  appearance: auto;
+/* 코스 시간: 스크롤되는 커스텀 드롭다운 */
+.gcp-time-dd {
+  position: relative;
+  width: 100%;
+  min-width: 0;
 }
 
-.gcp-select--time {
+.gcp-time-dd--open {
+  z-index: 30;
+}
+
+.gcp-time-dd-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+  cursor: pointer;
+  text-align: left;
+}
+
+.gcp-time-dd-value,
+.gcp-time-dd-placeholder {
+  flex: 1;
   min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.gcp-time-dd-placeholder {
+  color: #9ca3af;
+}
+
+.gcp-time-dd-chevron {
+  flex-shrink: 0;
+  font-size: 10px;
+  color: #6b7280;
+  line-height: 1;
+}
+
+.gcp-time-dd-list {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: calc(100% + 4px);
+  margin: 0;
+  padding: 4px 0;
+  list-style: none;
+  max-height: 200px;
+  overflow-y: auto;
+  border-radius: 8px;
+  border: 1px solid #e5e7eb;
+  background: #fff;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
+  box-sizing: border-box;
+}
+
+.gcp-time-dd-option {
+  display: block;
+  width: 100%;
+  padding: 8px 12px;
+  border: none;
+  background: transparent;
+  color: #111;
+  font: inherit;
+  font-size: 14px;
+  text-align: left;
+  cursor: pointer;
+  box-sizing: border-box;
+}
+
+.gcp-time-dd-option:hover,
+.gcp-time-dd-option:focus {
+  outline: none;
+  background: #f3f4f6;
+}
+
+.gcp-time-dd-option--selected {
+  font-weight: 600;
+  background: #fafafa;
 }
 
 .gcp-textarea {

--- a/frontend/src/pages/GuideCoursePanel.jsx
+++ b/frontend/src/pages/GuideCoursePanel.jsx
@@ -1,10 +1,50 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { apiRequest } from '../api/client.js'
 import { DEFAULT_KOREA_CENTER, geocodeAddressOnly, getUserLatLng, resolveLatLng } from '../lib/kakaoGeocode.js'
 import { loadKakaoSdk } from '../lib/kakaoMapSdk.js'
 import './GuideCoursePanel.css'
 
 const KAKAO_APP_KEY = import.meta.env.VITE_KAKAO_MAP_APP_KEY
+
+/** @param {number} h 0–23 @param {number} minute 0 or 30 */
+function formatKoreanTimeSlot(h, minute) {
+  const isPM = h >= 12
+  let displayH = h % 12
+  if (displayH === 0) displayH = 12
+  const period = isPM ? '오후' : '오전'
+  return `${period} ${displayH}:${String(minute).padStart(2, '0')}`
+}
+
+/** @param {string | undefined} s "HH:mm" */
+function parseHmToMinutes(s) {
+  if (s == null || typeof s !== 'string') return null
+  const m = s.trim().match(/^(\d{1,2}):(\d{2})$/)
+  if (!m) return null
+  const h = Number(m[1])
+  const min = Number(m[2])
+  if (!Number.isFinite(h) || !Number.isFinite(min) || h < 0 || h > 23 || min < 0 || min > 59) return null
+  return h * 60 + min
+}
+
+/** 30분 간격 라벨 목록. 스케줄 시작·종료가 파싱되면 그 구간만, 아니면 하루 전체 */
+function buildCourseTimeOptionLabels(startTime, endTime) {
+  const all = []
+  for (let h = 0; h < 24; h += 1) {
+    for (const minute of [0, 30]) {
+      all.push(formatKoreanTimeSlot(h, minute))
+    }
+  }
+  const start = parseHmToMinutes(startTime)
+  const end = parseHmToMinutes(endTime)
+  if (start == null || end == null || end < start) return all
+  const filtered = []
+  for (let mins = 0; mins < 24 * 60; mins += 30) {
+    if (mins >= start && mins <= end) {
+      filtered.push(formatKoreanTimeSlot(Math.floor(mins / 60), mins % 60))
+    }
+  }
+  return filtered.length > 0 ? filtered : all
+}
 
 function createPinOverlay(kakao, map, latlng, idx, name) {
   const root = document.createElement('div')
@@ -76,6 +116,12 @@ export function GuideCoursePanel({
   const debounceTimerRef = useRef(null)
   const dragSpotIdx = useRef(null)
   const spotsRef = useRef(spots)
+
+  const courseTimeOptions = useMemo(
+    () => buildCourseTimeOptionLabels(schedule?.startTime, schedule?.endTime),
+    [schedule?.startTime, schedule?.endTime],
+  )
+  const courseTimeOptionSet = useMemo(() => new Set(courseTimeOptions), [courseTimeOptions])
 
   // ── 초기 데이터 로드 (GET form) ──────────────────────────────────────
   useEffect(() => {
@@ -498,13 +544,21 @@ export function GuideCoursePanel({
                         )}
                       </div>
                       <div className="gcp-spot-row2">
-                        <input
-                          className="gcp-input"
-                          type="text"
-                          placeholder="시간 (예: 오전 10:00)"
+                        <select
+                          id={`gcp-spot-time-${idx}`}
+                          className="gcp-input gcp-select gcp-select--time"
+                          aria-label={`스팟 ${idx + 1} 시간`}
                           value={spot.time}
                           onChange={(e) => updateSpot(idx, 'time', e.target.value)}
-                        />
+                        >
+                          <option value="">시간 선택</option>
+                          {courseTimeOptions.map((t) => (
+                            <option key={t} value={t}>{t}</option>
+                          ))}
+                          {spot.time && !courseTimeOptionSet.has(spot.time) ? (
+                            <option value={spot.time}>{spot.time}</option>
+                          ) : null}
+                        </select>
                         <input
                           className="gcp-input"
                           type="text"

--- a/frontend/src/pages/GuideCoursePanel.jsx
+++ b/frontend/src/pages/GuideCoursePanel.jsx
@@ -77,6 +77,106 @@ export function parseCourseDetail(text) {
     })
 }
 
+/** 네이티브 select는 목록 높이 제한이 불가해, 스크롤 가능한 커스텀 패널 사용 */
+function CourseTimeDropdown({
+  id,
+  ariaLabel,
+  value,
+  options,
+  optionSet,
+  isOpen,
+  onToggle,
+  onClose,
+  onSelect,
+}) {
+  const listRef = useRef(null)
+  const legacy = value && !optionSet.has(value) ? value : null
+
+  useEffect(() => {
+    if (!isOpen) return
+    const onKey = (e) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [isOpen, onClose])
+
+  useEffect(() => {
+    if (!isOpen || !listRef.current) return
+    const sel = listRef.current.querySelector('.gcp-time-dd-option--selected')
+    sel?.scrollIntoView({ block: 'nearest' })
+  }, [isOpen, value])
+
+  return (
+    <div className={`gcp-time-dd${isOpen ? ' gcp-time-dd--open' : ''}`} data-gcp-time-dd>
+      <button
+        type="button"
+        id={id}
+        className="gcp-input gcp-time-dd-trigger"
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        aria-label={ariaLabel}
+        onClick={() => onToggle()}
+      >
+        <span className={value ? 'gcp-time-dd-value' : 'gcp-time-dd-placeholder'}>
+          {value || '시간 선택'}
+        </span>
+        <span className="gcp-time-dd-chevron" aria-hidden>▾</span>
+      </button>
+      {isOpen ? (
+        <ul ref={listRef} className="gcp-time-dd-list" role="listbox" aria-labelledby={id}>
+          <li role="presentation">
+            <button
+              type="button"
+              role="option"
+              aria-selected={!value}
+              className={`gcp-time-dd-option${!value ? ' gcp-time-dd-option--selected' : ''}`}
+              onClick={() => {
+                onSelect('')
+                onClose()
+              }}
+            >
+              시간 선택
+            </button>
+          </li>
+          {options.map((t) => (
+            <li key={t} role="presentation">
+              <button
+                type="button"
+                role="option"
+                aria-selected={value === t}
+                className={`gcp-time-dd-option${value === t ? ' gcp-time-dd-option--selected' : ''}`}
+                onClick={() => {
+                  onSelect(t)
+                  onClose()
+                }}
+              >
+                {t}
+              </button>
+            </li>
+          ))}
+          {legacy ? (
+            <li role="presentation">
+              <button
+                type="button"
+                role="option"
+                aria-selected={value === legacy}
+                className={`gcp-time-dd-option${value === legacy ? ' gcp-time-dd-option--selected' : ''}`}
+                onClick={() => {
+                  onSelect(legacy)
+                  onClose()
+                }}
+              >
+                {legacy}
+              </button>
+            </li>
+          ) : null}
+        </ul>
+      ) : null}
+    </div>
+  )
+}
+
 // ── 메인 컴포넌트 ─────────────────────────────────────────────────────
 /**
  * @param {{
@@ -122,6 +222,19 @@ export function GuideCoursePanel({
     [schedule?.startTime, schedule?.endTime],
   )
   const courseTimeOptionSet = useMemo(() => new Set(courseTimeOptions), [courseTimeOptions])
+  const [openTimeIdx, setOpenTimeIdx] = useState(null)
+  const closeCourseTimeDropdown = useCallback(() => setOpenTimeIdx(null), [])
+
+  useEffect(() => {
+    if (openTimeIdx == null) return
+    const onPointerDown = (e) => {
+      const t = e.target
+      if (!(t instanceof Element)) return
+      if (!t.closest('[data-gcp-time-dd]')) setOpenTimeIdx(null)
+    }
+    document.addEventListener('pointerdown', onPointerDown, true)
+    return () => document.removeEventListener('pointerdown', onPointerDown, true)
+  }, [openTimeIdx])
 
   // ── 초기 데이터 로드 (GET form) ──────────────────────────────────────
   useEffect(() => {
@@ -313,6 +426,7 @@ export function GuideCoursePanel({
   }
 
   const addSpot = () => {
+    setOpenTimeIdx(null)
     setSpots((prev) => {
       const next = [...prev, { name: '', time: '', desc: '' }]
       spotsRef.current = next
@@ -323,6 +437,7 @@ export function GuideCoursePanel({
 
   const removeSpot = (idx) => {
     if (spots.length <= 1) return
+    setOpenTimeIdx(null)
     const newSpots = spots.filter((_, i) => i !== idx)
     spotsRef.current = newSpots
     setSpots(newSpots)
@@ -335,6 +450,7 @@ export function GuideCoursePanel({
     const from = dragSpotIdx.current
     if (from === null || from === dropIdx) return
     dragSpotIdx.current = null
+    setOpenTimeIdx(null)
     setSpots((prev) => {
       const next = [...prev]
       const [moved] = next.splice(from, 1)
@@ -544,21 +660,17 @@ export function GuideCoursePanel({
                         )}
                       </div>
                       <div className="gcp-spot-row2">
-                        <select
+                        <CourseTimeDropdown
                           id={`gcp-spot-time-${idx}`}
-                          className="gcp-input gcp-select gcp-select--time"
-                          aria-label={`스팟 ${idx + 1} 시간`}
+                          ariaLabel={`스팟 ${idx + 1} 시간`}
                           value={spot.time}
-                          onChange={(e) => updateSpot(idx, 'time', e.target.value)}
-                        >
-                          <option value="">시간 선택</option>
-                          {courseTimeOptions.map((t) => (
-                            <option key={t} value={t}>{t}</option>
-                          ))}
-                          {spot.time && !courseTimeOptionSet.has(spot.time) ? (
-                            <option value={spot.time}>{spot.time}</option>
-                          ) : null}
-                        </select>
+                          options={courseTimeOptions}
+                          optionSet={courseTimeOptionSet}
+                          isOpen={openTimeIdx === idx}
+                          onToggle={() => setOpenTimeIdx((cur) => (cur === idx ? null : idx))}
+                          onClose={closeCourseTimeDropdown}
+                          onSelect={(v) => updateSpot(idx, 'time', v)}
+                        />
                         <input
                           className="gcp-input"
                           type="text"


### PR DESCRIPTION
## 🔗 이슈 번호

Closes #387

## 💡 주요 변경 사항

- `GuideCoursePanel` 코스 스팟의 시간 필드를 텍스트 입력에서 `<select>`로 변경하고, 스케줄 `startTime`–`endTime` 구간에 맞춰 30분 간격(오전/오후 표기) 옵션을 생성함
- 기존에 저장된 `courseDetail`의 시간 문자열이 목록에 없을 때는 해당 값을 그대로 선택 가능한 옵션으로 노출해 하위 호환을 유지함
- `GuideCoursePanel.css`에 셀렉트 커서·최소 너비 스타일 추가

## ⚠️ 주의 사항 / 질문

- 해당 없음

## ✅ 체크리스트

- [x] 빌드가 정상적으로 되는가? (`cd frontend && npm run build`)
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [x] `.gitignore`에 설정 파일(비밀·로컬 전용)이 잘 제외되었는가? (해당 없음)

Made with [Cursor](https://cursor.com)