### PR TITLE
[Feat/be#428] OpenAI LLM 프롬프트 추출 실구현

### DIFF
--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationTuning.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationTuning.java
@@ -19,7 +19,7 @@ public final class AiRecommendationTuning {
     /**
      * 룰/스코어/Reason/응답 계약이 바뀔 때마다 올린다. 로그·API에서 동일 프롬프트 비교 시 정책 변경 여부를 구분하는 데 쓴다.
      */
-    public static final String POLICY_VERSION = "2026.04.30";
+    public static final String POLICY_VERSION = "2026.05.01";
 
     public static final int DEFAULT_TOP_N = 3;
 

--- a/backend/module-openai/src/main/java/com/team6/module/openai/config/LocalGuestOpenAiConfiguration.java
+++ b/backend/module-openai/src/main/java/com/team6/module/openai/config/LocalGuestOpenAiConfiguration.java
@@ -1,5 +1,6 @@
 package com.team6.module.openai.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.team6.module.ai.spi.LlmPromptExtractor;
 import com.team6.module.openai.prompt.OpenAiLlmPromptExtractor;
 import io.micrometer.observation.ObservationRegistry;
@@ -82,8 +83,8 @@ public class LocalGuestOpenAiConfiguration {
     @Bean
     @ConditionalOnBean(OpenAiChatModel.class)
     @ConditionalOnProperty(prefix = "localguest.ai", name = "llm-prompt-extraction-enabled", havingValue = "true", matchIfMissing = false)
-    public LlmPromptExtractor llmPromptExtractor(OpenAiChatModel chatModel) {
-        return new OpenAiLlmPromptExtractor(chatModel);
+    public LlmPromptExtractor llmPromptExtractor(OpenAiChatModel chatModel, ObjectMapper objectMapper) {
+        return new OpenAiLlmPromptExtractor(chatModel, objectMapper);
     }
 
     private static String resolveApiKey(LocalGuestOpenAiProperties props, Environment env) {

--- a/backend/module-openai/src/main/java/com/team6/module/openai/prompt/LlmGuideRecommendJson.java
+++ b/backend/module-openai/src/main/java/com/team6/module/openai/prompt/LlmGuideRecommendJson.java
@@ -1,0 +1,39 @@
+package com.team6.module.openai.prompt;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+/**
+ * LLM이 반환하는 추천 요청 JSON과 1:1에 가깝게 맞춘 DTO(알 수 없는 키는 무시).
+ */
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class LlmGuideRecommendJson {
+
+    private String region;
+    private String travelStyle;
+    private String budgetLevel;
+    private Integer budgetMinWon;
+    private Integer budgetMaxWon;
+    private String budgetScope;
+    private Boolean strictBudget;
+    private String companionType;
+    private List<String> activityTags;
+    private List<String> requiredActivityTags;
+    private List<String> niceToHaveActivityTags;
+    private List<String> preferredLanguages;
+    private List<String> requiredLanguages;
+    private List<String> niceToHaveLanguages;
+    private Boolean allowAdjacentRegion;
+    private Integer headcount;
+    private Integer durationDays;
+    private List<String> excludedActivityTags;
+    private List<String> excludedRegions;
+    private List<String> excludedTravelStyles;
+    private List<String> excludedLanguages;
+    private List<String> softPenaltyActivityTags;
+}

--- a/backend/module-openai/src/main/java/com/team6/module/openai/prompt/OpenAiLlmPromptExtractor.java
+++ b/backend/module-openai/src/main/java/com/team6/module/openai/prompt/OpenAiLlmPromptExtractor.java
@@ -1,23 +1,44 @@
 package com.team6.module.openai.prompt;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.team6.module.ai.dto.request.GuideRecommendRequest;
 import com.team6.module.ai.spi.LlmPromptExtractor;
-import org.springframework.ai.openai.OpenAiChatModel;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.ai.openai.api.ResponseFormat;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
 import java.util.Optional;
 
 /**
- * OpenAI 기반 프롬프트 추출기. 현재는 스텁({@link Optional#empty()})으로 두고,
- * 호출부({@code PromptRecommendationService})가 룰 파서로 폴백한다.
+ * OpenAI(ChatModel)로 프롬프트를 구조화한 뒤 {@link GuideRecommendRequest}로 만든다.
+ * <p>후보 목록·{@code topN}은 호출 인자를 그대로 쓰며, LLM 출력의 해당 필드는 무시한다.
  */
+@Slf4j
 public final class OpenAiLlmPromptExtractor implements LlmPromptExtractor {
 
-    @SuppressWarnings("unused")
-    private final OpenAiChatModel chatModel;
+    private static final String SYSTEM_INSTRUCTION = """
+            당신은 여행 매칭용 정보 추출기다. 사용자 한국어 입력만 보고 아래 키를 가진 JSON 객체 하나만 출력한다. 설명·마크다운·코드펜스 금지.
+            키: region, travelStyle, budgetLevel, budgetMinWon, budgetMaxWon, budgetScope, strictBudget, companionType,
+            activityTags, requiredActivityTags, niceToHaveActivityTags, preferredLanguages, requiredLanguages, niceToHaveLanguages,
+            allowAdjacentRegion, headcount, durationDays, excludedActivityTags, excludedRegions, excludedTravelStyles, excludedLanguages, softPenaltyActivityTags.
+            모르면 null. 배열은 JSON 배열(빈 배열 가능). region은 한국어 지역명이면 그대로(예: 제주, 서울, 부산). 숫자는 정수.
+            """;
 
-    public OpenAiLlmPromptExtractor(OpenAiChatModel chatModel) {
+    private final ChatModel chatModel;
+    private final ObjectMapper objectMapper;
+
+    public OpenAiLlmPromptExtractor(ChatModel chatModel, ObjectMapper objectMapper) {
         this.chatModel = chatModel;
+        this.objectMapper = objectMapper;
     }
 
     @Override
@@ -26,6 +47,110 @@ public final class OpenAiLlmPromptExtractor implements LlmPromptExtractor {
             int topN,
             List<GuideRecommendRequest.GuideCandidateDto> guideCandidates
     ) {
-        return Optional.empty();
+        if (!StringUtils.hasText(prompt)) {
+            return Optional.empty();
+        }
+        try {
+            OpenAiChatOptions opts = buildCallOptions();
+            Prompt p = new Prompt(
+                    List.of(new SystemMessage(SYSTEM_INSTRUCTION), new UserMessage(prompt.trim())),
+                    opts
+            );
+            ChatResponse response = chatModel.call(p);
+            String raw = response.getResult().getOutput().getText();
+            String json = stripJsonFence(raw);
+            if (!StringUtils.hasText(json)) {
+                log.warn("[OPEN_AI_PROMPT] 빈 응답, 룰 파서 폴백");
+                return Optional.empty();
+            }
+            LlmGuideRecommendJson parsed = objectMapper.readValue(json, LlmGuideRecommendJson.class);
+            GuideRecommendRequest built = toGuideRequest(parsed, topN, guideCandidates);
+            if (!StringUtils.hasText(built.getRegion())) {
+                log.warn("[OPEN_AI_PROMPT] LLM 결과에 region 없음, 룰 파서 폴백");
+                return Optional.empty();
+            }
+            return Optional.of(built);
+        } catch (Exception e) {
+            log.warn("[OPEN_AI_PROMPT] LLM 추출 실패, 룰 파서 폴백: {}", e.toString());
+            return Optional.empty();
+        }
+    }
+
+    private OpenAiChatOptions buildCallOptions() {
+        OpenAiChatOptions base = chatModel.getDefaultOptions() instanceof OpenAiChatOptions o ? o : null;
+        OpenAiChatOptions opts = base != null ? OpenAiChatOptions.fromOptions(base) : new OpenAiChatOptions();
+        opts.setTemperature(0.2);
+        opts.setResponseFormat(ResponseFormat.builder().type(ResponseFormat.Type.JSON_OBJECT).build());
+        return opts;
+    }
+
+    private static String stripJsonFence(String text) {
+        if (text == null) {
+            return "";
+        }
+        String t = text.trim();
+        if (t.startsWith("```")) {
+            int firstNl = t.indexOf('\n');
+            if (firstNl > 0) {
+                t = t.substring(firstNl + 1);
+            }
+            int fence = t.lastIndexOf("```");
+            if (fence >= 0) {
+                t = t.substring(0, fence).trim();
+            }
+        }
+        return t.trim();
+    }
+
+    private static GuideRecommendRequest toGuideRequest(
+            LlmGuideRecommendJson j,
+            int topN,
+            List<GuideRecommendRequest.GuideCandidateDto> guideCandidates
+    ) {
+        return GuideRecommendRequest.builder()
+                .region(trimToNull(j.getRegion()))
+                .travelStyle(trimToNull(j.getTravelStyle()))
+                .budgetLevel(trimToNull(j.getBudgetLevel()))
+                .budgetMinWon(j.getBudgetMinWon())
+                .budgetMaxWon(j.getBudgetMaxWon())
+                .budgetScope(trimToNull(j.getBudgetScope()))
+                .strictBudget(j.getStrictBudget())
+                .companionType(trimToNull(j.getCompanionType()))
+                .activityTags(copyList(j.getActivityTags()))
+                .requiredActivityTags(copyList(j.getRequiredActivityTags()))
+                .niceToHaveActivityTags(copyList(j.getNiceToHaveActivityTags()))
+                .preferredLanguages(copyList(j.getPreferredLanguages()))
+                .requiredLanguages(copyList(j.getRequiredLanguages()))
+                .niceToHaveLanguages(copyList(j.getNiceToHaveLanguages()))
+                .allowAdjacentRegion(j.getAllowAdjacentRegion())
+                .headcount(j.getHeadcount())
+                .durationDays(j.getDurationDays())
+                .excludedActivityTags(copyList(j.getExcludedActivityTags()))
+                .excludedRegions(copyList(j.getExcludedRegions()))
+                .excludedTravelStyles(copyList(j.getExcludedTravelStyles()))
+                .excludedLanguages(copyList(j.getExcludedLanguages()))
+                .softPenaltyActivityTags(copyList(j.getSoftPenaltyActivityTags()))
+                .topN(topN)
+                .guideCandidates(guideCandidates)
+                .build();
+    }
+
+    private static String trimToNull(String s) {
+        if (s == null) {
+            return null;
+        }
+        String t = s.trim();
+        return t.isEmpty() ? null : t;
+    }
+
+    private static List<String> copyList(List<String> raw) {
+        if (raw == null || raw.isEmpty()) {
+            return null;
+        }
+        List<String> cleaned = raw.stream()
+                .map(s -> s == null ? "" : s.trim())
+                .filter(s -> !s.isEmpty())
+                .toList();
+        return cleaned.isEmpty() ? null : List.copyOf(cleaned);
     }
 }

--- a/backend/module-openai/src/test/java/com/team6/module/openai/prompt/OpenAiLlmPromptExtractorTest.java
+++ b/backend/module-openai/src/test/java/com/team6/module/openai/prompt/OpenAiLlmPromptExtractorTest.java
@@ -1,0 +1,67 @@
+package com.team6.module.openai.prompt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team6.module.ai.dto.request.GuideRecommendRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.openai.OpenAiChatOptions;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OpenAiLlmPromptExtractorTest {
+
+    @Mock
+    private ChatModel chatModel;
+
+    @Test
+    void tryExtract_mapsJson_and_fixesTopNAndCandidates() {
+        OpenAiChatOptions def = new OpenAiChatOptions();
+        def.setModel("gpt-4o-mini");
+        when(chatModel.getDefaultOptions()).thenReturn(def);
+        when(chatModel.call(any(Prompt.class))).thenReturn(ChatResponse.builder()
+                .generations(List.of(new Generation(new AssistantMessage(
+                        "{\"region\":\"제주\",\"activityTags\":[\"맛집\"]}"
+                ))))
+                .build());
+
+        OpenAiLlmPromptExtractor ext = new OpenAiLlmPromptExtractor(chatModel, new ObjectMapper());
+        GuideRecommendRequest.GuideCandidateDto c = GuideRecommendRequest.GuideCandidateDto.builder()
+                .guideId(9L)
+                .guideName("가이드")
+                .region("제주")
+                .build();
+        Optional<GuideRecommendRequest> out = ext.tryExtract("제주 맛집", 5, List.of(c));
+
+        assertThat(out).isPresent();
+        assertThat(out.get().getRegion()).isEqualTo("제주");
+        assertThat(out.get().getTopN()).isEqualTo(5);
+        assertThat(out.get().getGuideCandidates()).containsExactly(c);
+        assertThat(out.get().getActivityTags()).containsExactly("맛집");
+    }
+
+    @Test
+    void tryExtract_emptyRegion_returnsEmpty() {
+        OpenAiChatOptions def = new OpenAiChatOptions();
+        def.setModel("gpt-4o-mini");
+        when(chatModel.getDefaultOptions()).thenReturn(def);
+        when(chatModel.call(any(Prompt.class))).thenReturn(ChatResponse.builder()
+                .generations(List.of(new Generation(new AssistantMessage("{}"))))
+                .build());
+
+        OpenAiLlmPromptExtractor ext = new OpenAiLlmPromptExtractor(chatModel, new ObjectMapper());
+        assertThat(ext.tryExtract("?", 2, List.of())).isEmpty();
+    }
+}


### PR DESCRIPTION
## 변경 범위
- `OpenAiLlmPromptExtractor`: `ChatModel` 호출, `response_format=json_object`, JSON→`GuideRecommendRequest` 매핑. `region` 없으면 empty(룰 파서 폴백). `topN`·`guideCandidates`는 인자 고정
- `LlmGuideRecommendJson`: LLM 출력 DTO
- `LocalGuestOpenAiConfiguration`: `ObjectMapper` 주입
- `AiRecommendationTuning.POLICY_VERSION` → `2026.05.01` (캐시·응답 계약)
- `OpenAiLlmPromptExtractorTest`: Mock 기반 단위 테스트

## 스키마
- API 응답 `policyVersion` 문자열 변경

## 검증
```bash
cd backend && ./gradlew :module-openai:test :module-ai:test :api-server:compileJava
```

Closes #428


Made with [Cursor](https://cursor.com)