### PR TITLE
Feat/fe#391 결제 전 코스 미리보기: 지명 마스킹·시간/설명 공개

### DIFF
--- a/frontend/src/pages/GuideCourseEditorPage.jsx
+++ b/frontend/src/pages/GuideCourseEditorPage.jsx
@@ -67,7 +67,19 @@ async function readJsonError(res, text) {
 function buildProposedSchedule(courseDetail) {
   const spots = parseCourseDetail(courseDetail ?? '').filter((spot) => String(spot.name ?? '').trim())
   if (spots.length === 0) return ''
-  return spots.map((spot) => spot.name.trim()).join(' -> ')
+  // 결제 전 미리보기용: 지명은 숨기고 시간/설명만 노출
+  // 포맷: "SPOT 1 | 오전 10:00 | 한적한 산책 + 카페" (줄바꿈 구분)
+  const clamp = (s, n) => (s.length > n ? `${s.slice(0, n)}…` : s)
+  return spots
+    .map((spot, idx) => {
+      const time = String(spot.time ?? '').trim()
+      const desc = String(spot.desc ?? '').trim()
+      const safeDesc = clamp(desc.replace(/\s+/g, ' '), 44)
+      const label = `SPOT ${idx + 1}`
+      // time/desc가 비어도 게스트 화면에서 깨지지 않게 빈 칸 허용
+      return `${label} | ${time || '시간 미정'} | ${safeDesc || '자세한 코스는 결제 후 공개됩니다'}`
+    })
+    .join('\n')
 }
 
 function formatTime(t) {

--- a/frontend/src/pages/GuideMatchOptionsPage.css
+++ b/frontend/src/pages/GuideMatchOptionsPage.css
@@ -362,6 +362,30 @@
 .gmo-spot-preview-name {
   font-size: 0.86rem;
   color: #111827;
+  font-weight: 900;
+  letter-spacing: -0.02em;
+}
+
+.gmo-spot-preview-time {
+  font-size: 0.74rem;
+  font-weight: 900;
+  letter-spacing: -0.01em;
+  color: #6b7280;
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 999px;
+  padding: 0.16rem 0.5rem;
+  flex-shrink: 0;
+}
+
+.gmo-spot-preview-desc {
+  font-size: 0.82rem;
+  color: rgba(17, 24, 39, 0.74);
+  letter-spacing: -0.01em;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .gmo-locked-zone {

--- a/frontend/src/pages/GuideMatchOptionsPage.jsx
+++ b/frontend/src/pages/GuideMatchOptionsPage.jsx
@@ -49,7 +49,15 @@ function parsePreviewSpots(proposedSchedule) {
     .split(/\r?\n|,/)
     .map((v) => v.trim())
     .filter(Boolean)
-  return rows
+  return rows.map((line, idx) => {
+    const parts = line.split('|').map((p) => p.trim()).filter(Boolean)
+    // 새 포맷: "SPOT n | time | desc"
+    if (parts.length >= 3 && /^SPOT\s*\d+/i.test(parts[0])) {
+      return { idx, time: parts[1], desc: parts.slice(2).join(' | ') }
+    }
+    // 구 포맷(장소명만): desc로 처리
+    return { idx, time: '', desc: line }
+  })
 }
 
 function hasProposalContent(row) {
@@ -215,7 +223,7 @@ export function GuideMatchOptionsPage() {
   const courseReadyForPayment = useMemo(() => {
     return String(activeRequest?.proposedSchedule ?? '').trim().length > 0
   }, [activeRequest])
-  const previewFirstSpot = previewSpots[0] ?? ''
+  const previewFirstSpot = previewSpots[0] ?? null
   const previewLockedSpots = previewSpots.slice(1)
   const hasLockedPreview = previewLockedSpots.length > 0 || !!previewHint
 
@@ -536,7 +544,9 @@ export function GuideMatchOptionsPage() {
           <ul className="gmo-spot-preview-list">
             <li className="gmo-spot-preview-item">
               <span className="gmo-spot-preview-num">1</span>
-              <span className="gmo-spot-preview-name">{previewFirstSpot}</span>
+              <span className="gmo-spot-preview-name">로컬 스팟</span>
+              {previewFirstSpot?.time && <span className="gmo-spot-preview-time">{previewFirstSpot.time}</span>}
+              <span className="gmo-spot-preview-desc">{previewFirstSpot?.desc ?? ''}</span>
             </li>
           </ul>
 
@@ -545,9 +555,11 @@ export function GuideMatchOptionsPage() {
               <div className="gmo-locked-blur" aria-hidden>
                 <ul className="gmo-spot-preview-list">
                   {previewLockedSpots.map((spot, idx) => (
-                    <li key={`${idx + 1}-${spot.slice(0, 12)}`} className="gmo-spot-preview-item">
+                    <li key={`${idx + 2}-${spot.time}-${spot.desc.slice(0, 12)}`} className="gmo-spot-preview-item">
                       <span className="gmo-spot-preview-num">{idx + 2}</span>
-                      <span className="gmo-spot-preview-name">{spot}</span>
+                      <span className="gmo-spot-preview-name">로컬 스팟</span>
+                      {spot.time && <span className="gmo-spot-preview-time">{spot.time}</span>}
+                      <span className="gmo-spot-preview-desc">{spot.desc}</span>
                     </li>
                   ))}
                 </ul>

--- a/frontend/src/pages/GuideMatchedCoursePage.jsx
+++ b/frontend/src/pages/GuideMatchedCoursePage.jsx
@@ -42,6 +42,13 @@ function parsePreviewSpots(proposedSchedule) {
     .split(/\r?\n|,/)
     .map((v) => v.trim())
     .filter(Boolean)
+    .map((line, idx) => {
+      const parts = line.split('|').map((p) => p.trim()).filter(Boolean)
+      if (parts.length >= 3 && /^SPOT\s*\d+/i.test(parts[0])) {
+        return { idx, time: parts[1], desc: parts.slice(2).join(' | ') }
+      }
+      return { idx, time: '', desc: line }
+    })
 }
 
 // ── 메인 컴포넌트 ─────────────────────────────────────────────────────────
@@ -316,7 +323,11 @@ export function GuideMatchedCoursePage() {
                     </p>
                     {previewSpots.length > 0 && (
                       <p className="gmc-spot-desc">
-                        미리보기: {previewSpots.slice(0, 3).join(' → ')}
+                        미리보기:{' '}
+                        {previewSpots
+                          .slice(0, 3)
+                          .map((s, i) => `${i + 1}. ${s.time ? `${s.time} · ` : ''}${s.desc}`)
+                          .join(' / ')}
                         {previewSpots.length > 3 ? ' …' : ''}
                       </p>
                     )}


### PR DESCRIPTION
## 🔗 이슈 번호

Related to #391

## 💡 주요 변경 사항

- 가이드가 제시안 전송 시 `proposedSchedule` 생성 포맷을 변경하여 지명 대신 `SPOT n`으로 마스킹하고, 시간/설명(요약)만 노출
- 게스트 결제 전 미리보기(`GuideMatchOptionsPage`)를 새 포맷으로 파싱하여 시간 pill + 설명 텍스트로 표시 (구 포맷도 fallback 지원)
- 결제 전 잠금 안내 영역(`GuideMatchedCoursePage`)의 미리보기 문구도 새 포맷에 맞게 표시

## ✅ 체크리스트

- [x] `cd frontend && npm run build` 통과