### PR TITLE
[Feat/fe#398] 결제 전 코스 미리보기 전체 공개

### DIFF
--- a/frontend/src/pages/GuideMatchOptionsPage.css
+++ b/frontend/src/pages/GuideMatchOptionsPage.css
@@ -388,48 +388,6 @@
   white-space: nowrap;
 }
 
-.gmo-locked-zone {
-  margin-top: 0.75rem;
-  position: relative;
-  border-radius: 14px;
-  overflow: hidden;
-  border: 1px solid #dbe3f0;
-  background: linear-gradient(180deg, #eef2ff 0%, #e9eefc 100%);
-  min-height: 180px;
-}
-
-.gmo-locked-blur {
-  padding: 0.75rem 0.8rem;
-  filter: blur(5px);
-  transform: scale(1.02);
-  opacity: 0.92;
-  user-select: none;
-  pointer-events: none;
-}
-
-.gmo-locked-overlay {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.8rem;
-  pointer-events: none;
-}
-
-.gmo-pay-hint-card {
-  margin-top: 0;
-  padding: 0.75rem 0.8rem;
-  border-radius: 12px;
-  border: 1px solid #d1d5db;
-  background: #fff;
-  box-shadow: 0 8px 22px rgba(15, 23, 42, 0.16);
-  pointer-events: auto;
-  text-align: center;
-  max-width: 260px;
-  width: 100%;
-}
-
 .gmo-pay-hint-title {
   margin: 0;
   font-size: 0.82rem;

--- a/frontend/src/pages/GuideMatchOptionsPage.jsx
+++ b/frontend/src/pages/GuideMatchOptionsPage.jsx
@@ -223,9 +223,7 @@ export function GuideMatchOptionsPage() {
   const courseReadyForPayment = useMemo(() => {
     return String(activeRequest?.proposedSchedule ?? '').trim().length > 0
   }, [activeRequest])
-  const previewFirstSpot = previewSpots[0] ?? null
-  const previewLockedSpots = previewSpots.slice(1)
-  const hasLockedPreview = previewLockedSpots.length > 0 || !!previewHint
+  const hasPreview = previewSpots.length > 0
 
   const modalTags = useMemo(() => parseProfileTags(profile?.keywords), [profile])
 
@@ -538,57 +536,29 @@ export function GuideMatchOptionsPage() {
         </section>
       </div>
 
-      {previewSpots.length > 0 && (
+      {hasPreview && (
         <section className="gmo-half-preview" aria-label="코스 텍스트 미리보기">
-          <p className="gmo-half-title">가이드가 작성한 코스 일부</p>
+          <p className="gmo-half-title">가이드가 작성한 코스 (시간·설명)</p>
           <ul className="gmo-spot-preview-list">
-            <li className="gmo-spot-preview-item">
-              <span className="gmo-spot-preview-num">1</span>
-              <span className="gmo-spot-preview-name">로컬 스팟</span>
-              {previewFirstSpot?.time && <span className="gmo-spot-preview-time">{previewFirstSpot.time}</span>}
-              <span className="gmo-spot-preview-desc">{previewFirstSpot?.desc ?? ''}</span>
-            </li>
+            {previewSpots.map((spot, idx) => (
+              <li key={`${idx + 1}-${spot.time}-${spot.desc.slice(0, 12)}`} className="gmo-spot-preview-item">
+                <span className="gmo-spot-preview-num">{idx + 1}</span>
+                <span className="gmo-spot-preview-name">로컬 스팟</span>
+                {spot.time && <span className="gmo-spot-preview-time">{spot.time}</span>}
+                <span className="gmo-spot-preview-desc">{spot.desc}</span>
+              </li>
+            ))}
           </ul>
 
-          {hasLockedPreview && (
-            <div className="gmo-locked-zone">
-              <div className="gmo-locked-blur" aria-hidden>
-                <ul className="gmo-spot-preview-list">
-                  {previewLockedSpots.map((spot, idx) => (
-                    <li key={`${idx + 2}-${spot.time}-${spot.desc.slice(0, 12)}`} className="gmo-spot-preview-item">
-                      <span className="gmo-spot-preview-num">{idx + 2}</span>
-                      <span className="gmo-spot-preview-name">로컬 스팟</span>
-                      {spot.time && <span className="gmo-spot-preview-time">{spot.time}</span>}
-                      <span className="gmo-spot-preview-desc">{spot.desc}</span>
-                    </li>
-                  ))}
-                </ul>
-                {previewHint && <p className="gmo-half-visible">가이드 메모: {previewHint}</p>}
-                <p className="gmo-half-foot">나머지 상세 코스는 결제 후 공개됩니다.</p>
-              </div>
-              <div className="gmo-locked-overlay">
-                <div className="gmo-pay-hint-card">
-                  <p className="gmo-pay-hint-title">아직 공개되지 않은 코스가 있어요</p>
-                  <p className="gmo-pay-hint-sub">아래 버튼을 누르면 바로 결제 단계로 이동합니다.</p>
-                  <button type="button" className="gmo-pay-hint-btn" onClick={() => void onPay()}>
-                    결제 진행하기
-                  </button>
-                </div>
-              </div>
-            </div>
-          )}
-          {!hasLockedPreview && (
-            <div className="gmo-pay-hint-inline">
-              <p className="gmo-half-foot">나머지 상세 코스는 결제 후 공개됩니다.</p>
-            </div>
-          )}
-          {!hasLockedPreview && (
-            <div className="gmo-pay-hint-inline">
-              <button type="button" className="gmo-pay-hint-btn" onClick={() => void onPay()}>
-                결제 진행하기
-              </button>
-            </div>
-          )}
+          {previewHint && <p className="gmo-half-visible">가이드 메모: {previewHint}</p>}
+          <div className="gmo-pay-hint-inline">
+            <p className="gmo-half-foot">장소명은 투어 완료 후 공개됩니다.</p>
+          </div>
+          <div className="gmo-pay-hint-inline">
+            <button type="button" className="gmo-pay-hint-btn" onClick={() => void onPay()}>
+              결제 진행하기
+            </button>
+          </div>
         </section>
       )}
       {previewSpots.length === 0 && (


### PR DESCRIPTION
## 🔗 이슈 번호

Related to #398

## 💡 주요 변경 사항

- 결제 전 `추천 코스 미리보기`에서 일부만 노출/블러 처리하던 UI 제거
- 지명은 계속 `로컬 스팟`으로 마스킹하고, 시간/설명은 전체 스팟을 모두 표시
- 하단 CTA는 유지하고 문구를 `장소명은 투어 완료 후 공개됩니다.`로 조정

## ✅ 체크리스트

- [x] cd frontend && npm run build 통과


Made with [Cursor](https://cursor.com)