### PR TITLE
Feat/be#422 module-openai 스캐폴딩 (Spring AI, api-server 미연결)

### DIFF
--- a/backend/module-openai/build.gradle
+++ b/backend/module-openai/build.gradle
@@ -1,0 +1,14 @@
+/**
+ * OpenAI(Spring AI) 연동 전용 모듈.
+ * {@code api-server}에 아직 조립하지 않는 한 런타임에 영향을 주지 않는다.
+ */
+dependencies {
+    implementation platform('org.springframework.ai:spring-ai-bom:1.0.0')
+    implementation 'org.springframework.ai:spring-ai-starter-model-openai'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+bootJar { enabled = false }
+jar { enabled = true }

--- a/backend/module-openai/src/main/java/com/team6/module/openai/package-info.java
+++ b/backend/module-openai/src/main/java/com/team6/module/openai/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Spring AI(OpenAI) 클라이언트 및 추후 LLM 기반 추출기 구현을 둔다.
+ */
+package com.team6.module.openai;

--- a/backend/settings.gradle
+++ b/backend/settings.gradle
@@ -7,4 +7,6 @@ include 'module-chat'
 include 'module-ai'
 include 'module-ai-integration'
 
+include 'module-openai'
+
 include 'module-common'


### PR DESCRIPTION
## 변경 범위
- `backend/settings.gradle`: `include 'module-openai'`
- `backend/module-openai/`: Spring AI BOM 1.0.0, `spring-ai-starter-model-openai`, 패키지 `com.team6.module.openai`
- **`api-server`에는 의존성을 추가하지 않음** → 기존 런타임/파서 MVP에 영향 없음

## 스키마 영향
- 없음 (DB/JPA 변경 없음)

## 검증
```bash
cd backend && ./gradlew :module-openai:compileJava
```

Closes #422


Made with [Cursor](https://cursor.com)