### PR TITLE
[Feat/fe#413] 결제 후 코스 리스트 타이틀에 설명 표시

### DIFF
--- a/frontend/src/pages/GuideMatchedCoursePage.jsx
+++ b/frontend/src/pages/GuideMatchedCoursePage.jsx
@@ -319,8 +319,17 @@ export function GuideMatchedCoursePage() {
               ? spots.slice(0, 4).map((spot, idx) => (
                   <article key={idx} className="gmc-spot">
                     <p className="gmc-spot-label">SPOT {idx + 1}</p>
-                    <h3 className="gmc-spot-name">{spot.name}{spot.time ? ` (${spot.time})` : ''}</h3>
-                    {spot.desc && <p className="gmc-spot-desc">{spot.desc}</p>}
+                    {(() => {
+                      const rawName = String(spot?.name ?? '').trim()
+                      const isMaskedName = !revealPlaceName && rawName === '로컬 스팟'
+                      const title = isMaskedName ? String(spot?.desc ?? '').trim() : rawName
+                      return (
+                        <>
+                          <h3 className="gmc-spot-name">{title || '코스'}{spot?.time ? ` (${spot.time})` : ''}</h3>
+                          {!isMaskedName && spot?.desc && <p className="gmc-spot-desc">{spot.desc}</p>}
+                        </>
+                      )
+                    })()}
                   </article>
                 ))
               : !mapUnlocked && (


### PR DESCRIPTION
## 🔗 이슈 번호

Closes #413

## 💡 주요 변경 사항

- 결제 후(PAID/IN_PROGRESS) 코스 리스트에서 마스킹된 장소명('로컬 스팟') 텍스트는 숨김
- 대신 스팟 타이틀을 설명(desc)으로 표시하고, 시간(time)을 `설명 (시간)` 형태로 노출
- 완료(COMPLETED) 상태에서는 기존처럼 실제 장소명/설명 표시 유지

## ⚠️ 주의 사항 / 질문

- 기존 데이터(좌표 미저장)에서는 게스트 지도 마커 위치가 가이드 화면과 다를 수 있으며, 가이드가 코스를 재저장하면 좌표가 저장되어 일치도가 개선됩니다.

## 🗄️ 스키마 영향

- 없음

## ✅ 체크리스트

- [x] `cd frontend && npm run build`