### PR TITLE
[Feat/be#424] OpenAI 조건부 ChatModel + api-server 연결

### DIFF
--- a/backend/api-server/build.gradle
+++ b/backend/api-server/build.gradle
@@ -5,6 +5,7 @@ dependencies {
     implementation project(':module-domain')
     implementation project(':module-ai')
     implementation project(':module-ai-integration')
+    implementation project(':module-openai')
     implementation project(':module-chat')
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 

--- a/backend/api-server/src/main/resources/application.yml
+++ b/backend/api-server/src/main/resources/application.yml
@@ -7,6 +7,12 @@ spring:
       max-file-size: 10MB
       max-request-size: 10MB
 
+# OpenAI(Spring AI) — 기본 비활성. 켤 때는 API 키(spring.ai.openai.api-key 등)가 필요하다.
+localguest:
+  openai:
+    enabled: false
+    model: gpt-4o-mini
+
 ---
 spring:
   config:

--- a/backend/module-openai/build.gradle
+++ b/backend/module-openai/build.gradle
@@ -1,10 +1,14 @@
 /**
  * OpenAI(Spring AI) 연동 전용 모듈.
- * {@code api-server}에 아직 조립하지 않는 한 런타임에 영향을 주지 않는다.
+ * <p>{@code spring-ai-starter-model-openai}는 자동구성이 항상 classpath에 올라가 API 키 없이 부팅하기 어려워,
+ * {@code spring-ai-openai}만 사용하고 빈은 {@code localguest.openai.enabled=true}일 때만 등록한다.
  */
 dependencies {
     implementation platform('org.springframework.ai:spring-ai-bom:1.0.0')
-    implementation 'org.springframework.ai:spring-ai-starter-model-openai'
+    implementation 'org.springframework.ai:spring-ai-openai'
+    implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.retry:spring-retry'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/backend/module-openai/src/main/java/com/team6/module/openai/config/LocalGuestOpenAiConfiguration.java
+++ b/backend/module-openai/src/main/java/com/team6/module/openai/config/LocalGuestOpenAiConfiguration.java
@@ -1,0 +1,93 @@
+package com.team6.module.openai.config;
+
+import io.micrometer.observation.ObservationRegistry;
+import org.springframework.ai.model.tool.DefaultToolCallingManager;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.ai.tool.execution.DefaultToolExecutionExceptionProcessor;
+import org.springframework.ai.tool.resolution.StaticToolCallbackResolver;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.DefaultResponseErrorHandler;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+
+/**
+ * OpenAI 클라이언트 빈 등록. 기본은 비활성({@code localguest.openai.enabled=false})이라 부팅에 영향이 없다.
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnProperty(prefix = "localguest.openai", name = "enabled", havingValue = "true", matchIfMissing = false)
+public class LocalGuestOpenAiConfiguration {
+
+    @Bean
+    public OpenAiApi openAiApi(LocalGuestOpenAiProperties props, Environment env) {
+        String resolved = resolveApiKey(props, env);
+        if (!StringUtils.hasText(resolved)) {
+            throw new IllegalStateException(
+                    "localguest.openai.enabled=true 인데 API 키가 없습니다. "
+                            + "spring.ai.openai.api-key, SPRING_AI_OPENAI_API_KEY, localguest.openai.api-key 중 하나를 설정하세요."
+            );
+        }
+        return OpenAiApi.builder()
+                .apiKey(resolved)
+                .restClientBuilder(RestClient.builder())
+                .webClientBuilder(WebClient.builder())
+                .responseErrorHandler(new DefaultResponseErrorHandler())
+                .build();
+    }
+
+    @Bean
+    public ToolCallingManager toolCallingManager() {
+        return DefaultToolCallingManager.builder()
+                .observationRegistry(ObservationRegistry.NOOP)
+                .toolCallbackResolver(new StaticToolCallbackResolver(List.of()))
+                .toolExecutionExceptionProcessor(DefaultToolExecutionExceptionProcessor.builder().build())
+                .build();
+    }
+
+    @Bean
+    public RetryTemplate openAiRetryTemplate() {
+        return new RetryTemplate();
+    }
+
+    @Bean
+    public OpenAiChatModel openAiChatModel(
+            OpenAiApi openAiApi,
+            LocalGuestOpenAiProperties props,
+            ToolCallingManager toolCallingManager,
+            RetryTemplate openAiRetryTemplate
+    ) {
+        OpenAiChatOptions options = new OpenAiChatOptions();
+        options.setModel(props.getModel());
+        return new OpenAiChatModel(
+                openAiApi,
+                options,
+                toolCallingManager,
+                openAiRetryTemplate,
+                ObservationRegistry.NOOP
+        );
+    }
+
+    private static String resolveApiKey(LocalGuestOpenAiProperties props, Environment env) {
+        if (StringUtils.hasText(props.getApiKey())) {
+            return props.getApiKey().trim();
+        }
+        String springAi = env.getProperty("spring.ai.openai.api-key");
+        if (StringUtils.hasText(springAi)) {
+            return springAi.trim();
+        }
+        String envVar = env.getProperty("SPRING_AI_OPENAI_API_KEY");
+        if (StringUtils.hasText(envVar)) {
+            return envVar.trim();
+        }
+        return "";
+    }
+}

--- a/backend/module-openai/src/main/java/com/team6/module/openai/config/LocalGuestOpenAiProperties.java
+++ b/backend/module-openai/src/main/java/com/team6/module/openai/config/LocalGuestOpenAiProperties.java
@@ -1,0 +1,31 @@
+package com.team6.module.openai.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * OpenAI 호출 스위치 및 기본 모델({@code localguest.openai.*}).
+ * <p>API 키는 {@code spring.ai.openai.api-key} 또는 환경 변수 {@code SPRING_AI_OPENAI_API_KEY}를
+ * 우선 사용하고, 필요 시 {@code localguest.openai.api-key}로 덮어쓸 수 있다.
+ */
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "localguest.openai")
+public class LocalGuestOpenAiProperties {
+
+    /**
+     * {@code true}일 때만 {@link org.springframework.ai.openai.OpenAiChatModel} 빈을 등록한다.
+     */
+    private boolean enabled = false;
+
+    /**
+     * 비어 있지 않으면 최우선으로 사용하는 API 키(로컬 전용). 비밀 저장소에만 둔다.
+     */
+    private String apiKey = "";
+
+    /**
+     * 기본 채팅 모델명(OpenAI API 기준).
+     */
+    private String model = "gpt-4o-mini";
+}

--- a/backend/module-openai/src/main/java/com/team6/module/openai/config/LocalGuestOpenAiPropertiesBootstrapConfiguration.java
+++ b/backend/module-openai/src/main/java/com/team6/module/openai/config/LocalGuestOpenAiPropertiesBootstrapConfiguration.java
@@ -1,0 +1,13 @@
+package com.team6.module.openai.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * {@link LocalGuestOpenAiProperties}를 항상 바인딩한다(기본 {@code enabled=false} 포함).
+ * 실제 OpenAI 빈은 {@link LocalGuestOpenAiConfiguration}에서만 조건부로 등록한다.
+ */
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(LocalGuestOpenAiProperties.class)
+public class LocalGuestOpenAiPropertiesBootstrapConfiguration {
+}

--- a/backend/module-openai/src/main/java/com/team6/module/openai/package-info.java
+++ b/backend/module-openai/src/main/java/com/team6/module/openai/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Spring AI(OpenAI) 클라이언트 및 추후 LLM 기반 추출기 구현을 둔다.
+ * <p>설정은 {@code com.team6.module.openai.config}의 {@code localguest.openai.*}를 참고한다.
  */
 package com.team6.module.openai;


### PR DESCRIPTION
## 변경 범위
- `module-openai`: `spring-ai-starter-model-openai` 제거 → `spring-ai-openai` + 수동 빈 등록(자동구성 미사용)으로 **API 키 없이도 기본 부팅** 유지
- `localguest.openai.enabled`가 `true`일 때만 `OpenAiApi` / `OpenAiChatModel` 등록. 키는 `localguest.openai.api-key` → `spring.ai.openai.api-key` → `SPRING_AI_OPENAI_API_KEY` 순으로 해석
- `LocalGuestOpenAiPropertiesBootstrapConfiguration`: 프로퍼티 바인딩은 항상 활성(기본 `enabled=false`)
- `api-server`: `module-openai` 의존성 추가, `application.yml`에 기본값(`enabled: false`, `model: gpt-4o-mini`)

## 스키마 영향
- 없음

## 검증
```bash
cd backend && ./gradlew :module-openai:compileJava :api-server:compileJava :module-ai:test
```

Closes #424


Made with [Cursor](https://cursor.com)