### PR TITLE
[Feat/be#430] LLM 가이드 불릿·specialRequests 및 요약 반영

### DIFF
--- a/backend/module-ai/src/main/java/com/team6/module/ai/dto/request/GuideRecommendRequest.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/dto/request/GuideRecommendRequest.java
@@ -50,6 +50,16 @@ public class GuideRecommendRequest {
      * 하드 제외가 아니라, 가이드가 해당 활동을 강하게 전문으로 내세울 때 점수를 깎는(soft) 태그.
      */
     private List<String> softPenaltyActivityTags;
+    /**
+     * LLM 전용: 가이드에게 보여줄 불릿 한 줄(반말). OpenAPI·일반 JSON 응답에는 실리지 않는다.
+     */
+    @JsonIgnore
+    private List<String> llmGuideBullets;
+    /**
+     * LLM 전용: 특별 요청 문단. OpenAPI·일반 JSON 응답에는 실리지 않는다.
+     */
+    @JsonIgnore
+    private String llmSpecialRequests;
     private Integer topN;
     private List<GuideCandidateDto> guideCandidates;
 

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationTuning.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationTuning.java
@@ -19,7 +19,7 @@ public final class AiRecommendationTuning {
     /**
      * 룰/스코어/Reason/응답 계약이 바뀔 때마다 올린다. 로그·API에서 동일 프롬프트 비교 시 정책 변경 여부를 구분하는 데 쓴다.
      */
-    public static final String POLICY_VERSION = "2026.05.01";
+    public static final String POLICY_VERSION = "2026.05.02";
 
     public static final int DEFAULT_TOP_N = 3;
 

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/ConceptSummaryGenerator.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/ConceptSummaryGenerator.java
@@ -2,6 +2,7 @@ package com.team6.module.ai.support;
 
 import com.team6.module.ai.dto.request.GuideRecommendRequest;
 import com.team6.module.ai.parser.KeywordNormalizer;
+import org.springframework.util.StringUtils;
 
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -16,6 +17,13 @@ public final class ConceptSummaryGenerator {
     public static String generate(GuideRecommendRequest req) {
         if (req == null) {
             return null;
+        }
+
+        if (hasLlmGuideCopy(req)) {
+            String llm = formatLlmGuideCopy(req.getLlmGuideBullets(), req.getLlmSpecialRequests());
+            if (StringUtils.hasText(llm)) {
+                return llm;
+            }
         }
 
         StringBuilder sb = new StringBuilder();
@@ -74,6 +82,37 @@ public final class ConceptSummaryGenerator {
         return result.isBlank() ? null : result;
     }
 
+    private static boolean hasLlmGuideCopy(GuideRecommendRequest req) {
+        return (req.getLlmGuideBullets() != null && !req.getLlmGuideBullets().isEmpty())
+                || StringUtils.hasText(req.getLlmSpecialRequests());
+    }
+
+    /**
+     * LLM이 채운 불릿·특별 요청을 한 덩어리 요약 문자열로 만든다(가이드/응답 요약 공용).
+     */
+    public static String formatLlmGuideCopy(List<String> bullets, String specialRequests) {
+        StringBuilder sb = new StringBuilder();
+        if (bullets != null) {
+            for (String b : bullets) {
+                if (b == null || b.isBlank()) {
+                    continue;
+                }
+                if (sb.length() > 0) {
+                    sb.append('\n');
+                }
+                sb.append("• ").append(b.trim());
+            }
+        }
+        if (StringUtils.hasText(specialRequests)) {
+            if (sb.length() > 0) {
+                sb.append("\n\n");
+            }
+            sb.append(specialRequests.trim());
+        }
+        String out = sb.toString().trim();
+        return out.isBlank() ? null : out;
+    }
+
     public static String generateMatchRequestConcept(GuideRecommendRequest req) {
         if (req == null) {
             return null;
@@ -110,6 +149,15 @@ public final class ConceptSummaryGenerator {
         }
 
         String result = String.join(" / ", parts).trim();
+        if (hasLlmGuideCopy(req)) {
+            String llm = formatLlmGuideCopy(req.getLlmGuideBullets(), req.getLlmSpecialRequests());
+            if (StringUtils.hasText(llm)) {
+                if (StringUtils.hasText(result)) {
+                    return llm + "\n\n" + result;
+                }
+                return llm;
+            }
+        }
         return result.isBlank() ? null : result;
     }
 

--- a/backend/module-ai/src/test/java/com/team6/module/ai/support/ConceptSummaryGeneratorLlmTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/support/ConceptSummaryGeneratorLlmTest.java
@@ -1,0 +1,36 @@
+package com.team6.module.ai.support;
+
+import com.team6.module.ai.dto.request.GuideRecommendRequest;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConceptSummaryGeneratorLlmTest {
+
+    @Test
+    void generate_prefersLlmBulletsAndSpecialRequests() {
+        GuideRecommendRequest req = GuideRecommendRequest.builder()
+                .region("제주")
+                .durationDays(2)
+                .llmGuideBullets(List.of("맛집 위주"))
+                .llmSpecialRequests("애매한 일정 조정 가능해")
+                .build();
+
+        assertThat(ConceptSummaryGenerator.generate(req)).isEqualTo("• 맛집 위주\n\n애매한 일정 조정 가능해");
+    }
+
+    @Test
+    void generateMatchRequestConcept_prefixesLlmCopy() {
+        GuideRecommendRequest req = GuideRecommendRequest.builder()
+                .region("부산")
+                .llmGuideBullets(List.of("야경 좋아해"))
+                .durationDays(1)
+                .build();
+
+        String concept = ConceptSummaryGenerator.generateMatchRequestConcept(req);
+        assertThat(concept).startsWith("• 야경 좋아해");
+        assertThat(concept).contains("부산 여행");
+    }
+}

--- a/backend/module-openai/src/main/java/com/team6/module/openai/prompt/LlmCopyPiiMasker.java
+++ b/backend/module-openai/src/main/java/com/team6/module/openai/prompt/LlmCopyPiiMasker.java
@@ -1,0 +1,21 @@
+package com.team6.module.openai.prompt;
+
+/**
+ * LLM이 만든 가이드 노출용 문자열에서 흔한 PII 패턴만 얕게 가린다.
+ */
+public final class LlmCopyPiiMasker {
+
+    private LlmCopyPiiMasker() {
+    }
+
+    public static String mask(String text) {
+        if (text == null || text.isEmpty()) {
+            return text;
+        }
+        String t = text;
+        t = t.replaceAll("(?i)(010|01[016789])[-.\\s]?\\d{3,4}[-.\\s]?\\d{4}", "[연락처 생략]");
+        t = t.replaceAll("\\d{2,3}-\\d{3,4}-\\d{4}", "[연락처 생략]");
+        t = t.replaceAll("\\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}\\b", "[이메일 생략]");
+        return t;
+    }
+}

--- a/backend/module-openai/src/main/java/com/team6/module/openai/prompt/LlmGuideRecommendJson.java
+++ b/backend/module-openai/src/main/java/com/team6/module/openai/prompt/LlmGuideRecommendJson.java
@@ -36,4 +36,8 @@ public class LlmGuideRecommendJson {
     private List<String> excludedTravelStyles;
     private List<String> excludedLanguages;
     private List<String> softPenaltyActivityTags;
+    /** 가이드에게 보여줄 짧은 불릿(반말 한 줄씩). */
+    private List<String> guideBullets;
+    /** 특별 요청 등 문단으로 전달할 내용. */
+    private String specialRequests;
 }

--- a/backend/module-openai/src/main/java/com/team6/module/openai/prompt/OpenAiLlmPromptExtractor.java
+++ b/backend/module-openai/src/main/java/com/team6/module/openai/prompt/OpenAiLlmPromptExtractor.java
@@ -29,8 +29,11 @@ public final class OpenAiLlmPromptExtractor implements LlmPromptExtractor {
             당신은 여행 매칭용 정보 추출기다. 사용자 한국어 입력만 보고 아래 키를 가진 JSON 객체 하나만 출력한다. 설명·마크다운·코드펜스 금지.
             키: region, travelStyle, budgetLevel, budgetMinWon, budgetMaxWon, budgetScope, strictBudget, companionType,
             activityTags, requiredActivityTags, niceToHaveActivityTags, preferredLanguages, requiredLanguages, niceToHaveLanguages,
-            allowAdjacentRegion, headcount, durationDays, excludedActivityTags, excludedRegions, excludedTravelStyles, excludedLanguages, softPenaltyActivityTags.
+            allowAdjacentRegion, headcount, durationDays, excludedActivityTags, excludedRegions, excludedTravelStyles, excludedLanguages, softPenaltyActivityTags,
+            guideBullets, specialRequests.
+            guideBullets는 가이드에게 보여줄 짧은 한국어 반말 불릿(한 줄당 한 가지). specialRequests는 따로 전달해야 할 문단이 있을 때만(없으면 null).
             모르면 null. 배열은 JSON 배열(빈 배열 가능). region은 한국어 지역명이면 그대로(예: 제주, 서울, 부산). 숫자는 정수.
+            연락처·이메일·SNS·상세 주소는 넣지 말 것.
             """;
 
     private final ChatModel chatModel;
@@ -130,6 +133,8 @@ public final class OpenAiLlmPromptExtractor implements LlmPromptExtractor {
                 .excludedTravelStyles(copyList(j.getExcludedTravelStyles()))
                 .excludedLanguages(copyList(j.getExcludedLanguages()))
                 .softPenaltyActivityTags(copyList(j.getSoftPenaltyActivityTags()))
+                .llmGuideBullets(copyMaskedBulletList(j.getGuideBullets()))
+                .llmSpecialRequests(trimToNull(LlmCopyPiiMasker.mask(trimToNull(j.getSpecialRequests()))))
                 .topN(topN)
                 .guideCandidates(guideCandidates)
                 .build();
@@ -141,6 +146,17 @@ public final class OpenAiLlmPromptExtractor implements LlmPromptExtractor {
         }
         String t = s.trim();
         return t.isEmpty() ? null : t;
+    }
+
+    private static List<String> copyMaskedBulletList(List<String> raw) {
+        if (raw == null || raw.isEmpty()) {
+            return null;
+        }
+        List<String> cleaned = raw.stream()
+                .map(s -> s == null ? "" : LlmCopyPiiMasker.mask(s.trim()))
+                .filter(StringUtils::hasText)
+                .toList();
+        return cleaned.isEmpty() ? null : List.copyOf(cleaned);
     }
 
     private static List<String> copyList(List<String> raw) {

--- a/backend/module-openai/src/test/java/com/team6/module/openai/prompt/LlmCopyPiiMaskerTest.java
+++ b/backend/module-openai/src/test/java/com/team6/module/openai/prompt/LlmCopyPiiMaskerTest.java
@@ -1,0 +1,14 @@
+package com.team6.module.openai.prompt;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LlmCopyPiiMaskerTest {
+
+    @Test
+    void mask_replacesMobileAndEmail() {
+        assertThat(LlmCopyPiiMasker.mask("전화 010-1234-5678")).contains("[연락처 생략]");
+        assertThat(LlmCopyPiiMasker.mask("메일은 a@b.co.kr")).contains("[이메일 생략]");
+    }
+}

--- a/backend/module-openai/src/test/java/com/team6/module/openai/prompt/OpenAiLlmPromptExtractorTest.java
+++ b/backend/module-openai/src/test/java/com/team6/module/openai/prompt/OpenAiLlmPromptExtractorTest.java
@@ -2,6 +2,7 @@ package com.team6.module.openai.prompt;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.team6.module.ai.dto.request.GuideRecommendRequest;
+import com.team6.module.ai.support.ConceptSummaryGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -33,7 +34,7 @@ class OpenAiLlmPromptExtractorTest {
         when(chatModel.getDefaultOptions()).thenReturn(def);
         when(chatModel.call(any(Prompt.class))).thenReturn(ChatResponse.builder()
                 .generations(List.of(new Generation(new AssistantMessage(
-                        "{\"region\":\"제주\",\"activityTags\":[\"맛집\"]}"
+                        "{\"region\":\"제주\",\"activityTags\":[\"맛집\"],\"guideBullets\":[\"맛집 위주로 돌아다니고 싶어\"]}"
                 ))))
                 .build());
 
@@ -50,6 +51,24 @@ class OpenAiLlmPromptExtractorTest {
         assertThat(out.get().getTopN()).isEqualTo(5);
         assertThat(out.get().getGuideCandidates()).containsExactly(c);
         assertThat(out.get().getActivityTags()).containsExactly("맛집");
+        assertThat(ConceptSummaryGenerator.generate(out.get())).contains("• 맛집");
+    }
+
+    @Test
+    void tryExtract_masksPhoneInSpecialRequests() {
+        OpenAiChatOptions def = new OpenAiChatOptions();
+        def.setModel("gpt-4o-mini");
+        when(chatModel.getDefaultOptions()).thenReturn(def);
+        when(chatModel.call(any(Prompt.class))).thenReturn(ChatResponse.builder()
+                .generations(List.of(new Generation(new AssistantMessage(
+                        "{\"region\":\"서울\",\"specialRequests\":\"연락 010-1234-5678\"}"
+                ))))
+                .build());
+
+        OpenAiLlmPromptExtractor ext = new OpenAiLlmPromptExtractor(chatModel, new ObjectMapper());
+        Optional<GuideRecommendRequest> out = ext.tryExtract("서울", 2, List.of());
+        assertThat(out).isPresent();
+        assertThat(out.get().getLlmSpecialRequests()).contains("[연락처 생략]");
     }
 
     @Test


### PR DESCRIPTION
## 변경 범위
- LLM JSON에 `guideBullets`, `specialRequests` 추가 → `GuideRecommendRequest`의 `@JsonIgnore` 필드(`llmGuideBullets`, `llmSpecialRequests`)
- `ConceptSummaryGenerator.generate` / `generateMatchRequestConcept`: LLM 가이드 카피가 있으면 불릿·문단 형태로 우선(매칭 초안 concept에는 구조 요약 접두)
- `LlmCopyPiiMasker`: 휴대전화·이메일 패턴 마스킹
- `POLICY_VERSION` → `2026.05.02`

## 검증
```bash
cd backend && ./gradlew :module-openai:test :module-ai:test :api-server:compileJava
```

Closes #430


Made with [Cursor](https://cursor.com)