### PR TITLE
Feat/fe#391 앞으로의 여행 일정 UI 개선

### DIFF
--- a/frontend/src/pages/GuestUpcomingTripsPage.css
+++ b/frontend/src/pages/GuestUpcomingTripsPage.css
@@ -133,26 +133,106 @@
 .gut-card {
   border: 1px solid rgba(229, 231, 235, 0.95);
   border-radius: 16px;
-  background:
-    radial-gradient(600px 140px at 30% 0%, rgba(255, 225, 238, 0.26), transparent 60%),
-    linear-gradient(180deg, rgba(250, 250, 250, 0.96), rgba(255, 255, 255, 0.99));
-  padding: 0.9rem 0.9rem 0.85rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.7rem;
+  background-color: rgba(255, 255, 255, 0.98);
+  background-image:
+    radial-gradient(circle at 1px 1px, rgba(143, 70, 100, 0.055) 1px, transparent 1px),
+    radial-gradient(620px 150px at 28% 0%, rgba(255, 225, 238, 0.28), transparent 58%),
+    radial-gradient(520px 120px at 92% 18%, rgba(219, 234, 254, 0.22), transparent 55%),
+    linear-gradient(180deg, rgba(250, 250, 250, 0.98), rgba(255, 255, 255, 0.995));
+  background-size: 16px 16px, auto, auto, auto;
+  padding: 0.85rem 0.95rem 0.8rem;
   box-shadow: 0 10px 24px rgba(15, 23, 42, 0.06);
   transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
 }
 
 .gut-card--timeline {
   position: relative;
+  display: grid;
+  grid-template-columns: 2.65rem minmax(0, 1fr);
+  column-gap: 0.65rem;
+  row-gap: 0;
+  align-items: start;
+  overflow: hidden;
+}
+
+.gut-watermark {
+  position: absolute;
+  right: 0.1rem;
+  top: 44%;
+  transform: translateY(-42%) rotate(-8deg);
+  max-width: min(78%, 17rem);
+  font-size: clamp(1.35rem, 4.5vw, 2.15rem);
+  font-weight: 900;
+  letter-spacing: -0.05em;
+  line-height: 0.95;
+  color: rgba(143, 70, 100, 0.085);
+  pointer-events: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: right;
+  z-index: 0;
+}
+
+.gut-card-main {
+  position: relative;
+  z-index: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.gut-card-row--top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.45rem 0.65rem;
+  flex-wrap: wrap;
+}
+
+.gut-card-row--top .gut-meta-head {
+  flex: 1 1 200px;
+  min-width: 0;
+}
+
+.gut-card-row--top .gut-pills {
+  flex: 0 1 auto;
+  justify-content: flex-end;
+}
+
+.gut-title {
+  margin: 0.15rem 0 0;
+  font-size: 1.02rem;
+  color: #111827;
+  letter-spacing: -0.02em;
+  font-weight: 900;
+  line-height: 1.25;
+}
+
+.gut-card-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.65rem;
+  margin-top: 0.35rem;
+  padding-top: 0.55rem;
+  border-top: 1px dashed rgba(229, 231, 235, 0.95);
+}
+
+.gut-trail {
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: -0.01em;
+  color: rgba(143, 70, 100, 0.55);
+  white-space: nowrap;
 }
 
 .gut-card--timeline::before {
   content: '';
   position: absolute;
   left: -0.95rem;
-  top: 1.05rem;
+  top: 1.15rem;
   width: 0.75rem;
   height: 0.75rem;
   border-radius: 999px;
@@ -165,7 +245,7 @@
   content: '';
   position: absolute;
   left: -0.72rem;
-  top: 1.28rem;
+  top: 1.38rem;
   width: 0.28rem;
   height: 0.28rem;
   border-radius: 999px;
@@ -193,16 +273,9 @@
   }
 }
 
-.gut-card-top {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.65rem;
-}
-
 .gut-spot {
-  width: 2.15rem;
-  height: 2.15rem;
+  width: 2.55rem;
+  height: 2.55rem;
   border-radius: 16px;
   display: inline-flex;
   align-items: center;
@@ -210,7 +283,7 @@
   background: linear-gradient(180deg, rgba(255, 225, 238, 0.82), rgba(255, 255, 255, 0.96));
   border: 1px solid rgba(232, 184, 203, 0.85);
   color: #8f4664;
-  font-size: 1.02rem;
+  font-size: 1.12rem;
   flex: 0 0 auto;
   box-shadow: 0 10px 20px rgba(143, 70, 100, 0.1);
 }
@@ -220,7 +293,6 @@
   flex-wrap: wrap;
   justify-content: flex-end;
   gap: 0.35rem;
-  flex: 1;
   min-width: 0;
 }
 
@@ -249,13 +321,6 @@
   color: #6b4a5a;
 }
 
-.gut-meta h3 {
-  margin: 0.35rem 0 0.35rem;
-  font-size: 0.98rem;
-  color: #111827;
-  letter-spacing: -0.01em;
-}
-
 .gut-meta-head {
   display: flex;
   align-items: center;
@@ -267,13 +332,6 @@
   font-size: 0.8rem;
   font-weight: 800;
   color: rgba(31, 35, 40, 0.6);
-}
-
-.gut-meta p {
-  margin: 0.2rem 0 0;
-  font-size: 0.82rem;
-  color: #4b5563;
-  line-height: 1.45;
 }
 
 .gut-line {
@@ -321,7 +379,7 @@
   cursor: pointer;
   font-family: inherit;
   transition: background 0.18s ease, border-color 0.18s ease, transform 0.18s ease;
-  align-self: flex-end;
+  flex: 0 0 auto;
 }
 
 .gut-open:hover {

--- a/frontend/src/pages/GuestUpcomingTripsPage.css
+++ b/frontend/src/pages/GuestUpcomingTripsPage.css
@@ -2,35 +2,75 @@
   width: 100%;
   max-width: min(1080px, 100%);
   margin: 0 auto;
+  padding: 0.25rem 0;
 }
 
 .gut-hero {
   text-align: center;
-  background: #fffdfd;
-  border: 1px solid #f0dce4;
-  border-radius: 16px;
-  padding: clamp(1rem, 3vw, 1.35rem) clamp(0.9rem, 3vw, 1.25rem);
+  position: relative;
+  overflow: hidden;
+  background: radial-gradient(1200px 240px at 50% 0%, rgba(246, 216, 230, 0.95), rgba(255, 253, 253, 0.95) 55%, rgba(255, 255, 255, 0.98) 100%);
+  border: 1px solid rgba(240, 220, 228, 0.95);
+  border-radius: 18px;
+  padding: clamp(1.15rem, 3.4vw, 1.6rem) clamp(0.95rem, 3.2vw, 1.5rem);
   margin-bottom: 1rem;
+  box-shadow: 0 18px 40px rgba(143, 70, 100, 0.08);
+}
+
+.gut-hero::before {
+  content: '';
+  position: absolute;
+  inset: -120px -40px auto -40px;
+  height: 220px;
+  background:
+    radial-gradient(closest-side, rgba(255, 225, 238, 0.75), transparent 70%),
+    radial-gradient(closest-side, rgba(219, 234, 254, 0.65), transparent 70%),
+    radial-gradient(closest-side, rgba(254, 243, 199, 0.6), transparent 70%);
+  filter: blur(2px);
+  opacity: 0.9;
+  pointer-events: none;
+}
+
+.gut-hero-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.65rem;
+  border-radius: 999px;
+  border: 1px solid rgba(232, 184, 203, 0.85);
+  background: linear-gradient(180deg, rgba(255, 246, 251, 0.92), rgba(255, 255, 255, 0.9));
+  color: #6b4a5a;
+  font-weight: 900;
+  font-size: 0.78rem;
+  letter-spacing: -0.01em;
+  position: relative;
+  z-index: 1;
+  box-shadow: 0 10px 22px rgba(143, 70, 100, 0.08);
+  margin-bottom: 0.6rem;
 }
 
 .gut-hero h1 {
   margin: 0 0 0.3rem;
-  font-size: clamp(1.2rem, 4vw, 1.6rem);
-  color: #4a3c56;
+  font-size: clamp(1.25rem, 4.2vw, 1.72rem);
+  color: #1f2328;
   font-family: var(--heading);
-  font-weight: 800;
+  font-weight: 900;
   letter-spacing: -0.02em;
   line-height: 1.3;
+  position: relative;
+  z-index: 1;
 }
 
 .gut-hero p {
   margin: 0;
-  color: #7a6a80;
+  color: rgba(31, 35, 40, 0.72);
   font-family: var(--sans);
   font-size: 0.92rem;
   line-height: 1.55;
   max-width: 42rem;
   margin-inline: auto;
+  position: relative;
+  z-index: 1;
 }
 
 .gut-sections {
@@ -40,10 +80,11 @@
 }
 
 .gut-section {
-  border: 1px solid #e5e7eb;
-  border-radius: 14px;
-  background: #fff;
-  padding: 0.85rem;
+  border: 1px solid rgba(229, 231, 235, 0.95);
+  border-radius: 16px;
+  background: linear-gradient(180deg, rgba(255, 253, 253, 0.98), rgba(255, 255, 255, 0.98));
+  padding: 0.9rem;
+  box-shadow: 0 14px 28px rgba(15, 23, 42, 0.05);
 }
 
 .gut-section-head {
@@ -56,40 +97,104 @@
 .gut-section-head h2 {
   margin: 0;
   font-size: 1.02rem;
-  color: #5a3c56;
-  font-weight: 800;
+  color: #1f2328;
+  font-weight: 900;
   letter-spacing: -0.01em;
 }
 
 .gut-section-head span {
   font-size: 0.76rem;
-  color: #374151;
-  background: #f3f4f6;
-  border: 1px solid #e5e7eb;
+  color: #6b4a5a;
+  background: rgba(246, 216, 230, 0.45);
+  border: 1px solid rgba(239, 191, 208, 0.8);
   border-radius: 999px;
   padding: 0.18rem 0.55rem;
 }
 
 .gut-cards {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-  gap: 0.65rem;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 0.85rem;
 }
 
 .gut-card {
-  border: 1px solid #e5e7eb;
-  border-radius: 12px;
-  background: #fafafa;
-  padding: 0.75rem;
+  border: 1px solid rgba(229, 231, 235, 0.95);
+  border-radius: 16px;
+  background: linear-gradient(180deg, rgba(250, 250, 250, 0.95), rgba(255, 255, 255, 0.98));
+  padding: 0.9rem 0.9rem 0.85rem;
   display: flex;
   flex-direction: column;
+  gap: 0.7rem;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.06);
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+
+.gut-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.08);
+  border-color: rgba(232, 184, 203, 0.85);
+}
+
+.gut-card-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   gap: 0.65rem;
+}
+
+.gut-spot {
+  width: 2.15rem;
+  height: 2.15rem;
+  border-radius: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 225, 238, 0.7);
+  border: 1px solid rgba(232, 184, 203, 0.7);
+  color: #8f4664;
+  font-size: 1.02rem;
+  flex: 0 0 auto;
+}
+
+.gut-pills {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.35rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.gut-pill {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0.2rem 0.55rem;
+  font-size: 0.74rem;
+  font-weight: 800;
+  border: 1px solid rgba(229, 231, 235, 0.95);
+  background: rgba(249, 250, 251, 0.85);
+  color: rgba(31, 35, 40, 0.78);
+  max-width: 100%;
+}
+
+.gut-pill--dest {
+  border-color: rgba(191, 219, 254, 0.9);
+  background: rgba(219, 234, 254, 0.65);
+  color: #1e3a8a;
+}
+
+.gut-pill--status {
+  border-color: rgba(239, 191, 208, 0.9);
+  background: rgba(246, 216, 230, 0.55);
+  color: #6b4a5a;
 }
 
 .gut-meta h3 {
   margin: 0.35rem 0 0.35rem;
-  font-size: 0.95rem;
+  font-size: 0.98rem;
   color: #111827;
+  letter-spacing: -0.01em;
 }
 
 .gut-meta p {
@@ -99,29 +204,42 @@
   line-height: 1.45;
 }
 
+.gut-line {
+  margin: 0.15rem 0 0;
+  font-size: 0.84rem;
+  color: rgba(31, 35, 40, 0.72);
+}
+
+.gut-line--sub {
+  color: rgba(31, 35, 40, 0.6);
+}
+
 .gut-dday {
   display: inline-flex;
   align-items: center;
   border-radius: 999px;
   font-size: 0.74rem;
-  font-weight: 800;
-  padding: 0.2rem 0.55rem;
-  color: #1d4ed8;
-  background: #dbeafe;
+  font-weight: 900;
+  padding: 0.22rem 0.6rem;
+  color: #1e3a8a;
+  background: rgba(219, 234, 254, 0.85);
+  border: 1px solid rgba(191, 219, 254, 0.95);
 }
 
 .gut-dday.is-today {
-  color: #b91c1c;
-  background: #fee2e2;
+  color: #9f274c;
+  background: rgba(255, 216, 225, 0.95);
+  border-color: rgba(247, 180, 193, 0.95);
 }
 
 .gut-dday.is-soon {
   color: #92400e;
-  background: #fef3c7;
+  background: rgba(254, 243, 199, 0.92);
+  border-color: rgba(253, 230, 138, 0.95);
 }
 
 .gut-open {
-  border: 1px solid #efbfd0;
+  border: 1px solid rgba(239, 191, 208, 0.95);
   border-radius: 999px;
   background: linear-gradient(135deg, #f6d8e6 0%, #edbfd3 100%);
   color: #6d3f58;

--- a/frontend/src/pages/GuestUpcomingTripsPage.css
+++ b/frontend/src/pages/GuestUpcomingTripsPage.css
@@ -147,31 +147,8 @@
 
 .gut-card--timeline {
   position: relative;
-  display: grid;
-  grid-template-columns: 3.45rem minmax(0, 1fr);
-  column-gap: 0.65rem;
-  row-gap: 0;
-  align-items: stretch;
+  display: block;
   overflow: hidden;
-}
-
-.gut-watermark {
-  position: absolute;
-  right: 0.1rem;
-  top: 44%;
-  transform: translateY(-42%) rotate(-8deg);
-  max-width: min(78%, 17rem);
-  font-size: clamp(1.35rem, 4.5vw, 2.15rem);
-  font-weight: 900;
-  letter-spacing: -0.05em;
-  line-height: 0.95;
-  color: rgba(143, 70, 100, 0.085);
-  pointer-events: none;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  text-align: right;
-  z-index: 0;
 }
 
 .gut-card-main {
@@ -183,22 +160,13 @@
   gap: 0.35rem;
 }
 
-.gut-card-row--top {
+/* D-Day · 날짜 · pill 을 한 줄 흐름으로 묶어 가운데 공백 제거 */
+.gut-card-kick {
   display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 0.45rem 0.65rem;
   flex-wrap: wrap;
-}
-
-.gut-card-row--top .gut-meta-head {
-  flex: 1 1 200px;
-  min-width: 0;
-}
-
-.gut-card-row--top .gut-pills {
-  flex: 0 1 auto;
-  justify-content: flex-end;
+  align-items: center;
+  gap: 0.35rem 0.45rem;
+  row-gap: 0.4rem;
 }
 
 .gut-title {
@@ -218,6 +186,7 @@
   margin-top: 0.35rem;
   padding-top: 0.55rem;
   border-top: 1px dashed rgba(229, 231, 235, 0.95);
+  flex-wrap: wrap;
 }
 
 .gut-trail {
@@ -232,7 +201,7 @@
   content: '';
   position: absolute;
   left: -0.95rem;
-  top: 1.35rem;
+  top: 1.05rem;
   width: 0.75rem;
   height: 0.75rem;
   border-radius: 999px;
@@ -245,7 +214,7 @@
   content: '';
   position: absolute;
   left: -0.72rem;
-  top: 1.58rem;
+  top: 1.28rem;
   width: 0.28rem;
   height: 0.28rem;
   border-radius: 999px;
@@ -259,18 +228,6 @@
 }
 
 @media (max-width: 420px) {
-  .gut-card--timeline {
-    grid-template-columns: 3.05rem minmax(0, 1fr);
-  }
-
-  .gut-spot {
-    min-height: 3.25rem;
-  }
-
-  .gut-spot-emoji {
-    font-size: clamp(1.55rem, 6vw, 1.95rem);
-  }
-
   .gut-cards {
     padding-left: 0.9rem;
   }
@@ -283,47 +240,6 @@
   .gut-card--timeline::after {
     left: -0.67rem;
   }
-}
-
-.gut-spot {
-  box-sizing: border-box;
-  width: 100%;
-  min-height: 3.65rem;
-  height: 100%;
-  border-radius: 18px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  /* 박스는 은은하게: 심볼(이모지)이 메인으로 보이도록 */
-  background:
-    repeating-linear-gradient(
-      180deg,
-      rgba(255, 255, 255, 0.92) 0 4px,
-      rgba(241, 245, 249, 0.75) 4px 11px
-    ),
-    linear-gradient(165deg, rgba(255, 255, 255, 0.98), rgba(248, 250, 252, 0.96));
-  border: 1px solid rgba(226, 232, 240, 0.95);
-  color: #1f2328;
-  line-height: 1;
-  flex: 0 0 auto;
-  box-shadow: 0 6px 14px rgba(15, 23, 42, 0.06);
-}
-
-.gut-spot-emoji {
-  display: block;
-  line-height: 1;
-  font-size: clamp(1.85rem, 3.4vw, 2.2rem);
-  text-shadow:
-    0 1px 0 rgba(255, 255, 255, 1),
-    0 0 1px rgba(31, 35, 40, 0.12);
-}
-
-.gut-pills {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-  gap: 0.35rem;
-  min-width: 0;
 }
 
 .gut-pill {
@@ -351,17 +267,11 @@
   color: #6b4a5a;
 }
 
-.gut-meta-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.6rem;
-}
-
 .gut-date {
   font-size: 0.8rem;
   font-weight: 800;
   color: rgba(31, 35, 40, 0.6);
+  padding: 0.12rem 0;
 }
 
 .gut-line {
@@ -409,7 +319,25 @@
   cursor: pointer;
   font-family: inherit;
   transition: background 0.18s ease, border-color 0.18s ease, transform 0.18s ease;
-  flex: 0 0 auto;
+  flex: 0 1 auto;
+  margin-left: auto;
+}
+
+@media (max-width: 520px) {
+  .gut-card-footer {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .gut-trail {
+    text-align: center;
+  }
+
+  .gut-open {
+    margin-left: 0;
+    width: 100%;
+    text-align: center;
+  }
 }
 
 .gut-open:hover {

--- a/frontend/src/pages/GuestUpcomingTripsPage.css
+++ b/frontend/src/pages/GuestUpcomingTripsPage.css
@@ -175,7 +175,11 @@
   color: #111827;
   letter-spacing: -0.02em;
   font-weight: 900;
-  line-height: 1.25;
+  line-height: 1.3;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
 }
 
 .gut-card-footer {

--- a/frontend/src/pages/GuestUpcomingTripsPage.css
+++ b/frontend/src/pages/GuestUpcomingTripsPage.css
@@ -148,10 +148,10 @@
 .gut-card--timeline {
   position: relative;
   display: grid;
-  grid-template-columns: 2.65rem minmax(0, 1fr);
+  grid-template-columns: 3.45rem minmax(0, 1fr);
   column-gap: 0.65rem;
   row-gap: 0;
-  align-items: start;
+  align-items: stretch;
   overflow: hidden;
 }
 
@@ -232,7 +232,7 @@
   content: '';
   position: absolute;
   left: -0.95rem;
-  top: 1.15rem;
+  top: 1.35rem;
   width: 0.75rem;
   height: 0.75rem;
   border-radius: 999px;
@@ -245,7 +245,7 @@
   content: '';
   position: absolute;
   left: -0.72rem;
-  top: 1.38rem;
+  top: 1.58rem;
   width: 0.28rem;
   height: 0.28rem;
   border-radius: 999px;
@@ -259,6 +259,15 @@
 }
 
 @media (max-width: 420px) {
+  .gut-card--timeline {
+    grid-template-columns: 3.05rem minmax(0, 1fr);
+  }
+
+  .gut-spot {
+    min-height: 3.25rem;
+    font-size: 1.35rem;
+  }
+
   .gut-cards {
     padding-left: 0.9rem;
   }
@@ -274,16 +283,25 @@
 }
 
 .gut-spot {
-  width: 2.55rem;
-  height: 2.55rem;
-  border-radius: 16px;
-  display: inline-flex;
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 3.65rem;
+  height: 100%;
+  border-radius: 18px;
+  display: flex;
   align-items: center;
   justify-content: center;
-  background: linear-gradient(180deg, rgba(255, 225, 238, 0.82), rgba(255, 255, 255, 0.96));
-  border: 1px solid rgba(232, 184, 203, 0.85);
+  background:
+    repeating-linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.55) 0 3px,
+      rgba(255, 225, 238, 0.18) 3px 10px
+    ),
+    linear-gradient(160deg, rgba(255, 225, 238, 0.92), rgba(255, 255, 255, 0.98));
+  border: 1px solid rgba(232, 184, 203, 0.9);
   color: #8f4664;
-  font-size: 1.12rem;
+  font-size: 1.55rem;
+  line-height: 1;
   flex: 0 0 auto;
   box-shadow: 0 10px 20px rgba(143, 70, 100, 0.1);
 }

--- a/frontend/src/pages/GuestUpcomingTripsPage.css
+++ b/frontend/src/pages/GuestUpcomingTripsPage.css
@@ -112,9 +112,22 @@
 }
 
 .gut-cards {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  position: relative;
+  display: flex;
+  flex-direction: column;
   gap: 0.85rem;
+  padding-left: 1.05rem;
+}
+
+.gut-cards::before {
+  content: '';
+  position: absolute;
+  left: 0.45rem;
+  top: 0.35rem;
+  bottom: 0.35rem;
+  width: 2px;
+  background: linear-gradient(180deg, rgba(239, 191, 208, 0.25), rgba(239, 191, 208, 0.9), rgba(191, 219, 254, 0.6));
+  border-radius: 999px;
 }
 
 .gut-card {
@@ -129,10 +142,53 @@
   transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
 }
 
+.gut-card--timeline {
+  position: relative;
+}
+
+.gut-card--timeline::before {
+  content: '';
+  position: absolute;
+  left: -1.05rem;
+  top: 1.05rem;
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 999px;
+  background: linear-gradient(180deg, rgba(255, 246, 251, 0.98), rgba(255, 255, 255, 0.98));
+  border: 2px solid rgba(239, 191, 208, 0.95);
+  box-shadow: 0 10px 20px rgba(143, 70, 100, 0.12);
+}
+
+.gut-card--timeline::after {
+  content: '';
+  position: absolute;
+  left: -0.82rem;
+  top: 1.28rem;
+  width: 0.28rem;
+  height: 0.28rem;
+  border-radius: 999px;
+  background: rgba(143, 70, 100, 0.85);
+}
+
 .gut-card:hover {
   transform: translateY(-2px);
   box-shadow: 0 14px 30px rgba(15, 23, 42, 0.08);
   border-color: rgba(232, 184, 203, 0.85);
+}
+
+@media (max-width: 420px) {
+  .gut-cards {
+    padding-left: 0.9rem;
+  }
+  .gut-cards::before {
+    left: 0.38rem;
+  }
+  .gut-card--timeline::before {
+    left: -0.9rem;
+  }
+  .gut-card--timeline::after {
+    left: -0.67rem;
+  }
 }
 
 .gut-card-top {

--- a/frontend/src/pages/GuestUpcomingTripsPage.css
+++ b/frontend/src/pages/GuestUpcomingTripsPage.css
@@ -265,7 +265,10 @@
 
   .gut-spot {
     min-height: 3.25rem;
-    font-size: 1.35rem;
+  }
+
+  .gut-spot-emoji {
+    font-size: clamp(1.55rem, 6vw, 1.95rem);
   }
 
   .gut-cards {
@@ -291,19 +294,28 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  /* 박스는 은은하게: 심볼(이모지)이 메인으로 보이도록 */
   background:
     repeating-linear-gradient(
       180deg,
-      rgba(255, 255, 255, 0.55) 0 3px,
-      rgba(255, 225, 238, 0.18) 3px 10px
+      rgba(255, 255, 255, 0.92) 0 4px,
+      rgba(241, 245, 249, 0.75) 4px 11px
     ),
-    linear-gradient(160deg, rgba(255, 225, 238, 0.92), rgba(255, 255, 255, 0.98));
-  border: 1px solid rgba(232, 184, 203, 0.9);
-  color: #8f4664;
-  font-size: 1.55rem;
+    linear-gradient(165deg, rgba(255, 255, 255, 0.98), rgba(248, 250, 252, 0.96));
+  border: 1px solid rgba(226, 232, 240, 0.95);
+  color: #1f2328;
   line-height: 1;
   flex: 0 0 auto;
-  box-shadow: 0 10px 20px rgba(143, 70, 100, 0.1);
+  box-shadow: 0 6px 14px rgba(15, 23, 42, 0.06);
+}
+
+.gut-spot-emoji {
+  display: block;
+  line-height: 1;
+  font-size: clamp(1.85rem, 3.4vw, 2.2rem);
+  text-shadow:
+    0 1px 0 rgba(255, 255, 255, 1),
+    0 0 1px rgba(31, 35, 40, 0.12);
 }
 
 .gut-pills {

--- a/frontend/src/pages/GuestUpcomingTripsPage.css
+++ b/frontend/src/pages/GuestUpcomingTripsPage.css
@@ -116,13 +116,13 @@
   display: flex;
   flex-direction: column;
   gap: 0.85rem;
-  padding-left: 1.05rem;
+  padding-left: 0.95rem;
 }
 
 .gut-cards::before {
   content: '';
   position: absolute;
-  left: 0.45rem;
+  left: 0.4rem;
   top: 0.35rem;
   bottom: 0.35rem;
   width: 2px;
@@ -133,7 +133,9 @@
 .gut-card {
   border: 1px solid rgba(229, 231, 235, 0.95);
   border-radius: 16px;
-  background: linear-gradient(180deg, rgba(250, 250, 250, 0.95), rgba(255, 255, 255, 0.98));
+  background:
+    radial-gradient(600px 140px at 30% 0%, rgba(255, 225, 238, 0.26), transparent 60%),
+    linear-gradient(180deg, rgba(250, 250, 250, 0.96), rgba(255, 255, 255, 0.99));
   padding: 0.9rem 0.9rem 0.85rem;
   display: flex;
   flex-direction: column;
@@ -149,20 +151,20 @@
 .gut-card--timeline::before {
   content: '';
   position: absolute;
-  left: -1.05rem;
+  left: -0.95rem;
   top: 1.05rem;
   width: 0.75rem;
   height: 0.75rem;
   border-radius: 999px;
   background: linear-gradient(180deg, rgba(255, 246, 251, 0.98), rgba(255, 255, 255, 0.98));
   border: 2px solid rgba(239, 191, 208, 0.95);
-  box-shadow: 0 10px 20px rgba(143, 70, 100, 0.12);
+  box-shadow: 0 12px 22px rgba(143, 70, 100, 0.14);
 }
 
 .gut-card--timeline::after {
   content: '';
   position: absolute;
-  left: -0.82rem;
+  left: -0.72rem;
   top: 1.28rem;
   width: 0.28rem;
   height: 0.28rem;
@@ -201,15 +203,16 @@
 .gut-spot {
   width: 2.15rem;
   height: 2.15rem;
-  border-radius: 14px;
+  border-radius: 16px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: rgba(255, 225, 238, 0.7);
-  border: 1px solid rgba(232, 184, 203, 0.7);
+  background: linear-gradient(180deg, rgba(255, 225, 238, 0.82), rgba(255, 255, 255, 0.96));
+  border: 1px solid rgba(232, 184, 203, 0.85);
   color: #8f4664;
   font-size: 1.02rem;
   flex: 0 0 auto;
+  box-shadow: 0 10px 20px rgba(143, 70, 100, 0.1);
 }
 
 .gut-pills {
@@ -251,6 +254,19 @@
   font-size: 0.98rem;
   color: #111827;
   letter-spacing: -0.01em;
+}
+
+.gut-meta-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.gut-date {
+  font-size: 0.8rem;
+  font-weight: 800;
+  color: rgba(31, 35, 40, 0.6);
 }
 
 .gut-meta p {
@@ -300,11 +316,12 @@
   background: linear-gradient(135deg, #f6d8e6 0%, #edbfd3 100%);
   color: #6d3f58;
   font-size: 0.78rem;
-  font-weight: 700;
-  padding: 0.4rem 0.7rem;
+  font-weight: 800;
+  padding: 0.45rem 0.85rem;
   cursor: pointer;
   font-family: inherit;
   transition: background 0.18s ease, border-color 0.18s ease, transform 0.18s ease;
+  align-self: flex-end;
 }
 
 .gut-open:hover {

--- a/frontend/src/pages/GuestUpcomingTripsPage.jsx
+++ b/frontend/src/pages/GuestUpcomingTripsPage.jsx
@@ -192,26 +192,30 @@ export function GuestUpcomingTripsPage() {
                   const budget = formatBudgetRangeKrw(row.budgetMinWon, row.budgetMaxWon, row.desiredBudget)
                   return (
                     <article key={row.requestId} className="gut-card gut-card--timeline">
-                      <div className="gut-card-top">
-                        <span className="gut-spot" aria-hidden="true">{moodEmoji(row.status, d)}</span>
-                        <div className="gut-pills">
-                          <span className="gut-pill gut-pill--dest">{dest}</span>
-                          <span className="gut-pill gut-pill--status">{statusText(row.status)}</span>
+                      <span className="gut-spot" aria-hidden="true">{moodEmoji(row.status, d)}</span>
+                      <div className="gut-card-main">
+                        <span className="gut-watermark" aria-hidden="true">{dest}</span>
+                        <div className="gut-card-row gut-card-row--top">
+                          <div className="gut-meta-head">
+                            <span className={`gut-dday${d === 0 ? ' is-today' : d === 1 ? ' is-soon' : ''}`}>
+                              {row.status === 'ACCEPTED' ? '결제 필요' : ddayLabel(d, row.status)}
+                            </span>
+                            <span className="gut-date">{row.desiredDate ?? '—'}</span>
+                          </div>
+                          <div className="gut-pills">
+                            <span className="gut-pill gut-pill--dest">{dest}</span>
+                            <span className="gut-pill gut-pill--status">{statusText(row.status)}</span>
+                          </div>
                         </div>
-                      </div>
-                      <div className="gut-meta">
-                        <div className="gut-meta-head">
-                          <span className={`gut-dday${d === 0 ? ' is-today' : d === 1 ? ' is-soon' : ''}`}>
-                            {row.status === 'ACCEPTED' ? '결제 필요' : ddayLabel(d, row.status)}
-                          </span>
-                          <span className="gut-date">{row.desiredDate ?? '—'}</span>
-                        </div>
-                        <h3>{nick}</h3>
+                        <h3 className="gut-title">{nick}</h3>
                         <p className="gut-line gut-line--sub">예산 {budget}</p>
+                        <div className="gut-card-footer">
+                          <span className="gut-trail" aria-hidden="true">✈︎ 여행 준비 중</span>
+                          <button type="button" className="gut-open" onClick={() => openMatchScreen(row)}>
+                            일정 확인하기
+                          </button>
+                        </div>
                       </div>
-                      <button type="button" className="gut-open" onClick={() => openMatchScreen(row)}>
-                        일정 확인하기
-                      </button>
                     </article>
                   )
                 })}

--- a/frontend/src/pages/GuestUpcomingTripsPage.jsx
+++ b/frontend/src/pages/GuestUpcomingTripsPage.jsx
@@ -51,6 +51,68 @@ function statusText(status) {
   return '상태 확인 필요'
 }
 
+/** 한글 음절 받침 — 조사 와/과 */
+function hasBatchimKo(char) {
+  if (!char) return false
+  const c = char.charCodeAt(0)
+  if (c < 0xac00 || c > 0xd7a3) return false
+  return (c - 0xac00) % 28 !== 0
+}
+
+function nicknameWithWaParticle(nick) {
+  const n = String(nick ?? '').trim()
+  if (!n) return '가이드와'
+  const last = n[n.length - 1]
+  return `${n}${hasBatchimKo(last) ? '과' : '와'}`
+}
+
+function shortDestinationLabel(dest) {
+  const s = String(dest ?? '').trim()
+  if (!s) return '로컬'
+  if (/제주/i.test(s)) return '제주도'
+  if (/강릉|속초|동해/i.test(s)) return '동해안'
+  if (/부산/i.test(s)) return '부산'
+  if (/서울/i.test(s)) return '서울'
+  if (/경주/i.test(s)) return '경주'
+  const first = s.split(/[\s,，/|]+/).filter(Boolean)[0] ?? s
+  let cleaned = first.replace(/특별시|광역시|특별자치도/g, '').trim()
+  if (cleaned.endsWith('시') && cleaned.length > 2) cleaned = cleaned.slice(0, -1)
+  const w = cleaned || first
+  return w.length > 10 ? `${w.slice(0, 10)}…` : w
+}
+
+const ACTIVITY_HINTS = [
+  [/맛집|미식|먹거리|식도락|음식|식사/i, '맛집'],
+  [/카페|커피|브런치/i, '카페'],
+  [/야경|야경명소/i, '야경'],
+  [/역사|유적|문화재|박물관/i, '역사'],
+  [/한옥|전통\s*마을/i, '한옥마을'],
+  [/숲|산책|둘레길|트레킹/i, '숲길'],
+  [/해변|바다|해안/i, '바다'],
+  [/쇼핑|마켓|시장/i, '쇼핑'],
+  [/포토|사진|스냅/i, '포토'],
+  [/골목|골목길/i, '골목'],
+  [/힐링|여유|느긋/i, '힐링'],
+]
+
+function activityKeywordFromRow(row) {
+  const pool = [row.conceptSummary, row.concept, row.proposeMessage, row.destination]
+    .map((x) => String(x ?? ''))
+    .join('\n')
+  for (const [re, label] of ACTIVITY_HINTS) {
+    if (re.test(pool)) return label
+  }
+  return '로컬'
+}
+
+/** @param {Record<string, unknown>} row */
+function buildTripCardTitle(row, guideNickname) {
+  const nick = String(guideNickname ?? '').trim() || '가이드'
+  const dest = shortDestinationLabel(row.destination)
+  const act = activityKeywordFromRow(row)
+  return `${nicknameWithWaParticle(nick)} 함께하는 ${dest} ${act} 투어`
+}
+
 function groupRows(rows) {
   const paymentPending = []
   const inProgress = []
@@ -182,6 +244,7 @@ export function GuestUpcomingTripsPage() {
                   const nick = names[row.guideId] ?? `가이드 #${row.guideId}`
                   const dest = row.destination ?? '로컬 투어'
                   const budget = formatBudgetRangeKrw(row.budgetMinWon, row.budgetMaxWon, row.desiredBudget)
+                  const tripTitle = buildTripCardTitle(row, nick)
                   return (
                     <article key={row.requestId} className="gut-card gut-card--timeline">
                       <div className="gut-card-main">
@@ -193,7 +256,7 @@ export function GuestUpcomingTripsPage() {
                           <span className="gut-pill gut-pill--dest">{dest}</span>
                           <span className="gut-pill gut-pill--status">{statusText(row.status)}</span>
                         </div>
-                        <h3 className="gut-title">{nick}</h3>
+                        <h3 className="gut-title" title={tripTitle}>{tripTitle}</h3>
                         <p className="gut-line gut-line--sub">예산 {budget}</p>
                         <div className="gut-card-footer">
                           <span className="gut-trail" aria-hidden="true">✈︎ 여행 준비 중</span>

--- a/frontend/src/pages/GuestUpcomingTripsPage.jsx
+++ b/frontend/src/pages/GuestUpcomingTripsPage.jsx
@@ -200,11 +200,13 @@ export function GuestUpcomingTripsPage() {
                         </div>
                       </div>
                       <div className="gut-meta">
-                        <span className={`gut-dday${d === 0 ? ' is-today' : d === 1 ? ' is-soon' : ''}`}>
-                          {row.status === 'ACCEPTED' ? '결제 필요' : ddayLabel(d, row.status)}
-                        </span>
+                        <div className="gut-meta-head">
+                          <span className={`gut-dday${d === 0 ? ' is-today' : d === 1 ? ' is-soon' : ''}`}>
+                            {row.status === 'ACCEPTED' ? '결제 필요' : ddayLabel(d, row.status)}
+                          </span>
+                          <span className="gut-date">{row.desiredDate ?? '—'}</span>
+                        </div>
                         <h3>{nick}</h3>
-                        <p className="gut-line">{row.desiredDate ?? '—'}</p>
                         <p className="gut-line gut-line--sub">예산 {budget}</p>
                       </div>
                       <button type="button" className="gut-open" onClick={() => openMatchScreen(row)}>

--- a/frontend/src/pages/GuestUpcomingTripsPage.jsx
+++ b/frontend/src/pages/GuestUpcomingTripsPage.jsx
@@ -15,14 +15,6 @@ import './GuestUpcomingTripsPage.css'
 
 const UPCOMING = new Set(['PENDING', 'ACCEPTED', 'PAID', 'IN_PROGRESS'])
 
-function moodEmoji(status, d) {
-  if (status === 'IN_PROGRESS') return '🧳'
-  if (status === 'ACCEPTED') return '🧾'
-  if (d === 0) return '🚀'
-  if (d === 1) return '⏳'
-  return '✨'
-}
-
 function formatBudgetRangeKrw(minWon, maxWon, fallbackSingleWon) {
   const min = minWon != null && minWon !== '' && !Number.isNaN(Number(minWon)) ? Number(minWon) : null
   const max = maxWon != null && maxWon !== '' && !Number.isNaN(Number(maxWon)) ? Number(maxWon) : null
@@ -192,22 +184,14 @@ export function GuestUpcomingTripsPage() {
                   const budget = formatBudgetRangeKrw(row.budgetMinWon, row.budgetMaxWon, row.desiredBudget)
                   return (
                     <article key={row.requestId} className="gut-card gut-card--timeline">
-                      <span className="gut-spot" aria-hidden="true">
-                        <span className="gut-spot-emoji">{moodEmoji(row.status, d)}</span>
-                      </span>
                       <div className="gut-card-main">
-                        <span className="gut-watermark" aria-hidden="true">{dest}</span>
-                        <div className="gut-card-row gut-card-row--top">
-                          <div className="gut-meta-head">
-                            <span className={`gut-dday${d === 0 ? ' is-today' : d === 1 ? ' is-soon' : ''}`}>
-                              {row.status === 'ACCEPTED' ? '결제 필요' : ddayLabel(d, row.status)}
-                            </span>
-                            <span className="gut-date">{row.desiredDate ?? '—'}</span>
-                          </div>
-                          <div className="gut-pills">
-                            <span className="gut-pill gut-pill--dest">{dest}</span>
-                            <span className="gut-pill gut-pill--status">{statusText(row.status)}</span>
-                          </div>
+                        <div className="gut-card-kick">
+                          <span className={`gut-dday${d === 0 ? ' is-today' : d === 1 ? ' is-soon' : ''}`}>
+                            {row.status === 'ACCEPTED' ? '결제 필요' : ddayLabel(d, row.status)}
+                          </span>
+                          <span className="gut-date">{row.desiredDate ?? '—'}</span>
+                          <span className="gut-pill gut-pill--dest">{dest}</span>
+                          <span className="gut-pill gut-pill--status">{statusText(row.status)}</span>
                         </div>
                         <h3 className="gut-title">{nick}</h3>
                         <p className="gut-line gut-line--sub">예산 {budget}</p>

--- a/frontend/src/pages/GuestUpcomingTripsPage.jsx
+++ b/frontend/src/pages/GuestUpcomingTripsPage.jsx
@@ -191,7 +191,7 @@ export function GuestUpcomingTripsPage() {
                   const dest = row.destination ?? '로컬 투어'
                   const budget = formatBudgetRangeKrw(row.budgetMinWon, row.budgetMaxWon, row.desiredBudget)
                   return (
-                    <article key={row.requestId} className="gut-card">
+                    <article key={row.requestId} className="gut-card gut-card--timeline">
                       <div className="gut-card-top">
                         <span className="gut-spot" aria-hidden="true">{moodEmoji(row.status, d)}</span>
                         <div className="gut-pills">

--- a/frontend/src/pages/GuestUpcomingTripsPage.jsx
+++ b/frontend/src/pages/GuestUpcomingTripsPage.jsx
@@ -192,7 +192,9 @@ export function GuestUpcomingTripsPage() {
                   const budget = formatBudgetRangeKrw(row.budgetMinWon, row.budgetMaxWon, row.desiredBudget)
                   return (
                     <article key={row.requestId} className="gut-card gut-card--timeline">
-                      <span className="gut-spot" aria-hidden="true">{moodEmoji(row.status, d)}</span>
+                      <span className="gut-spot" aria-hidden="true">
+                        <span className="gut-spot-emoji">{moodEmoji(row.status, d)}</span>
+                      </span>
                       <div className="gut-card-main">
                         <span className="gut-watermark" aria-hidden="true">{dest}</span>
                         <div className="gut-card-row gut-card-row--top">

--- a/frontend/src/pages/GuestUpcomingTripsPage.jsx
+++ b/frontend/src/pages/GuestUpcomingTripsPage.jsx
@@ -15,6 +15,14 @@ import './GuestUpcomingTripsPage.css'
 
 const UPCOMING = new Set(['PENDING', 'ACCEPTED', 'PAID', 'IN_PROGRESS'])
 
+function moodEmoji(status, d) {
+  if (status === 'IN_PROGRESS') return '🧳'
+  if (status === 'ACCEPTED') return '🧾'
+  if (d === 0) return '🚀'
+  if (d === 1) return '⏳'
+  return '✨'
+}
+
 function formatBudgetRangeKrw(minWon, maxWon, fallbackSingleWon) {
   const min = minWon != null && minWon !== '' && !Number.isNaN(Number(minWon)) ? Number(minWon) : null
   const max = maxWon != null && maxWon !== '' && !Number.isNaN(Number(maxWon)) ? Number(maxWon) : null
@@ -150,12 +158,14 @@ export function GuestUpcomingTripsPage() {
   )
 
   const sections = useMemo(() => groupRows(rows), [rows])
+  const totalCount = rows.length
 
   return (
     <div className="gut-page">
       <header className="gut-hero">
-        <h1>📆 내 여행 일정 한눈에 보기</h1>
-        <p>가까운 일정부터 D-Day 순서로 확인하고, 필요한 일정은 바로 눌러 상세/매칭 화면으로 이동해 보세요.</p>
+        <div className="gut-hero-badge">설렘 ON · {totalCount}개의 여행</div>
+        <h1>내 여행 일정 한눈에 보기</h1>
+        <p>가까운 일정부터 D-Day 순서로 정리했어요. 다음 여행을 눌러 바로 상세/매칭 화면으로 이동해 보세요.</p>
       </header>
 
       {loading && <PageLoading />}
@@ -178,17 +188,24 @@ export function GuestUpcomingTripsPage() {
                 {section.rows.map((row) => {
                   const d = daysUntil(row.desiredDate)
                   const nick = names[row.guideId] ?? `가이드 #${row.guideId}`
+                  const dest = row.destination ?? '로컬 투어'
+                  const budget = formatBudgetRangeKrw(row.budgetMinWon, row.budgetMaxWon, row.desiredBudget)
                   return (
                     <article key={row.requestId} className="gut-card">
+                      <div className="gut-card-top">
+                        <span className="gut-spot" aria-hidden="true">{moodEmoji(row.status, d)}</span>
+                        <div className="gut-pills">
+                          <span className="gut-pill gut-pill--dest">{dest}</span>
+                          <span className="gut-pill gut-pill--status">{statusText(row.status)}</span>
+                        </div>
+                      </div>
                       <div className="gut-meta">
                         <span className={`gut-dday${d === 0 ? ' is-today' : d === 1 ? ' is-soon' : ''}`}>
                           {row.status === 'ACCEPTED' ? '결제 필요' : ddayLabel(d, row.status)}
                         </span>
                         <h3>{nick}</h3>
-                        <p>{row.destination ?? '로컬 투어'} · {row.desiredDate ?? '—'}</p>
-                        <p>
-                          상태: {statusText(row.status)} · 예산: {formatBudgetRangeKrw(row.budgetMinWon, row.budgetMaxWon, row.desiredBudget)}
-                        </p>
+                        <p className="gut-line">{row.desiredDate ?? '—'}</p>
+                        <p className="gut-line gut-line--sub">예산 {budget}</p>
                       </div>
                       <button type="button" className="gut-open" onClick={() => openMatchScreen(row)}>
                         일정 확인하기


### PR DESCRIPTION
## 🔗 이슈 번호

Closes #391

## 💡 주요 변경 사항

- `/upcoming-trips` 히어로 영역을 그라데이션·배지·타이포로 리프레시해 설렘 톤을 강화
- 여행 카드에 목적지/상태 pill, 분위기 이모지, 더 깊은 그림자/호버, D-Day 배지 스타일을 적용해 시각적 밀도를 개선
- 기능 로직(데이터/정렬/이동)은 유지하고 표현만 개선

## ⚠️ 주의 사항 / 질문

- 해당 없음

## ✅ 체크리스트

- [x] 빌드가 정상적으로 되는가? (`cd frontend && npm run build`)
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [x] `.gitignore`에 설정 파일(비밀·로컬 전용)이 잘 제외되었는가? (해당 없음)

Made with [Cursor](https://cursor.com)