### PR TITLE
Feat/be#391 코스 수정 시 기존 스팟 불러오기

### DIFF
--- a/frontend/src/pages/GuideCoursePanel.jsx
+++ b/frontend/src/pages/GuideCoursePanel.jsx
@@ -77,6 +77,31 @@ export function parseCourseDetail(text) {
     })
 }
 
+function courseDraftStorageKey(scheduleId) {
+  return `localguest.guide.courseFormDraft.v1.${String(scheduleId ?? '')}`
+}
+
+function loadCourseDraft(scheduleId) {
+  try {
+    if (typeof window === 'undefined') return null
+    const raw = window.localStorage.getItem(courseDraftStorageKey(scheduleId))
+    if (!raw) return null
+    const parsed = JSON.parse(raw)
+    return parsed && typeof parsed === 'object' ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+function saveCourseDraft(scheduleId, draft) {
+  try {
+    if (typeof window === 'undefined') return
+    window.localStorage.setItem(courseDraftStorageKey(scheduleId), JSON.stringify(draft ?? null))
+  } catch {
+    // ignore (storage full / disabled)
+  }
+}
+
 /** 네이티브 select는 목록 높이 제한이 불가해, 스크롤 가능한 커스텀 패널 사용 */
 function CourseTimeDropdown({
   id,
@@ -244,6 +269,7 @@ export function GuideCoursePanel({
       setLoading(true)
       setError('')
       try {
+        const cached = loadCourseDraft(schedule.scheduleId)
         const res = await apiRequest(
           `/guides/${guideId}/schedules/${schedule.scheduleId}/form`,
           { method: 'GET' },
@@ -252,11 +278,12 @@ export function GuideCoursePanel({
         if (!res.ok) {
           // 404면 빈 폼으로 시작 (아직 작성 안 한 케이스)
           if (res.status !== 404) throw new Error(text || '불러오기 실패')
-          if (!cancelled && initialForm) {
-            const mergedDetail = String(initialForm.courseDetail ?? '').trim()
+          const seed = initialForm ?? cached
+          if (!cancelled && seed) {
+            const mergedDetail = String(seed.courseDetail ?? '').trim()
             const parsed = parseCourseDetail(mergedDetail)
-            setMeetingPoint(initialForm.meetingPoint ?? '')
-            setGuideMessage(initialForm.guideMessage ?? '')
+            setMeetingPoint(seed.meetingPoint ?? '')
+            setGuideMessage(seed.guideMessage ?? '')
             setSpots(parsed.length ? parsed : [{ name: '', time: '', desc: '' }])
             setGeoStatus(parsed.map((s) => (s.name ? 'ok' : 'idle')))
           }
@@ -265,9 +292,9 @@ export function GuideCoursePanel({
           const merged = {
             ...data,
             // 결제 전 마스킹으로 courseDetail이 비어오는 경우를 대비해, 직전에 저장한 로컬 값을 우선 표시한다.
-            meetingPoint: data?.meetingPoint ?? initialForm?.meetingPoint ?? '',
-            guideMessage: data?.guideMessage ?? initialForm?.guideMessage ?? '',
-            courseDetail: data?.courseDetail ?? initialForm?.courseDetail ?? '',
+            meetingPoint: data?.meetingPoint ?? initialForm?.meetingPoint ?? cached?.meetingPoint ?? '',
+            guideMessage: data?.guideMessage ?? initialForm?.guideMessage ?? cached?.guideMessage ?? '',
+            courseDetail: data?.courseDetail ?? initialForm?.courseDetail ?? cached?.courseDetail ?? '',
           }
           if (!cancelled) {
             setMeetingPoint(merged.meetingPoint)
@@ -525,6 +552,7 @@ export function GuideCoursePanel({
         meetingPoint: savedForm?.meetingPoint ?? payload.meetingPoint,
         guideMessage: savedForm?.guideMessage ?? payload.guideMessage,
       }
+      saveCourseDraft(schedule.scheduleId, mergedSavedForm)
       setSaveMsg('저장되었습니다!')
       setTimeout(() => setSaveMsg(''), 2500)
       onSaved(mergedSavedForm)

--- a/frontend/src/pages/GuideFeedSchedulePage.jsx
+++ b/frontend/src/pages/GuideFeedSchedulePage.jsx
@@ -424,7 +424,7 @@ export function GuideFeedSchedulePage() {
     setFeedLocationTags((prev) => prev.filter((t) => t !== tag))
   }
 
-  const moveToCourseEditor = useCallback((tour) => {
+  const moveToCourseEditor = useCallback(async (tour) => {
     const sid = Number(tour?.scheduleId)
     if (!Number.isFinite(sid)) return
     const rid = Number(tour?.requestId)
@@ -438,13 +438,25 @@ export function GuideFeedSchedulePage() {
     if (tour?.startTime) params.set('startTime', String(tour.startTime))
     if (tour?.endTime) params.set('endTime', String(tour.endTime))
     if (tour?.destination) params.set('destination', String(tour.destination))
+
+    let initialForm = null
+    if (guideId) {
+      try {
+        const formRes = await apiRequest(`/guides/${guideId}/schedules/${sid}/form`, { method: 'GET' })
+        const formText = await formRes.text()
+        if (formRes.ok) initialForm = formText ? JSON.parse(formText) : null
+      } catch {
+        initialForm = null
+      }
+    }
+
     navigate(`${path}?${params.toString()}`, {
       state: {
         schedule: tour,
-        initialForm: null,
+        initialForm,
       },
     })
-  }, [navigate])
+  }, [navigate, guideId])
 
   if (idLoading) {
     return (

--- a/frontend/src/pages/GuideMatchedCoursePage.jsx
+++ b/frontend/src/pages/GuideMatchedCoursePage.jsx
@@ -34,6 +34,16 @@ function findLatestRequest(list, guideId, requestId) {
   return rows[0] ?? null
 }
 
+function parsePreviewSpots(proposedSchedule) {
+  const raw = String(proposedSchedule ?? '').trim()
+  if (!raw) return []
+  const normalized = raw.replace(/\s*->\s*/g, '\n')
+  return normalized
+    .split(/\r?\n|,/)
+    .map((v) => v.trim())
+    .filter(Boolean)
+}
+
 // ── 메인 컴포넌트 ─────────────────────────────────────────────────────────
 export function GuideMatchedCoursePage() {
   const { guideId } = useParams()
@@ -49,6 +59,7 @@ export function GuideMatchedCoursePage() {
   const [error, setError] = useState('')
   const [profile, setProfile] = useState(null)
   const [scheduleId, setScheduleId] = useState(null)
+  const [matchRequest, setMatchRequest] = useState(null)
   // schedule form 데이터 (백엔드 GuideScheduleFormResponse)
   const [formData, setFormData] = useState(null)
   const [mapErr, setMapErr] = useState('')
@@ -79,6 +90,7 @@ export function GuideMatchedCoursePage() {
         const reqText = await reqRes.text()
         const list = reqText ? JSON.parse(reqText) : []
         const req = findLatestRequest(list, guideId, requestId)
+        setMatchRequest(req)
         // scheduleId는 매칭 요청 응답에 포함되어 있어야 함
         // (matching 도메인 팀에서 scheduleId를 응답에 포함하는 것 전제)
         sid = req?.scheduleId != null ? Number(req.scheduleId) : null
@@ -113,6 +125,7 @@ export function GuideMatchedCoursePage() {
   const isPaid = formData?.isPaid === true
   const meetingPoint = formData?.meetingPoint ?? ''
   const guideMessage = formData?.guideMessage ?? ''
+  const previewSpots = useMemo(() => parsePreviewSpots(matchRequest?.proposedSchedule), [matchRequest?.proposedSchedule])
   // courseDetail: isPaid=true일 때만 내려옴
   const spots = useMemo(() => {
     if (!isPaid || !formData?.courseDetail) return []
@@ -301,6 +314,12 @@ export function GuideMatchedCoursePage() {
                     <p className="gmc-spot-desc">
                       가이드가 작성한 코스 스팟은 결제 완료 후 이 화면에 표시됩니다.
                     </p>
+                    {previewSpots.length > 0 && (
+                      <p className="gmc-spot-desc">
+                        미리보기: {previewSpots.slice(0, 3).join(' → ')}
+                        {previewSpots.length > 3 ? ' …' : ''}
+                      </p>
+                    )}
                   </article>
                 )
             }


### PR DESCRIPTION
## 🔗 이슈 번호

Related to #391

## 💡 주요 변경 사항

- 가이드 스케줄 관리에서 코스 수정 진입 시, 기존 저장된 스케줄 폼(코스 스팟)을 먼저 조회해 `initialForm`으로 전달
- 코스 에디터(`GuideCoursePanel`)의 로딩 실패/마스킹 상황에서도 기존 스팟이 화면에 프리필되도록 보강

## ✅ 체크리스트

- [x] `cd frontend && npm run build` 통과