### PR TITLE
[Feat/fe#396] 가이드 스케줄 일정 취소하기 버튼

### DIFF
--- a/frontend/src/pages/GuideFeedSchedulePage.jsx
+++ b/frontend/src/pages/GuideFeedSchedulePage.jsx
@@ -228,6 +228,39 @@ export function GuideFeedSchedulePage() {
     return map
   }, [guideRequests])
 
+  const cancelBookedRequest = useCallback(async ({ requestId, scheduleId, availableDate }) => {
+    if (!guideId) return
+    const rid = Number(requestId)
+    if (!Number.isFinite(rid) || rid <= 0) {
+      addToast('취소할 예약 정보를 찾을 수 없습니다.', 'error')
+      return
+    }
+    const reason = window.prompt('일정 취소 사유를 입력해 주세요.', '개인 사정으로 일정이 변경되었습니다.')
+    if (!reason || !String(reason).trim()) return
+    if (!window.confirm(`${availableDate || ''} 예약(#${rid})을 취소할까요?`)) return
+
+    setBusy(true)
+    try {
+      const res = await apiRequest(`/matching/requests/${rid}/guide/cancel`, {
+        method: 'PATCH',
+        json: { cancelReason: String(reason).trim() },
+      })
+      const text = await res.text()
+      if (!res.ok) {
+        addToast(await readJsonError(res, text), 'error')
+        return
+      }
+      addToast('일정을 취소했습니다.')
+      await reloadScheduleData(guideId)
+      const reqs = await fetchGuideMatchRequests(apiRequest).catch(() => [])
+      setGuideRequests(Array.isArray(reqs) ? reqs : [])
+    } catch {
+      addToast('일정 취소에 실패했습니다.', 'error')
+    } finally {
+      setBusy(false)
+    }
+  }, [guideId, addToast, reloadScheduleData])
+
   useEffect(() => {
     if (!guideId) return
     void loadAll(guideId)
@@ -679,6 +712,7 @@ export function GuideFeedSchedulePage() {
             onActivateReceiving={activateReceiving}
             onSetBlocked={setDayBlocked}
             onOpenCourse={moveToCourseEditor}
+            onCancelRequest={cancelBookedRequest}
             requestsByScheduleId={requestsByScheduleId}
           />
         </>

--- a/frontend/src/pages/GuideMypagePages.css
+++ b/frontend/src/pages/GuideMypagePages.css
@@ -2483,6 +2483,9 @@
 .gss3-bact--warn    { background: #d97706; color: #fff; border-color: #d97706; }
 .gss3-bact--warn:hover    { background: #b45309; }
 
+.gss3-bact--danger { background: #fff; color: #b91c1c; border-color: #fecaca; }
+.gss3-bact--danger:hover:not(:disabled) { background: #fef2f2; }
+
 /* 설정 없음 — 중립 (기본) */
 .gss3-day--neutral {
   background: #fafafa;

--- a/frontend/src/pages/GuideScheduleSection.jsx
+++ b/frontend/src/pages/GuideScheduleSection.jsx
@@ -62,6 +62,7 @@ function ScheduleDrawer({
   onActivateReceiving,
   onSetBlocked,
   onOpenCourse,
+  onCancelRequest,
   busy,
 }) {
   const navigate = useNavigate()
@@ -214,6 +215,20 @@ function ScheduleDrawer({
                     >
                       {s.hasCourse ? '코스 수정하기 →' : '코스 작성하기 →'}
                     </button>
+                    <button
+                      type="button"
+                      className="gss3-dact gss3-dact--danger"
+                      disabled={busy}
+                      onClick={() =>
+                        onCancelRequest?.({
+                          requestId: s.matchRequestId ?? req?.requestId ?? null,
+                          scheduleId: s.scheduleId,
+                          availableDate: s.availableDate,
+                        })
+                      }
+                    >
+                      일정 취소하기
+                    </button>
                   </div>
                 )}
               </div>
@@ -223,7 +238,7 @@ function ScheduleDrawer({
   )
 }
 
-function BookingCard({ dateKey, info, req, isSelected, onClickCard, onOpenCourse, navigate }) {
+function BookingCard({ dateKey, info, req, isSelected, onClickCard, onOpenCourse, onCancelRequest, navigate, busy }) {
   const d = parseDateOnly(dateKey)
   if (!d) return null
 
@@ -290,6 +305,22 @@ function BookingCard({ dateKey, info, req, isSelected, onClickCard, onOpenCourse
               {hasCourse ? '코스 수정' : '코스 작성 (필요)'}
             </button>
           )}
+          {isBooked && (
+            <button
+              type="button"
+              className="gss3-bact gss3-bact--danger"
+              disabled={busy}
+              onClick={() =>
+                onCancelRequest?.({
+                  requestId: info.matchRequestId ?? req?.requestId ?? null,
+                  scheduleId: info.scheduleId,
+                  availableDate: info.availableDate,
+                })
+              }
+            >
+              일정 취소
+            </button>
+          )}
           {isPending && (
             <button type="button" className="gss3-bact gss3-bact--primary" onClick={() => navigate('/guide/inbox')}>
               매칭 요청에서 처리 →
@@ -309,6 +340,7 @@ export function GuideScheduleSection({
   onActivateReceiving,
   onSetBlocked,
   onOpenCourse,
+  onCancelRequest,
   requestsByScheduleId = new Map(),
 }) {
   const navigate = useNavigate()
@@ -596,7 +628,9 @@ export function GuideScheduleSection({
                   isSelected={selectedKey === s.availableDate}
                   onClickCard={handleCardClick}
                   onOpenCourse={onOpenCourse}
+                  onCancelRequest={onCancelRequest}
                   navigate={navigate}
+                  busy={busy}
                 />
               )
             })


### PR DESCRIPTION
## 🔗 이슈 번호

Related to #396

## 💡 주요 변경 사항

- 가이드 스케줄 관리 탭에서 BOOKED 일정에 '일정 취소(하기)' 버튼 추가 (카드/드로어)
- 취소 사유 입력(prompt) 후 PATCH /matching/requests/{requestId}/guide/cancel 호출
- 취소 후 스케줄/매칭요청 목록을 재조회해 화면을 즉시 갱신

## ✅ 체크리스트

- [x] cd frontend && npm run build 통과


Made with [Cursor](https://cursor.com)