### PR TITLE
[Feat/be#432] LLM 프롬프트 추출 Micrometer

### DIFF
--- a/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
@@ -853,16 +853,22 @@ public class PromptRecommendationService {
             int resolvedTopN,
             List<GuideRecommendRequest.GuideCandidateDto> guideCandidates
     ) {
-        if (Boolean.TRUE.equals(aiProperties.isLlmPromptExtractionEnabled()) && llmPromptExtractor != null) {
-            try {
-                Optional<GuideRecommendRequest> llm =
-                        llmPromptExtractor.tryExtract(prompt, resolvedTopN, guideCandidates);
-                if (llm.isPresent()) {
-                    return llm.get();
-                }
-            } catch (Exception e) {
-                log.warn("[AI_PROMPT] LLM 추출 실패, 룰 파서로 폴백: {}", e.toString());
+        if (!Boolean.TRUE.equals(aiProperties.isLlmPromptExtractionEnabled()) || llmPromptExtractor == null) {
+            return promptParser.parse(prompt, resolvedTopN, guideCandidates);
+        }
+        long t0 = System.nanoTime();
+        try {
+            Optional<GuideRecommendRequest> llm =
+                    llmPromptExtractor.tryExtract(prompt, resolvedTopN, guideCandidates);
+            long elapsed = System.nanoTime() - t0;
+            if (llm.isPresent()) {
+                metrics.recordLlmPromptExtraction("success", elapsed, POLICY_VERSION);
+                return llm.get();
             }
+            metrics.recordLlmPromptExtraction("empty", elapsed, POLICY_VERSION);
+        } catch (Exception e) {
+            metrics.recordLlmPromptExtraction("error", System.nanoTime() - t0, POLICY_VERSION);
+            log.warn("[AI_PROMPT] LLM 추출 실패, 룰 파서로 폴백: {}", e.toString());
         }
         return promptParser.parse(prompt, resolvedTopN, guideCandidates);
     }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationMetrics.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationMetrics.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
  *   <li>{@code .debiased_click_used(policy_version=...,used=true|false)} — 디바이어스 클릭 신호 사용 여부(가이드별)</li>
  *   <li>{@code .negative_filter(reason=region|style|language,policy_version=...)} — 부정 의도로 제외된 후보 수</li>
  *   <li>{@code .budget_range_match(result=match|miss,policy_version=...)} — 범위 예산 매칭 분기(비교 가능 후보에 한함)</li>
+ *   <li>{@code .llm_prompt_extraction(result=success|empty|error,policy_version=...)} — LLM 프롬프트 추출 시도 결과</li>
  * </ul>
  * <b>Timer / Summary</b> (태그 {@code policy_version} 권장)
  * <ul>
@@ -32,6 +33,7 @@ import java.util.concurrent.TimeUnit;
  *   <li>{@code .effective_pool_size} — 확장 후 후보 풀 크기</li>
  *   <li>{@code .feedback_penalty_magnitude} — 후보별 피드백 감점 절댓값(룰 점수에서 깎인 양, 단위: 점)</li>
  *   <li>{@code .diversity_penalty_magnitude} — Top-N에서 2번째 슬롯부터 선택 시 적용된 유사도×λ 패널티(점수 스케일)</li>
+ *   <li>{@code .llm_prompt_extraction_latency} — LLM 추출 호출 지연(성공·empty·error 모두 기록)</li>
  * </ul>
  */
 @Component
@@ -206,5 +208,21 @@ public class AiRecommendationMetrics {
         String result = matched ? "match" : "miss";
         registry.counter(PREFIX + ".budget_range_match", Tags.of("policy_version", pv, "result", result))
                 .increment();
+    }
+
+    /**
+     * {@link com.team6.module.ai.spi.LlmPromptExtractor} 호출 1회당 기록한다.
+     *
+     * @param result {@code success}(비어 있지 않은 요청), {@code empty}(Optional.empty로 룰 파서 폴백),
+     *               {@code error}(예외 후 룰 파서 폴백)
+     * @param nanos  LLM 호출 구간 소요 시간
+     */
+    public void recordLlmPromptExtraction(String result, long nanos, String policyVersion) {
+        String pv = policyVersion == null ? "unknown" : policyVersion;
+        String r = result == null || result.isBlank() ? "unknown" : result;
+        registry.counter(PREFIX + ".llm_prompt_extraction", Tags.of("policy_version", pv, "result", r))
+                .increment();
+        registry.timer(PREFIX + ".llm_prompt_extraction_latency", Tags.of("policy_version", pv))
+                .record(Math.max(0L, nanos), TimeUnit.NANOSECONDS);
     }
 }

--- a/backend/module-ai/src/test/java/com/team6/module/ai/support/AiRecommendationMetricsTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/support/AiRecommendationMetricsTest.java
@@ -81,4 +81,14 @@ class AiRecommendationMetricsTest {
         assertThat(registry.summary("localguest.ai.recommend.diversity_penalty_magnitude", "policy_version", "pv").count())
                 .isEqualTo(1);
     }
+
+    @Test
+    void llm_prompt_extraction_should_record_counter_and_timer() {
+        metrics.recordLlmPromptExtraction("success", 500_000, "pv");
+
+        assertThat(registry.counter("localguest.ai.recommend.llm_prompt_extraction",
+                "policy_version", "pv", "result", "success").count()).isEqualTo(1);
+        assertThat(registry.timer("localguest.ai.recommend.llm_prompt_extraction_latency",
+                "policy_version", "pv").count()).isEqualTo(1);
+    }
 }


### PR DESCRIPTION
## 변경
- `AiRecommendationMetrics.recordLlmPromptExtraction(result, nanos, policyVersion)`
- Counter: `localguest.ai.recommend.llm_prompt_extraction` (tags: `result`=success|empty|error, `policy_version`)
- Timer: `localguest.ai.recommend.llm_prompt_extraction_latency`
- `PromptRecommendationService.parsePromptToRequest`: LLM 경로에서만 기록

## 검증
`./gradlew :module-ai:test`

Closes #432


Made with [Cursor](https://cursor.com)