### PR TITLE
[Feat/fe#397] 게스트 일정 취소하기 버튼

### DIFF
--- a/frontend/src/pages/GuestUpcomingTripsPage.css
+++ b/frontend/src/pages/GuestUpcomingTripsPage.css
@@ -87,6 +87,19 @@
   box-shadow: 0 14px 28px rgba(15, 23, 42, 0.05);
 }
 
+.gut-toast {
+  margin: 0.65rem 0 0.9rem;
+  padding: 0.55rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid rgba(239, 191, 208, 0.7);
+  background: rgba(255, 246, 251, 0.92);
+  color: #6b4a5a;
+  font-weight: 900;
+  font-size: 0.85rem;
+  letter-spacing: -0.01em;
+  box-shadow: 0 10px 22px rgba(143, 70, 100, 0.06);
+}
+
 .gut-section-head {
   display: flex;
   align-items: center;
@@ -450,6 +463,30 @@
   transition: background 0.18s ease, border-color 0.18s ease, transform 0.18s ease;
   flex: 0 1 auto;
   margin-left: auto;
+}
+
+.gut-cancel {
+  border: 1px solid rgba(254, 202, 202, 0.95);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.98);
+  color: #b91c1c;
+  font-size: 0.78rem;
+  font-weight: 900;
+  padding: 0.45rem 0.8rem;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.18s ease, border-color 0.18s ease, transform 0.18s ease;
+}
+
+.gut-cancel:hover:not(:disabled) {
+  background: rgba(254, 242, 242, 0.98);
+  border-color: rgba(252, 165, 165, 0.95);
+  transform: translateY(-1px);
+}
+
+.gut-cancel:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 @media (max-width: 520px) {

--- a/frontend/src/pages/GuestUpcomingTripsPage.css
+++ b/frontend/src/pages/GuestUpcomingTripsPage.css
@@ -302,6 +302,13 @@
   flex-wrap: wrap;
 }
 
+.gut-card-actions {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+}
+
 .gut-trail {
   font-size: 0.72rem;
   font-weight: 900;
@@ -462,7 +469,7 @@
   font-family: inherit;
   transition: background 0.18s ease, border-color 0.18s ease, transform 0.18s ease;
   flex: 0 1 auto;
-  margin-left: auto;
+  margin-left: 0;
 }
 
 .gut-cancel {

--- a/frontend/src/pages/GuestUpcomingTripsPage.jsx
+++ b/frontend/src/pages/GuestUpcomingTripsPage.jsx
@@ -147,6 +147,8 @@ export function GuestUpcomingTripsPage() {
   const [names, setNames] = useState({})
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
+  const [toast, setToast] = useState('')
+  const [busyId, setBusyId] = useState(null)
   const [paymentIdByRequest, setPaymentIdByRequest] = useState(() => ({}))
 
   const reload = useCallback(async () => {
@@ -211,6 +213,35 @@ export function GuestUpcomingTripsPage() {
     [navigate, paymentIdByRequest],
   )
 
+  const cancelTrip = useCallback(async (row) => {
+    if (!row?.requestId) return
+    const rid = Number(row.requestId)
+    if (!Number.isFinite(rid) || rid <= 0) return
+    const st = String(row.status ?? '').toUpperCase()
+    if (!(st === 'ACCEPTED' || st === 'PAID')) return
+
+    const reason = window.prompt('예약 취소 사유를 입력해 주세요.', '개인 사정으로 일정이 변경되었습니다.')
+    if (!reason || !String(reason).trim()) return
+    if (!window.confirm(`요청 #${rid} 예약을 취소할까요?`)) return
+
+    setBusyId(rid)
+    setToast('')
+    try {
+      const res = await apiRequest(`/matching/requests/${rid}/guest/cancel`, {
+        method: 'PATCH',
+        json: { cancelReason: String(reason).trim() },
+      })
+      const text = await res.text()
+      if (!res.ok) throw new Error(text || '취소 실패')
+      setToast('예약을 취소했습니다.')
+      await reload()
+    } catch (e) {
+      setToast(e instanceof Error ? e.message : '취소 실패')
+    } finally {
+      setBusyId(null)
+    }
+  }, [reload])
+
   const sections = useMemo(() => groupRows(rows), [rows])
   const totalCount = rows.length
 
@@ -224,6 +255,7 @@ export function GuestUpcomingTripsPage() {
 
       {loading && <PageLoading />}
       {!loading && error && <PageError message={error} onRetry={() => void reload()} />}
+      {!loading && !error && toast && <p className="gut-toast" role="status">{toast}</p>}
 
       {!loading && !error && rows.length === 0 && (
         <PageEmpty title="예정된 여행이 없습니다">진행 중이거나 예정된 매칭이 생기면 여기에 표시됩니다.</PageEmpty>
@@ -256,6 +288,16 @@ export function GuestUpcomingTripsPage() {
                           <p className="gut-line gut-line--sub">예산 {budget}</p>
                           <div className="gut-card-footer">
                             <span className="gut-trail" aria-hidden="true">✈︎ 여행 준비 중</span>
+                            {(row.status === 'ACCEPTED' || row.status === 'PAID') && (
+                              <button
+                                type="button"
+                                className="gut-cancel"
+                                disabled={busyId != null}
+                                onClick={() => void cancelTrip(row)}
+                              >
+                                {busyId === row.requestId ? '취소 중…' : '예약 취소'}
+                              </button>
+                            )}
                             <button type="button" className="gut-open" onClick={() => openMatchScreen(row)}>
                               일정 확인하기
                             </button>

--- a/frontend/src/pages/GuestUpcomingTripsPage.jsx
+++ b/frontend/src/pages/GuestUpcomingTripsPage.jsx
@@ -288,19 +288,21 @@ export function GuestUpcomingTripsPage() {
                           <p className="gut-line gut-line--sub">예산 {budget}</p>
                           <div className="gut-card-footer">
                             <span className="gut-trail" aria-hidden="true">✈︎ 여행 준비 중</span>
-                            {(row.status === 'ACCEPTED' || row.status === 'PAID') && (
-                              <button
-                                type="button"
-                                className="gut-cancel"
-                                disabled={busyId != null}
-                                onClick={() => void cancelTrip(row)}
-                              >
-                                {busyId === row.requestId ? '취소 중…' : '예약 취소'}
+                            <div className="gut-card-actions">
+                              {(row.status === 'ACCEPTED' || row.status === 'PAID') && (
+                                <button
+                                  type="button"
+                                  className="gut-cancel"
+                                  disabled={busyId != null}
+                                  onClick={() => void cancelTrip(row)}
+                                >
+                                  {busyId === row.requestId ? '취소 중…' : '예약 취소'}
+                                </button>
+                              )}
+                              <button type="button" className="gut-open" onClick={() => openMatchScreen(row)}>
+                                일정 확인하기
                               </button>
-                            )}
-                            <button type="button" className="gut-open" onClick={() => openMatchScreen(row)}>
-                              일정 확인하기
-                            </button>
+                            </div>
                           </div>
                         </div>
                         <div className="gut-card-preview-wrap">


### PR DESCRIPTION
## 🔗 이슈 번호

Related to #397

## 💡 주요 변경 사항

- 게스트 `앞으로의 여행 일정`(GuestUpcomingTripsPage)에서 ACCEPTED/PAID 상태에 `예약 취소` 버튼 추가
- 사유 입력(prompt) 후 `PATCH /matching/requests/{requestId}/guest/cancel` 호출
- 취소 성공 시 목록 재조회 및 상단 토스트로 결과 안내

## ✅ 체크리스트

- [x] cd frontend && npm run build 통과


Made with [Cursor](https://cursor.com)