### PR TITLE
[Feat/be#426] LLM 프롬프트 추출 SPI + OpenAI 스텁

### DIFF
--- a/backend/api-server/src/main/resources/application.yml
+++ b/backend/api-server/src/main/resources/application.yml
@@ -12,6 +12,9 @@ localguest:
   openai:
     enabled: false
     model: gpt-4o-mini
+  ai:
+    # LLM 프롬프트 추출(LlmPromptExtractor 빈 + OpenAI 활성 시). 스텁 단계에서는 false 권장.
+    llm-prompt-extraction-enabled: false
 
 ---
 spring:

--- a/backend/module-ai/src/main/java/com/team6/module/ai/config/LocalGuestAiProperties.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/config/LocalGuestAiProperties.java
@@ -62,6 +62,12 @@ public class LocalGuestAiProperties {
      */
     private DiversityRerankSettings diversityRerank = new DiversityRerankSettings();
 
+    /**
+     * {@code true}이면 {@link com.team6.module.ai.spi.LlmPromptExtractor} 빈이 있을 때 LLM 추출을 시도한다.
+     * empty·예외 시에는 항상 룰 기반 파서로 폴백한다({@code localguest.ai.llm-prompt-extraction-enabled}).
+     */
+    private boolean llmPromptExtractionEnabled = false;
+
     @Getter
     @Setter
     public static class ParserSettings {

--- a/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
@@ -2,8 +2,10 @@ package com.team6.module.ai.service;
 
 import com.team6.module.ai.dto.request.GuideRecommendRequest;
 import com.team6.module.ai.dto.response.GuideRecommendResponse;
+import com.team6.module.ai.config.LocalGuestAiProperties;
 import com.team6.module.ai.config.ScoringPolicySnapshot;
 import com.team6.module.ai.parser.PromptParser;
+import com.team6.module.ai.spi.LlmPromptExtractor;
 import com.team6.module.ai.support.AdjacentRegionProvider;
 import com.team6.module.ai.support.AiRecommendationMetrics;
 import com.team6.module.ai.support.AiRecommendationTuning;
@@ -11,6 +13,8 @@ import com.team6.module.ai.support.ConceptSummaryGenerator;
 import com.team6.module.ai.support.RecommendationNoticeCodes;
 import com.team6.module.ai.support.RegionCandidateExpansion;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 
 import com.team6.module.ai.dto.response.GuideRecommendItem;
@@ -22,6 +26,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -47,18 +52,27 @@ public class PromptRecommendationService {
     // 운영 중 조정 가능한 추천 임계값(low-signal 점수, fallback 개선폭 등) 스냅샷.
     private final ScoringPolicySnapshot scoringPolicy;
 
+    private final LocalGuestAiProperties aiProperties;
+
+    @Nullable
+    private final LlmPromptExtractor llmPromptExtractor;
+
     public PromptRecommendationService(
             PromptParser promptParser,
             AiRecommendationService aiRecommendationService,
             AdjacentRegionProvider adjacentRegionProvider,
             AiRecommendationMetrics metrics,
-            ScoringPolicySnapshot scoringPolicy
+            ScoringPolicySnapshot scoringPolicy,
+            LocalGuestAiProperties aiProperties,
+            @Autowired(required = false) @Nullable LlmPromptExtractor llmPromptExtractor
     ) {
         this.promptParser = promptParser;
         this.aiRecommendationService = aiRecommendationService;
         this.adjacentRegionProvider = adjacentRegionProvider;
         this.metrics = metrics;
         this.scoringPolicy = scoringPolicy;
+        this.aiProperties = aiProperties;
+        this.llmPromptExtractor = llmPromptExtractor;
     }
 
     private static final String NOTICE_REGION_REQUIRED =
@@ -119,7 +133,7 @@ public class PromptRecommendationService {
             Integer resolvedTopN = (topN == null || topN <= 0)
                     ? AiRecommendationTuning.DEFAULT_TOP_N
                     : topN;
-            GuideRecommendRequest parsed = promptParser.parse(prompt, resolvedTopN, guideCandidates);
+            GuideRecommendRequest parsed = parsePromptToRequest(prompt, resolvedTopN, guideCandidates);
 
             // 2) 지역이 없으면 추천 품질이 크게 떨어지기 때문에 여기서 바로 short-circuit 한다.
             // 대신 빈 응답만 보내지 않고 conceptSummary / keywords / matchRequestDraft는 같이 만들어
@@ -832,6 +846,25 @@ public class PromptRecommendationService {
         } catch (Exception e) {
             log.debug("[AI_RECOMMEND] logging skipped: {}", e.toString());
         }
+    }
+
+    private GuideRecommendRequest parsePromptToRequest(
+            String prompt,
+            int resolvedTopN,
+            List<GuideRecommendRequest.GuideCandidateDto> guideCandidates
+    ) {
+        if (Boolean.TRUE.equals(aiProperties.isLlmPromptExtractionEnabled()) && llmPromptExtractor != null) {
+            try {
+                Optional<GuideRecommendRequest> llm =
+                        llmPromptExtractor.tryExtract(prompt, resolvedTopN, guideCandidates);
+                if (llm.isPresent()) {
+                    return llm.get();
+                }
+            } catch (Exception e) {
+                log.warn("[AI_PROMPT] LLM 추출 실패, 룰 파서로 폴백: {}", e.toString());
+            }
+        }
+        return promptParser.parse(prompt, resolvedTopN, guideCandidates);
     }
 
     private static Long topGuideId(GuideRecommendResponse resp) {

--- a/backend/module-ai/src/main/java/com/team6/module/ai/spi/LlmPromptExtractor.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/spi/LlmPromptExtractor.java
@@ -1,0 +1,24 @@
+package com.team6.module.ai.spi;
+
+import com.team6.module.ai.dto.request.GuideRecommendRequest;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 자연어 프롬프트를 {@link GuideRecommendRequest}로 바꾸는 LLM 기반 추출기 SPI.
+ * <p>구현체는 {@code module-openai} 등에서 제공하며, 비어 있으면({@link Optional#empty()}) 호출부가
+ * 룰 기반 {@link com.team6.module.ai.parser.PromptParser}로 폴백한다.
+ */
+@FunctionalInterface
+public interface LlmPromptExtractor {
+
+    /**
+     * @return 추출 성공 시 값, 아니면 empty(호출부에서 룰 파서 사용)
+     */
+    Optional<GuideRecommendRequest> tryExtract(
+            String prompt,
+            int topN,
+            List<GuideRecommendRequest.GuideCandidateDto> guideCandidates
+    );
+}

--- a/backend/module-ai/src/test/java/com/team6/module/ai/regression/AiRecommendationRegressionTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/regression/AiRecommendationRegressionTest.java
@@ -522,7 +522,9 @@ class AiRecommendationRegressionTest {
                 ai,
                 adjacent,
                 metrics,
-                scoring
+                scoring,
+                aiProps,
+                null
         );
     }
 

--- a/backend/module-ai/src/test/java/com/team6/module/ai/service/PromptRecommendationServiceTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/service/PromptRecommendationServiceTest.java
@@ -56,7 +56,9 @@ class PromptRecommendationServiceTest {
                 aiRecommendationService,
                 adjacent,
                 metrics,
-                scoring
+                scoring,
+                aiProps,
+                null
         );
     }
 

--- a/backend/module-openai/build.gradle
+++ b/backend/module-openai/build.gradle
@@ -4,6 +4,8 @@
  * {@code spring-ai-openai}만 사용하고 빈은 {@code localguest.openai.enabled=true}일 때만 등록한다.
  */
 dependencies {
+    implementation project(':module-ai')
+
     implementation platform('org.springframework.ai:spring-ai-bom:1.0.0')
     implementation 'org.springframework.ai:spring-ai-openai'
     implementation 'org.springframework.boot:spring-boot-starter'

--- a/backend/module-openai/src/main/java/com/team6/module/openai/config/LocalGuestOpenAiConfiguration.java
+++ b/backend/module-openai/src/main/java/com/team6/module/openai/config/LocalGuestOpenAiConfiguration.java
@@ -1,11 +1,14 @@
 package com.team6.module.openai.config;
 
+import com.team6.module.ai.spi.LlmPromptExtractor;
+import com.team6.module.openai.prompt.OpenAiLlmPromptExtractor;
 import io.micrometer.observation.ObservationRegistry;
 import org.springframework.ai.model.tool.DefaultToolCallingManager;
 import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.openai.OpenAiChatModel;
 import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.ai.tool.execution.DefaultToolExecutionExceptionProcessor;
 import org.springframework.ai.tool.resolution.StaticToolCallbackResolver;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -74,6 +77,13 @@ public class LocalGuestOpenAiConfiguration {
                 openAiRetryTemplate,
                 ObservationRegistry.NOOP
         );
+    }
+
+    @Bean
+    @ConditionalOnBean(OpenAiChatModel.class)
+    @ConditionalOnProperty(prefix = "localguest.ai", name = "llm-prompt-extraction-enabled", havingValue = "true", matchIfMissing = false)
+    public LlmPromptExtractor llmPromptExtractor(OpenAiChatModel chatModel) {
+        return new OpenAiLlmPromptExtractor(chatModel);
     }
 
     private static String resolveApiKey(LocalGuestOpenAiProperties props, Environment env) {

--- a/backend/module-openai/src/main/java/com/team6/module/openai/package-info.java
+++ b/backend/module-openai/src/main/java/com/team6/module/openai/package-info.java
@@ -1,5 +1,6 @@
 /**
  * Spring AI(OpenAI) 클라이언트 및 추후 LLM 기반 추출기 구현을 둔다.
  * <p>설정은 {@code com.team6.module.openai.config}의 {@code localguest.openai.*}를 참고한다.
+ * LLM 프롬프트 추출 SPI 구현은 {@code com.team6.module.openai.prompt}에 둔다({@code localguest.ai.llm-prompt-extraction-enabled}).
  */
 package com.team6.module.openai;

--- a/backend/module-openai/src/main/java/com/team6/module/openai/prompt/OpenAiLlmPromptExtractor.java
+++ b/backend/module-openai/src/main/java/com/team6/module/openai/prompt/OpenAiLlmPromptExtractor.java
@@ -1,0 +1,31 @@
+package com.team6.module.openai.prompt;
+
+import com.team6.module.ai.dto.request.GuideRecommendRequest;
+import com.team6.module.ai.spi.LlmPromptExtractor;
+import org.springframework.ai.openai.OpenAiChatModel;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * OpenAI 기반 프롬프트 추출기. 현재는 스텁({@link Optional#empty()})으로 두고,
+ * 호출부({@code PromptRecommendationService})가 룰 파서로 폴백한다.
+ */
+public final class OpenAiLlmPromptExtractor implements LlmPromptExtractor {
+
+    @SuppressWarnings("unused")
+    private final OpenAiChatModel chatModel;
+
+    public OpenAiLlmPromptExtractor(OpenAiChatModel chatModel) {
+        this.chatModel = chatModel;
+    }
+
+    @Override
+    public Optional<GuideRecommendRequest> tryExtract(
+            String prompt,
+            int topN,
+            List<GuideRecommendRequest.GuideCandidateDto> guideCandidates
+    ) {
+        return Optional.empty();
+    }
+}


### PR DESCRIPTION
## 변경 범위
- `module-ai`: `LlmPromptExtractor` SPI, `LocalGuestAiProperties.llmPromptExtractionEnabled` (`localguest.ai.llm-prompt-extraction-enabled`)
- `PromptRecommendationService`: 플래그+빈이 있으면 LLM 추출 시도 → empty/예외 시 **룰 `PromptParser` 폴백**
- `module-openai`: `module-ai` 의존, `OpenAiLlmPromptExtractor` 스텁(`Optional.empty()`), `OpenAiChatModel` 존재·플래그 true일 때만 `LlmPromptExtractor` 빈 등록
- `application.yml`: 기본 `llm-prompt-extraction-enabled: false`

## 스키마
- 없음

## 검증
```bash
cd backend && ./gradlew :module-openai:compileJava :module-ai:test :api-server:compileJava :module-ai-integration:compileJava
```

## 비고
- 스텁 단계라 **동작은 기존과 동일**(항상 룰 파서). 이후 `OpenAiLlmPromptExtractor`에 JSON 스키마·`GuideRecommendRequest` 매핑만 채우면 됨.
- 로컬에서 키는 채팅에 노출하지 않아도 됨(빈 문자열/환경 변수 등 기존 방식 유지).

Closes #426


Made with [Cursor](https://cursor.com)