### PR TITLE
[Feat/fe#407] 결제 후 지도 오픈(마스킹 라벨)·완료 후 장소명

### DIFF
--- a/frontend/src/pages/GuideCoursePanel.jsx
+++ b/frontend/src/pages/GuideCoursePanel.jsx
@@ -54,25 +54,36 @@ function createPinOverlay(kakao, map, latlng, idx, name) {
 }
 
 // ── courseDetail 직렬화/파싱 ───────────────────────────────────────────
-// 형식: "1. 장소명 | 시간 | 설명\n2. ..."
+// 형식: "1. 장소명 | 시간 | 설명 | lat,lng\n2. ..."
 export function serializeCourse(spots) {
   return spots
     .filter((s) => s.name.trim())
-    .map((s, i) => `${i + 1}. ${s.name.trim()} | ${s.time.trim()} | ${s.desc.trim()}`)
+    .map((s, i) => {
+      const lat = Number(s.lat)
+      const lng = Number(s.lng)
+      const coord = Number.isFinite(lat) && Number.isFinite(lng) ? ` | ${lat},${lng}` : ''
+      return `${i + 1}. ${s.name.trim()} | ${s.time.trim()} | ${s.desc.trim()}${coord}`
+    })
     .join('\n')
 }
 
 export function parseCourseDetail(text) {
-  if (!text?.trim()) return [{ name: '', time: '', desc: '' }]
+  if (!text?.trim()) return [{ name: '', time: '', desc: '', lat: null, lng: null }]
   return text
     .split('\n')
     .filter(Boolean)
     .map((line) => {
       const parts = line.replace(/^\d+\.\s*/, '').split('|')
+      const coordRaw = parts[3]?.trim() ?? ''
+      const coordMatch = coordRaw.match(/(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)/)
+      const lat = coordMatch ? Number(coordMatch[1]) : null
+      const lng = coordMatch ? Number(coordMatch[2]) : null
       return {
         name: parts[0]?.trim() ?? '',
         time: parts[1]?.trim() ?? '',
         desc: parts[2]?.trim() ?? '',
+        lat: Number.isFinite(lat) ? lat : null,
+        lng: Number.isFinite(lng) ? lng : null,
       }
     })
 }
@@ -230,7 +241,7 @@ export function GuideCoursePanel({
 
   const [meetingPoint, setMeetingPoint] = useState('')
   const [guideMessage, setGuideMessage] = useState('')
-  const [spots, setSpots] = useState([{ name: '', time: '', desc: '' }])
+  const [spots, setSpots] = useState([{ name: '', time: '', desc: '', lat: null, lng: null }])
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
@@ -284,7 +295,7 @@ export function GuideCoursePanel({
             const parsed = parseCourseDetail(mergedDetail)
             setMeetingPoint(seed.meetingPoint ?? '')
             setGuideMessage(seed.guideMessage ?? '')
-            setSpots(parsed.length ? parsed : [{ name: '', time: '', desc: '' }])
+            setSpots(parsed.length ? parsed : [{ name: '', time: '', desc: '', lat: null, lng: null }])
             setGeoStatus(parsed.map((s) => (s.name ? 'ok' : 'idle')))
           }
         } else {
@@ -300,7 +311,7 @@ export function GuideCoursePanel({
             setMeetingPoint(merged.meetingPoint)
             setGuideMessage(merged.guideMessage)
             const parsed = parseCourseDetail(merged.courseDetail)
-            setSpots(parsed.length ? parsed : [{ name: '', time: '', desc: '' }])
+            setSpots(parsed.length ? parsed : [{ name: '', time: '', desc: '', lat: null, lng: null }])
             setGeoStatus(parsed.map((s) => (s.name ? 'ok' : 'idle')))
           }
         }
@@ -345,6 +356,19 @@ export function GuideCoursePanel({
     setGeoStatus((prev) => {
       const next = [...prev]
       results.forEach(({ point, origIdx }) => { next[origIdx] = point ? 'ok' : 'error' })
+      return next
+    })
+
+    // 좌표 캐시: 저장 시 courseDetail에 포함되도록 spots에 lat/lng 반영
+    setSpots((prev) => {
+      const next = [...prev]
+      results.forEach(({ point, origIdx }) => {
+        if (!point) return
+        const cur = next[origIdx]
+        if (!cur) return
+        next[origIdx] = { ...cur, lat: point.lat, lng: point.lng }
+      })
+      spotsRef.current = next
       return next
     })
 
@@ -455,7 +479,7 @@ export function GuideCoursePanel({
   const addSpot = () => {
     setOpenTimeIdx(null)
     setSpots((prev) => {
-      const next = [...prev, { name: '', time: '', desc: '' }]
+      const next = [...prev, { name: '', time: '', desc: '', lat: null, lng: null }]
       spotsRef.current = next
       return next
     })

--- a/frontend/src/pages/GuideMatchedCoursePage.jsx
+++ b/frontend/src/pages/GuideMatchedCoursePage.jsx
@@ -303,7 +303,7 @@ export function GuideMatchedCoursePage() {
             <div ref={mapRef} className="gmc-map" />
             {mapErr && <p className="gmc-err gmc-map-err">{mapErr}</p>}
             {/* 결제 전 지도 잠금 오버레이 */}
-            {!isPaid && (
+            {!mapUnlocked && (
               <div className="gmc-map-lock">
                 <span className="gmc-lock-icon"><span className="gmc-lock-glyph" /></span>
                 <p className="gmc-lock-title">결제 완료 후 코스 공개</p>
@@ -315,7 +315,7 @@ export function GuideMatchedCoursePage() {
           {/* 타임라인 */}
           <aside className="gmc-timeline">
             {/* 결제 완료: 실제 courseDetail 스팟 표시 */}
-            {isPaid && spots.length > 0
+            {mapUnlocked && spots.length > 0
               ? spots.slice(0, 4).map((spot, idx) => (
                   <article key={idx} className="gmc-spot">
                     <p className="gmc-spot-label">SPOT {idx + 1}</p>
@@ -323,7 +323,7 @@ export function GuideMatchedCoursePage() {
                     {spot.desc && <p className="gmc-spot-desc">{spot.desc}</p>}
                   </article>
                 ))
-              : !isPaid && (
+              : !mapUnlocked && (
                   // 결제 전: 잠금 안내
                   <article className="gmc-spot gmc-spot--locked">
                     <p className="gmc-spot-label">SPOT 1 ~ N</p>
@@ -345,7 +345,7 @@ export function GuideMatchedCoursePage() {
                 )
             }
             {/* 가이드 미작성 케이스 (isPaid=true인데 spots=0) */}
-            {isPaid && spots.length === 0 && (
+            {mapUnlocked && spots.length === 0 && (
               <article className="gmc-spot">
                 <p className="gmc-spot-label">코스 준비 중</p>
                 <h3 className="gmc-spot-name">가이드가 코스를 작성 중이에요</h3>

--- a/frontend/src/pages/GuideMatchedCoursePage.jsx
+++ b/frontend/src/pages/GuideMatchedCoursePage.jsx
@@ -127,23 +127,22 @@ export function GuideMatchedCoursePage() {
 
   useEffect(() => { void load() }, [load])
 
-  // ── isPaid 판단 ─────────────────────────────────────────────────────────
-  // 백엔드 GuideScheduleFormResponse: isPaid=false이면 courseDetail=null으로 마스킹
-  const isPaid = formData?.isPaid === true
+  const matchStatus = String(matchRequest?.status ?? '').toUpperCase()
+  const mapUnlocked = matchStatus === 'PAID' || matchStatus === 'IN_PROGRESS' || matchStatus === 'COMPLETED'
+  const revealPlaceName = matchStatus === 'COMPLETED'
   const meetingPoint = formData?.meetingPoint ?? ''
   const guideMessage = formData?.guideMessage ?? ''
   const previewSpots = useMemo(() => parsePreviewSpots(matchRequest?.proposedSchedule), [matchRequest?.proposedSchedule])
-  // courseDetail: isPaid=true일 때만 내려옴
+  // courseDetail: 결제 후(PAID/IN_PROGRESS)부터 내려오며, 완료(COMPLETED) 시 장소명까지 공개됨
   const spots = useMemo(() => {
-    if (!isPaid || !formData?.courseDetail) return []
+    if (!mapUnlocked || !formData?.courseDetail) return []
     return parseCourseDetail(formData.courseDetail)
-  }, [isPaid, formData])
+  }, [mapUnlocked, formData])
 
   // ── 지도 ───────────────────────────────────────────────────────────────
   useEffect(() => {
     if (!mapRef.current) return
-    // isPaid=false면 지도에 마커 없이 흐린 처리만
-    if (!isPaid || spots.length === 0) return
+    if (!mapUnlocked || spots.length === 0) return
     let cancelled = false
 
     const draw = async () => {
@@ -159,6 +158,8 @@ export function GuideMatchedCoursePage() {
         } else if (meetingPoint.trim()) {
           const byMeeting = await resolveLatLng(kakao, meetingPoint.trim(), { regionHint: String(profile?.region ?? '').trim() })
           if (byMeeting) center = byMeeting
+        } else if (spots[0]?.lat != null && spots[0]?.lng != null) {
+          center = { lat: Number(spots[0].lat), lng: Number(spots[0].lng) }
         } else if (spots[0]?.name) {
           const firstSpot = await resolveLatLng(kakao, spots[0].name, { regionHint: String(profile?.region ?? '').trim() })
           if (firstSpot) center = firstSpot
@@ -171,7 +172,12 @@ export function GuideMatchedCoursePage() {
         const regionHint = String(profile?.region ?? '').trim()
         const resolved = await Promise.all(
           spots.map(async (spot, idx) => {
-            const point = await resolveLatLng(kakao, spot.name, { regionHint })
+            if (spot?.lat != null && spot?.lng != null) {
+              const lat = Number(spot.lat)
+              const lng = Number(spot.lng)
+              if (Number.isFinite(lat) && Number.isFinite(lng)) return { lat, lng }
+            }
+            const point = spot?.name ? await resolveLatLng(kakao, spot.name, { regionHint }) : null
             return point ?? fallbackLatLng(idx)
           }),
         )
@@ -183,7 +189,11 @@ export function GuideMatchedCoursePage() {
           const latlng = new kakao.maps.LatLng(p.lat, p.lng)
           path.push(latlng)
           bounds.extend(latlng)
-          createSpotOverlay(kakao, map, latlng, idx, spots[idx].name)
+          const s = spots[idx]
+          const label = revealPlaceName
+            ? (s?.name ?? '')
+            : `${s?.time ? `${s.time} · ` : ''}${s?.desc ?? ''}`.trim() || '코스'
+          createSpotOverlay(kakao, map, latlng, idx, label)
         })
         if (path.length > 1) {
           new kakao.maps.Polyline({ map, path, strokeWeight: 8, strokeColor: '#f9fafb', strokeOpacity: 0.95, strokeStyle: 'solid' })
@@ -197,7 +207,7 @@ export function GuideMatchedCoursePage() {
 
     void draw()
     return () => { cancelled = true }
-  }, [spots, isPaid, profile?.region, meetingPoint])
+  }, [spots, mapUnlocked, revealPlaceName, profile?.region, meetingPoint])
 
   const handleOpenMatchChat = async () => {
     setChatBusy(true)


### PR DESCRIPTION
## 🔗 이슈 번호

Closes #407

## 💡 주요 변경 사항

- 가이드 코스 저장 포맷에 좌표(lat,lng)를 포함하도록 `courseDetail` 직렬화/파싱 확장
- 결제 후(PAID/IN_PROGRESS) 게스트 지도는 잠금 해제 + 좌표 기반 경로/마커 표시
- 결제 후(완료 전) 마커 라벨은 시간/설명으로 표시(장소명 비노출), 투어 완료(COMPLETED) 시 장소명 라벨 표시

## 🗄️ 스키마 영향

- 없음

## ✅ 체크리스트

- [x] `cd frontend && npm run build`