### PR TITLE
[Feat/be#402] 투어 완료 후 courseDetail(장소명) 공개

### DIFF
--- a/backend/module-domain/src/main/java/com/team6/domain/guide/controller/GuideScheduleController.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/controller/GuideScheduleController.java
@@ -108,7 +108,14 @@ public class GuideScheduleController {
             @PathVariable Long guideId,
             @PathVariable Long scheduleId
     ) {
-        return ResponseEntity.ok(guideScheduleService.getScheduleForm(scheduleId, guideId));
+        boolean isGuideCaller;
+        try {
+            guideAuthenticationSupport.getCurrentGuideMemberId();
+            isGuideCaller = true;
+        } catch (Exception e) {
+            isGuideCaller = false;
+        }
+        return ResponseEntity.ok(guideScheduleService.getScheduleForm(scheduleId, guideId, isGuideCaller));
     }
 
     // 수락 후 여행 계획 양식 저장 — BOOKED 상태에만 가능 (F06-04)

--- a/backend/module-domain/src/main/java/com/team6/domain/guide/dto/response/GuideScheduleFormResponse.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/dto/response/GuideScheduleFormResponse.java
@@ -26,8 +26,7 @@ public class GuideScheduleFormResponse {
     private Boolean isPaid;          // 결제 완료 여부 (프론트 잠금 처리 기준)
 
     // Entity → 양식 응답 DTO 변환
-    // courseDetail은 isPaid=true일 때만 반환, 결제 전이면 null (잠금)
-    public static GuideScheduleFormResponse from(GuideSchedule schedule) {
+    public static GuideScheduleFormResponse from(GuideSchedule schedule, boolean exposeCourseDetail) {
         boolean paid = Boolean.TRUE.equals(schedule.getIsPaid());
         return GuideScheduleFormResponse.builder()
                 .scheduleId(schedule.getId())
@@ -37,8 +36,17 @@ public class GuideScheduleFormResponse {
                 .endTime(schedule.getEndTime())
                 .meetingPoint(schedule.getMeetingPoint() != null ? schedule.getMeetingPoint() : "")
                 .guideMessage(schedule.getGuideMessage() != null ? schedule.getGuideMessage() : "")
-                .courseDetail(paid ? schedule.getCourseDetail() : null) // 결제 전 잠금
+                .courseDetail(exposeCourseDetail ? schedule.getCourseDetail() : null)
                 .isPaid(paid)
                 .build();
+    }
+
+    /**
+     * @deprecated 공개 정책 판단은 서비스에서 수행하고, {@link #from(GuideSchedule, boolean)}를 사용한다.
+     */
+    @Deprecated
+    public static GuideScheduleFormResponse from(GuideSchedule schedule) {
+        boolean paid = Boolean.TRUE.equals(schedule.getIsPaid());
+        return from(schedule, paid);
     }
 }

--- a/backend/module-domain/src/main/java/com/team6/domain/guide/service/GuideScheduleService.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/service/GuideScheduleService.java
@@ -12,6 +12,9 @@ import com.team6.domain.guide.exception.GuideErrorCode;
 import com.team6.domain.guide.exception.GuideException;
 import com.team6.domain.guide.repository.GuideProfileRepository;
 import com.team6.domain.guide.repository.GuideScheduleRepository;
+import com.team6.domain.matching.entity.MatchRequest;
+import com.team6.domain.matching.entity.enums.MatchRequestStatus;
+import com.team6.domain.matching.repository.MatchRequestRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -31,6 +34,7 @@ public class GuideScheduleService {
 
     private final GuideScheduleRepository guideScheduleRepository;
     private final GuideProfileRepository guideProfileRepository;
+    private final MatchRequestRepository matchRequestRepository;
 
     // 스케줄 등록 (F06-04)
     @Transactional
@@ -194,9 +198,18 @@ public class GuideScheduleService {
     // 현재 인증된 사용자라면 누구나 호출 가능
     // 개선 시 가이드 본인 또는 매칭된 게스트만 허용하도록 변경 필요
     @Transactional(readOnly = true)
-    public GuideScheduleFormResponse getScheduleForm(Long scheduleId, Long guideId) {
+    public GuideScheduleFormResponse getScheduleForm(Long scheduleId, Long guideId, boolean isGuideCaller) {
         GuideSchedule schedule = getVerifiedSchedule(scheduleId, guideId);
-        return GuideScheduleFormResponse.from(schedule);
+        boolean expose = isGuideCaller || isTourCompleted(schedule.getMatchRequestId());
+        return GuideScheduleFormResponse.from(schedule, expose);
+    }
+
+    private boolean isTourCompleted(Long matchRequestId) {
+        if (matchRequestId == null) return false;
+        return matchRequestRepository.findById(matchRequestId)
+                .map(MatchRequest::getStatus)
+                .filter(st -> st == MatchRequestStatus.COMPLETED)
+                .isPresent();
     }
 
     // 수락 후 여행 계획 양식 저장 — BOOKED 상태 스케줄에만 가능 (F06-04)


### PR DESCRIPTION
## 🔗 이슈 번호

Closes #402

## 💡 주요 변경 사항

- `GET /guides/{guideId}/schedules/{scheduleId}/form`의 `courseDetail` 공개 기준을 `isPaid` → `MatchRequestStatus.COMPLETED`(투어 완료)로 변경
- 가이드가 호출한 경우에는 항상 `courseDetail`을 반환(편집/운영 영향 방지)

## ⚠️ 주의 사항 / 질문

- 현재 form 조회 API는 인증된 사용자면 누구나 호출 가능한 상태라(기존 TODO), 공개 정책만 강화했습니다. 추후 접근 제어(가이드 본인/매칭 게스트만)를 추가하는 게 안전합니다.

## ✅ 체크리스트

- [x] `cd backend && ./gradlew :api-server:compileJava` 통과


Made with [Cursor](https://cursor.com)