### PR TITLE
[Feat/be#434] LLM 프롬프트 추출 입력 길이 상한

### DIFF
--- a/backend/api-server/src/main/resources/application.yml
+++ b/backend/api-server/src/main/resources/application.yml
@@ -15,6 +15,8 @@ localguest:
   ai:
     # LLM 프롬프트 추출(LlmPromptExtractor 빈 + OpenAI 활성 시). 스텁 단계에서는 false 권장.
     llm-prompt-extraction-enabled: false
+    # LLM 경로에만 적용. 0 이하이면 제한 없음.
+    llm-prompt-max-chars: 6000
 
 ---
 spring:

--- a/backend/module-ai/src/main/java/com/team6/module/ai/config/LocalGuestAiProperties.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/config/LocalGuestAiProperties.java
@@ -68,6 +68,12 @@ public class LocalGuestAiProperties {
      */
     private boolean llmPromptExtractionEnabled = false;
 
+    /**
+     * LLM 프롬프트 추출에 넘기는 사용자 원문 최대 길이(Java {@link String#length()} 기준). 초과분은 잘린다.
+     * {@code localguest.ai.llm-prompt-max-chars}, 기본 6000. 0 이하이면 제한 없음.
+     */
+    private int llmPromptMaxChars = 6000;
+
     @Getter
     @Setter
     public static class ParserSettings {

--- a/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
@@ -856,10 +856,11 @@ public class PromptRecommendationService {
         if (!Boolean.TRUE.equals(aiProperties.isLlmPromptExtractionEnabled()) || llmPromptExtractor == null) {
             return promptParser.parse(prompt, resolvedTopN, guideCandidates);
         }
+        String llmPrompt = truncateForLlm(prompt);
         long t0 = System.nanoTime();
         try {
             Optional<GuideRecommendRequest> llm =
-                    llmPromptExtractor.tryExtract(prompt, resolvedTopN, guideCandidates);
+                    llmPromptExtractor.tryExtract(llmPrompt, resolvedTopN, guideCandidates);
             long elapsed = System.nanoTime() - t0;
             if (llm.isPresent()) {
                 metrics.recordLlmPromptExtraction("success", elapsed, POLICY_VERSION);
@@ -871,6 +872,22 @@ public class PromptRecommendationService {
             log.warn("[AI_PROMPT] LLM 추출 실패, 룰 파서로 폴백: {}", e.toString());
         }
         return promptParser.parse(prompt, resolvedTopN, guideCandidates);
+    }
+
+    /**
+     * LLM 전송 전 원문 길이 제한. 룰 파서 폴백에는 원문 전체를 그대로 쓴다.
+     */
+    private String truncateForLlm(String prompt) {
+        if (prompt == null) {
+            return null;
+        }
+        int max = aiProperties.getLlmPromptMaxChars();
+        if (max <= 0 || prompt.length() <= max) {
+            return prompt;
+        }
+        log.warn("[AI_PROMPT] LLM 입력 길이 제한으로 잘림: orig={} → sent={} chars (max={})",
+                prompt.length(), max, max);
+        return prompt.substring(0, max);
     }
 
     private static Long topGuideId(GuideRecommendResponse resp) {

--- a/backend/module-ai/src/test/java/com/team6/module/ai/service/PromptRecommendationServiceTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/service/PromptRecommendationServiceTest.java
@@ -20,12 +20,22 @@ import com.team6.module.ai.policy.RegionMatchPolicy;
 import com.team6.module.ai.policy.StyleMatchPolicy;
 import com.team6.module.ai.support.AiRecommendationMetrics;
 import com.team6.module.ai.support.AiRecommendationTuning;
+import com.team6.module.ai.spi.LlmPromptExtractor;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class PromptRecommendationServiceTest {
 
@@ -162,5 +172,64 @@ class PromptRecommendationServiceTest {
                 RecommendationNoticeCodes.SPARSE_GUIDE_POOL
         );
         assertThat(response.getRecommendations().get(0).getGuideId()).isEqualTo(99L);
+    }
+
+    @Test
+    void recommendByPrompt_whenLlmEnabled_truncatesPromptSentToExtractor() {
+        LlmPromptExtractor extractor = mock(LlmPromptExtractor.class);
+        when(extractor.tryExtract(anyString(), anyInt(), any())).thenReturn(Optional.empty());
+
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        LocalGuestAiProperties aiProps = new LocalGuestAiProperties();
+        aiProps.setLlmPromptExtractionEnabled(true);
+        aiProps.setLlmPromptMaxChars(4);
+        ScoringPolicySnapshot scoring = ScoringPolicySnapshot.defaults();
+        AdjacentRegionProvider adjacent = new AdjacentRegionProvider(aiProps);
+        AiRecommendationMetrics metrics = new AiRecommendationMetrics(meterRegistry);
+        ScoreCalculator scoreCalculator = new ScoreCalculator(
+                new RegionMatchPolicy(adjacent, scoring),
+                new StyleMatchPolicy(scoring),
+                new BudgetMatchPolicy(scoring),
+                new ActivityMatchPolicy(scoring),
+                new LanguageMatchPolicy(scoring),
+                new FeedbackMatchPolicy(scoring),
+                new ComboMatchPolicy(scoring),
+                metrics
+        );
+        ReasonGenerator reasonGenerator = new ReasonGenerator(adjacent, scoring);
+        AiRecommendationService aiRecommendationService =
+                new AiRecommendationServiceImpl(
+                        new MatchingEngine(scoreCalculator, reasonGenerator, adjacent, DiversityRerankSnapshot.defaults(),
+                                metrics, scoring));
+
+        PromptRecommendationService service = new PromptRecommendationService(
+                new PromptParser(aiProps),
+                aiRecommendationService,
+                adjacent,
+                metrics,
+                scoring,
+                aiProps,
+                extractor
+        );
+
+        service.recommendByPrompt(
+                "제주도여행가고싶어",
+                2,
+                List.of(
+                        GuideRecommendRequest.GuideCandidateDto.builder()
+                                .guideId(1L)
+                                .guideName("가")
+                                .region("제주")
+                                .guideStyle("감성")
+                                .priceLevel("중간")
+                                .specialtyTags(List.of("카페"))
+                                .languages(List.of("한국어"))
+                                .build()
+                )
+        );
+
+        ArgumentCaptor<String> promptSent = ArgumentCaptor.forClass(String.class);
+        verify(extractor).tryExtract(promptSent.capture(), eq(2), any());
+        assertThat(promptSent.getValue()).isEqualTo("제주도여");
     }
 }


### PR DESCRIPTION
## 변경 범위
- `localguest.ai.llm-prompt-max-chars`(기본 6000): LLM `tryExtract`에만 적용, 초과 시 잘림 + `[AI_PROMPT]` warn 로그
- 0 이하이면 제한 없음. 룰 파서 폴백은 항상 원문 전체
- `application.yml` 기본값 명시

## 스키마
- 없음

## 검증
```
./gradlew :module-ai:test --tests com.team6.module.ai.service.PromptRecommendationServiceTest
./gradlew :api-server:compileJava
```

Closes #434

Made with [Cursor](https://cursor.com)