### PR TITLE
[Feat/be#408] 결제 후 지도용 courseDetail(마스킹) 반환

### DIFF
--- a/backend/module-domain/src/main/java/com/team6/domain/guide/dto/response/GuideScheduleFormResponse.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/dto/response/GuideScheduleFormResponse.java
@@ -26,7 +26,7 @@ public class GuideScheduleFormResponse {
     private Boolean isPaid;          // 결제 완료 여부 (프론트 잠금 처리 기준)
 
     // Entity → 양식 응답 DTO 변환
-    public static GuideScheduleFormResponse from(GuideSchedule schedule, boolean exposeCourseDetail) {
+    public static GuideScheduleFormResponse from(GuideSchedule schedule, boolean exposeCourseDetail, String courseDetailOverride) {
         boolean paid = Boolean.TRUE.equals(schedule.getIsPaid());
         return GuideScheduleFormResponse.builder()
                 .scheduleId(schedule.getId())
@@ -36,9 +36,13 @@ public class GuideScheduleFormResponse {
                 .endTime(schedule.getEndTime())
                 .meetingPoint(schedule.getMeetingPoint() != null ? schedule.getMeetingPoint() : "")
                 .guideMessage(schedule.getGuideMessage() != null ? schedule.getGuideMessage() : "")
-                .courseDetail(exposeCourseDetail ? schedule.getCourseDetail() : null)
+                .courseDetail(exposeCourseDetail ? (courseDetailOverride != null ? courseDetailOverride : schedule.getCourseDetail()) : null)
                 .isPaid(paid)
                 .build();
+    }
+
+    public static GuideScheduleFormResponse from(GuideSchedule schedule, boolean exposeCourseDetail) {
+        return from(schedule, exposeCourseDetail, null);
     }
 
     /**

--- a/backend/module-domain/src/main/java/com/team6/domain/guide/service/GuideScheduleService.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/service/GuideScheduleService.java
@@ -200,16 +200,54 @@ public class GuideScheduleService {
     @Transactional(readOnly = true)
     public GuideScheduleFormResponse getScheduleForm(Long scheduleId, Long guideId, boolean isGuideCaller) {
         GuideSchedule schedule = getVerifiedSchedule(scheduleId, guideId);
-        boolean expose = isGuideCaller || isTourCompleted(schedule.getMatchRequestId());
-        return GuideScheduleFormResponse.from(schedule, expose);
+        if (isGuideCaller) {
+            return GuideScheduleFormResponse.from(schedule, true);
+        }
+
+        MatchRequestStatus st = resolveMatchStatus(schedule.getMatchRequestId());
+        if (st == MatchRequestStatus.COMPLETED) {
+            return GuideScheduleFormResponse.from(schedule, true);
+        }
+        if (st == MatchRequestStatus.PAID || st == MatchRequestStatus.IN_PROGRESS) {
+            String masked = maskCourseDetail(schedule.getCourseDetail());
+            return GuideScheduleFormResponse.from(schedule, true, masked);
+        }
+        // 결제 전(ACCEPTED) 등: 상세 코스는 숨김
+        return GuideScheduleFormResponse.from(schedule, false);
     }
 
-    private boolean isTourCompleted(Long matchRequestId) {
-        if (matchRequestId == null) return false;
+    private MatchRequestStatus resolveMatchStatus(Long matchRequestId) {
+        if (matchRequestId == null) return null;
         return matchRequestRepository.findById(matchRequestId)
                 .map(MatchRequest::getStatus)
-                .filter(st -> st == MatchRequestStatus.COMPLETED)
-                .isPresent();
+                .orElse(null);
+    }
+
+    /**
+     * courseDetail 포맷(줄 단위): "n. name | time | desc" (+ 이후 확장 필드가 있어도 보존)
+     * 결제 후(완료 전)에는 name만 마스킹한다.
+     */
+    private String maskCourseDetail(String courseDetail) {
+        if (courseDetail == null || courseDetail.isBlank()) return courseDetail;
+        String[] lines = courseDetail.split("\\R");
+        StringBuilder out = new StringBuilder();
+        for (String line : lines) {
+            if (line == null || line.isBlank()) continue;
+            String trimmed = line.trim();
+            // "1. ..." prefix 제거 후 '|' 기준으로 파싱
+            String noNum = trimmed.replaceFirst("^\\d+\\.\\s*", "");
+            String[] parts = noNum.split("\\|", -1);
+            if (parts.length >= 1) {
+                parts[0] = "로컬 스팟";
+            }
+            String rebuilt = String.join(" | ", java.util.Arrays.stream(parts).map(String::trim).toArray(String[]::new));
+            // 원래 번호가 있으면 유지
+            String prefix = trimmed.matches("^\\d+\\..*") ? trimmed.replaceFirst("^(\\d+\\.).*$", "$1 ") : "";
+            if (!prefix.isEmpty()) out.append(prefix);
+            out.append(rebuilt);
+            out.append('\n');
+        }
+        return out.toString().trim();
     }
 
     // 수락 후 여행 계획 양식 저장 — BOOKED 상태 스케줄에만 가능 (F06-04)


### PR DESCRIPTION
## 🔗 이슈 번호

Closes #408

## 💡 주요 변경 사항

- 게스트가 `GET /guides/{guideId}/schedules/{scheduleId}/form` 호출 시 상태별 `courseDetail` 공개 수준 조정
  - PAID/IN_PROGRESS: `courseDetail` 반환하되 **장소명만 '로컬 스팟'으로 마스킹**, 시간/설명/확장 필드는 유지
  - COMPLETED: `courseDetail` 전체 공개
  - 그 외: `courseDetail` null
- 가이드 호출은 항상 전체 `courseDetail` 반환(편집/운영 영향 방지)

## 🗄️ 스키마 영향

- 없음

## ✅ 체크리스트

- [x] `cd backend && ./gradlew :api-server:compileJava`