### PR TITLE
Feat/be#391 앞으로의 여행 카드 D-Day·폴라로이드 레이아웃

### DIFF
--- a/frontend/src/pages/GuestUpcomingTripsPage.css
+++ b/frontend/src/pages/GuestUpcomingTripsPage.css
@@ -151,26 +151,122 @@
   overflow: hidden;
 }
 
-.gut-card-main {
+.gut-card-split {
   position: relative;
   z-index: 1;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) clamp(5.5rem, 22vw, 8.1rem);
+  gap: 0.7rem 1rem;
+  align-items: stretch;
+}
+
+.gut-card-text {
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.15rem;
 }
 
-/* D-Day · 날짜 · pill 을 한 줄 흐름으로 묶어 가운데 공백 제거 */
-.gut-card-kick {
+.gut-card-hero-row {
   display: flex;
   flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.45rem 0.65rem;
+}
+
+.gut-card-preview-wrap {
+  display: flex;
   align-items: center;
-  gap: 0.35rem 0.45rem;
-  row-gap: 0.4rem;
+  justify-content: center;
+  min-height: 6.25rem;
+}
+
+.gut-trip-polaroid {
+  position: relative;
+  width: 100%;
+  max-width: 7.85rem;
+  aspect-ratio: 4 / 5;
+  border-radius: 10px;
+  border: 1px solid rgba(226, 232, 240, 0.95);
+  background: linear-gradient(165deg, #f8fafc 0%, #e2e8f0 100%);
+  box-shadow:
+    0 10px 22px rgba(15, 23, 42, 0.08),
+    inset 0 1px 0 rgba(255, 255, 255, 0.75);
+  transform: rotate(-3.5deg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.gut-trip-polaroid__dday {
+  padding: 0.2rem 0.35rem;
+  text-align: center;
+  font-family: var(--heading);
+  font-size: clamp(1.28rem, 4.8vmin, 1.62rem);
+  font-weight: 900;
+  letter-spacing: -0.06em;
+  line-height: 1.1;
+  font-variant-numeric: tabular-nums;
+  -webkit-font-smoothing: antialiased;
+  color: #e11d48;
+  text-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.45),
+    0 0.08em 0.12em rgba(190, 18, 60, 0.12);
+}
+
+.gut-trip-polaroid__dday.is-today {
+  color: #db2777;
+  text-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.45),
+    0 0.08em 0.12em rgba(157, 23, 77, 0.12);
+}
+
+.gut-trip-polaroid__dday.is-soon {
+  color: #ea580c;
+  text-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.45),
+    0 0.08em 0.12em rgba(154, 52, 18, 0.12);
+}
+
+@supports ((-webkit-background-clip: text) or (background-clip: text)) {
+  .gut-trip-polaroid__dday {
+    background-image: linear-gradient(158deg, #fda4af 0%, #f43f5e 38%, #be123c 92%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    text-shadow: none;
+  }
+
+  .gut-trip-polaroid__dday.is-today {
+    background-image: linear-gradient(158deg, #fbcfe8 0%, #ec4899 42%, #9d174d 95%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+  }
+
+  .gut-trip-polaroid__dday.is-soon {
+    background-image: linear-gradient(158deg, #fed7aa 0%, #f97316 45%, #9a3412 95%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+  }
+}
+
+.gut-trip-polaroid__tape {
+  position: absolute;
+  top: -0.32rem;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 2.15rem;
+  height: 0.78rem;
+  border-radius: 2px;
+  background: rgba(255, 255, 255, 0.62);
+  border: 1px solid rgba(226, 232, 240, 0.95);
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06);
 }
 
 .gut-title {
-  margin: 0.15rem 0 0;
+  margin: 0.2rem 0 0;
   font-size: 1.02rem;
   color: #111827;
   letter-spacing: -0.02em;
@@ -310,6 +406,35 @@
   color: #92400e;
   background: rgba(254, 243, 199, 0.92);
   border-color: rgba(253, 230, 138, 0.95);
+}
+
+.gut-payment-need {
+  font-size: 0.82rem;
+  font-weight: 900;
+  letter-spacing: -0.02em;
+  color: #e11d48;
+}
+
+.gut-date--hero {
+  font-size: 0.8rem;
+  font-weight: 800;
+  color: rgba(31, 35, 40, 0.55);
+}
+
+@media (max-width: 560px) {
+  .gut-card-split {
+    grid-template-columns: 1fr;
+  }
+
+  .gut-card-preview-wrap {
+    min-height: 0;
+    padding-bottom: 0.15rem;
+  }
+
+  .gut-trip-polaroid {
+    max-width: 6.75rem;
+    margin-inline: auto;
+  }
 }
 
 .gut-open {

--- a/frontend/src/pages/GuestUpcomingTripsPage.jsx
+++ b/frontend/src/pages/GuestUpcomingTripsPage.jsx
@@ -242,27 +242,38 @@ export function GuestUpcomingTripsPage() {
                 {section.rows.map((row) => {
                   const d = daysUntil(row.desiredDate)
                   const nick = names[row.guideId] ?? `가이드 #${row.guideId}`
-                  const dest = row.destination ?? '로컬 투어'
                   const budget = formatBudgetRangeKrw(row.budgetMinWon, row.budgetMaxWon, row.desiredBudget)
                   const tripTitle = buildTripCardTitle(row, nick)
                   return (
                     <article key={row.requestId} className="gut-card gut-card--timeline">
-                      <div className="gut-card-main">
-                        <div className="gut-card-kick">
-                          <span className={`gut-dday${d === 0 ? ' is-today' : d === 1 ? ' is-soon' : ''}`}>
-                            {row.status === 'ACCEPTED' ? '결제 필요' : ddayLabel(d, row.status)}
-                          </span>
-                          <span className="gut-date">{row.desiredDate ?? '—'}</span>
-                          <span className="gut-pill gut-pill--dest">{dest}</span>
-                          <span className="gut-pill gut-pill--status">{statusText(row.status)}</span>
+                      <div className="gut-card-split">
+                        <div className="gut-card-text">
+                          <div className="gut-card-hero-row">
+                            {row.status === 'ACCEPTED' && <span className="gut-payment-need">결제 필요</span>}
+                            <span className="gut-date gut-date--hero">{row.desiredDate ?? '—'}</span>
+                          </div>
+                          <h3 className="gut-title" title={tripTitle}>{tripTitle}</h3>
+                          <p className="gut-line gut-line--sub">예산 {budget}</p>
+                          <div className="gut-card-footer">
+                            <span className="gut-trail" aria-hidden="true">✈︎ 여행 준비 중</span>
+                            <button type="button" className="gut-open" onClick={() => openMatchScreen(row)}>
+                              일정 확인하기
+                            </button>
+                          </div>
                         </div>
-                        <h3 className="gut-title" title={tripTitle}>{tripTitle}</h3>
-                        <p className="gut-line gut-line--sub">예산 {budget}</p>
-                        <div className="gut-card-footer">
-                          <span className="gut-trail" aria-hidden="true">✈︎ 여행 준비 중</span>
-                          <button type="button" className="gut-open" onClick={() => openMatchScreen(row)}>
-                            일정 확인하기
-                          </button>
+                        <div className="gut-card-preview-wrap">
+                          <div
+                            className="gut-trip-polaroid"
+                            role="img"
+                            aria-label={ddayLabel(d, row.status)}
+                          >
+                            <span className="gut-trip-polaroid__tape" />
+                            <span
+                              className={`gut-trip-polaroid__dday${d === 0 ? ' is-today' : d === 1 ? ' is-soon' : ''}`}
+                            >
+                              {ddayLabel(d, row.status)}
+                            </span>
+                          </div>
                         </div>
                       </div>
                     </article>


### PR DESCRIPTION
## 🔗 이슈 번호

Related to #391

## 💡 주요 변경 사항

- `GuestUpcomingTripsPage`: 카드 상단 중복 pill(목적지·결제 전) 제거, 결제 대기(ACCEPTED)는 `결제 필요` + 날짜만 표시
- 오른쪽 폴라로이드 영역에 D-Day(`D-2`, `D-Day` 등) 표시, 왼쪽 세로 액센트 바·Trip Preview 문구 제거
- D-Day 타이포 확대(`var(--heading)`, `clamp` 크기, 그라데이션/그림자)

## ⚠️ 주의 사항 / 질문

- #392 머지 이후 동일 이슈 브랜치에 후속 커밋입니다. 이슈 자동 종료는 `Related to`로 두었습니다(필요 시 본문에서 `Closes`로 바꿔 주세요).

## ✅ 체크리스트

- [x] 빌드가 정상적으로 되는가? (`cd frontend && npm run build` 통과)
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [x] `.gitignore`에 설정 파일(비밀·로컬 전용)이 잘 제외되었는가? 해당 없음


Made with [Cursor](https://cursor.com)