### PR TITLE
[Feat/be#436] Gemini LLM 프롬프트 추출 및 provider 선택

### DIFF
--- a/backend/api-server/build.gradle
+++ b/backend/api-server/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     implementation project(':module-ai')
     implementation project(':module-ai-integration')
     implementation project(':module-openai')
+    implementation project(':module-gemini')
     implementation project(':module-chat')
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 

--- a/backend/api-server/src/main/resources/application.yml
+++ b/backend/api-server/src/main/resources/application.yml
@@ -8,13 +8,19 @@ spring:
       max-request-size: 10MB
 
 # OpenAI(Spring AI) — 기본 비활성. 켤 때는 API 키(spring.ai.openai.api-key 등)가 필요하다.
+# Gemini(Google AI Studio API 키) — module-gemini. llm-provider=gemini 일 때 localguest.gemini.enabled 필요.
 localguest:
   openai:
     enabled: false
     model: gpt-4o-mini
+  gemini:
+    enabled: false
+    model: gemini-2.0-flash
   ai:
-    # LLM 프롬프트 추출(LlmPromptExtractor 빈 + OpenAI 활성 시). 스텁 단계에서는 false 권장.
+    # LLM 프롬프트 추출(LlmPromptExtractor 빈 + 백엔드 활성 시). 스텁 단계에서는 false 권장.
     llm-prompt-extraction-enabled: false
+    # openai(기본) | gemini — 각각 localguest.openai.enabled / localguest.gemini.enabled 와 함께 켠다.
+    llm-provider: openai
     # LLM 경로에만 적용. 0 이하이면 제한 없음.
     llm-prompt-max-chars: 6000
 

--- a/backend/module-ai/src/main/java/com/team6/module/ai/config/LlmPromptExtractorStartupDiagnostics.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/config/LlmPromptExtractorStartupDiagnostics.java
@@ -1,0 +1,44 @@
+package com.team6.module.ai.config;
+
+import com.team6.module.ai.spi.LlmPromptExtractor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+
+import java.util.Locale;
+
+/**
+ * 부팅 시 {@link LlmPromptExtractor} 주입 여부와 {@code localguest.ai.llm-provider} 설정을 한 줄로 남긴다.
+ */
+@Component
+@Slf4j
+public class LlmPromptExtractorStartupDiagnostics implements ApplicationRunner {
+
+    private final LocalGuestAiProperties aiProperties;
+    @Nullable
+    private final LlmPromptExtractor llmPromptExtractor;
+
+    public LlmPromptExtractorStartupDiagnostics(
+            LocalGuestAiProperties aiProperties,
+            @Autowired(required = false) @Nullable LlmPromptExtractor llmPromptExtractor
+    ) {
+        this.aiProperties = aiProperties;
+        this.llmPromptExtractor = llmPromptExtractor;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        String p = aiProperties.getLlmProvider();
+        String provider = p == null || p.isBlank() ? "unknown" : p.trim().toLowerCase(Locale.ROOT);
+        String bean = llmPromptExtractor == null ? "none" : llmPromptExtractor.getClass().getSimpleName();
+        log.info(
+                "[AI_LLM] startup llmPromptExtractionEnabled={} llmProviderCfg={} llmPromptExtractorBean={}",
+                aiProperties.isLlmPromptExtractionEnabled(),
+                provider,
+                bean
+        );
+    }
+}

--- a/backend/module-ai/src/main/java/com/team6/module/ai/config/LocalGuestAiProperties.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/config/LocalGuestAiProperties.java
@@ -69,6 +69,12 @@ public class LocalGuestAiProperties {
     private boolean llmPromptExtractionEnabled = false;
 
     /**
+     * LLM 백엔드. {@code openai}(기본)는 {@code module-openai}, {@code gemini}는 {@code module-gemini}(Google AI Studio API 키).
+     * {@code localguest.ai.llm-provider}
+     */
+    private String llmProvider = "openai";
+
+    /**
      * LLM 프롬프트 추출에 넘기는 사용자 원문 최대 길이(Java {@link String#length()} 기준). 초과분은 잘린다.
      * {@code localguest.ai.llm-prompt-max-chars}, 기본 6000. 0 이하이면 제한 없음.
      */

--- a/backend/module-ai/src/main/java/com/team6/module/ai/llm/LlmCopyPiiMasker.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/llm/LlmCopyPiiMasker.java
@@ -1,4 +1,4 @@
-package com.team6.module.openai.prompt;
+package com.team6.module.ai.llm;
 
 /**
  * LLM이 만든 가이드 노출용 문자열에서 흔한 PII 패턴만 얕게 가린다.

--- a/backend/module-ai/src/main/java/com/team6/module/ai/llm/LlmGuideRecommendJson.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/llm/LlmGuideRecommendJson.java
@@ -1,4 +1,4 @@
-package com.team6.module.openai.prompt;
+package com.team6.module.ai.llm;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Getter;

--- a/backend/module-ai/src/main/java/com/team6/module/ai/llm/LlmGuideRecommendMapper.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/llm/LlmGuideRecommendMapper.java
@@ -1,0 +1,80 @@
+package com.team6.module.ai.llm;
+
+import com.team6.module.ai.dto.request.GuideRecommendRequest;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+/**
+ * {@link LlmGuideRecommendJson} → {@link GuideRecommendRequest} (후보·{@code topN}은 호출부에서 고정).
+ */
+public final class LlmGuideRecommendMapper {
+
+    private LlmGuideRecommendMapper() {
+    }
+
+    public static GuideRecommendRequest toRequest(
+            LlmGuideRecommendJson j,
+            int topN,
+            List<GuideRecommendRequest.GuideCandidateDto> guideCandidates
+    ) {
+        return GuideRecommendRequest.builder()
+                .region(trimToNull(j.getRegion()))
+                .travelStyle(trimToNull(j.getTravelStyle()))
+                .budgetLevel(trimToNull(j.getBudgetLevel()))
+                .budgetMinWon(j.getBudgetMinWon())
+                .budgetMaxWon(j.getBudgetMaxWon())
+                .budgetScope(trimToNull(j.getBudgetScope()))
+                .strictBudget(j.getStrictBudget())
+                .companionType(trimToNull(j.getCompanionType()))
+                .activityTags(copyList(j.getActivityTags()))
+                .requiredActivityTags(copyList(j.getRequiredActivityTags()))
+                .niceToHaveActivityTags(copyList(j.getNiceToHaveActivityTags()))
+                .preferredLanguages(copyList(j.getPreferredLanguages()))
+                .requiredLanguages(copyList(j.getRequiredLanguages()))
+                .niceToHaveLanguages(copyList(j.getNiceToHaveLanguages()))
+                .allowAdjacentRegion(j.getAllowAdjacentRegion())
+                .headcount(j.getHeadcount())
+                .durationDays(j.getDurationDays())
+                .excludedActivityTags(copyList(j.getExcludedActivityTags()))
+                .excludedRegions(copyList(j.getExcludedRegions()))
+                .excludedTravelStyles(copyList(j.getExcludedTravelStyles()))
+                .excludedLanguages(copyList(j.getExcludedLanguages()))
+                .softPenaltyActivityTags(copyList(j.getSoftPenaltyActivityTags()))
+                .llmGuideBullets(copyMaskedBulletList(j.getGuideBullets()))
+                .llmSpecialRequests(trimToNull(LlmCopyPiiMasker.mask(trimToNull(j.getSpecialRequests()))))
+                .topN(topN)
+                .guideCandidates(guideCandidates)
+                .build();
+    }
+
+    private static String trimToNull(String s) {
+        if (s == null) {
+            return null;
+        }
+        String t = s.trim();
+        return t.isEmpty() ? null : t;
+    }
+
+    private static List<String> copyMaskedBulletList(List<String> raw) {
+        if (raw == null || raw.isEmpty()) {
+            return null;
+        }
+        List<String> cleaned = raw.stream()
+                .map(s -> s == null ? "" : LlmCopyPiiMasker.mask(s.trim()))
+                .filter(StringUtils::hasText)
+                .toList();
+        return cleaned.isEmpty() ? null : List.copyOf(cleaned);
+    }
+
+    private static List<String> copyList(List<String> raw) {
+        if (raw == null || raw.isEmpty()) {
+            return null;
+        }
+        List<String> cleaned = raw.stream()
+                .map(s -> s == null ? "" : s.trim())
+                .filter(s -> !s.isEmpty())
+                .toList();
+        return cleaned.isEmpty() ? null : List.copyOf(cleaned);
+    }
+}

--- a/backend/module-ai/src/main/java/com/team6/module/ai/llm/LlmPromptExtractionSystemText.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/llm/LlmPromptExtractionSystemText.java
@@ -1,0 +1,21 @@
+package com.team6.module.ai.llm;
+
+/**
+ * OpenAI·Gemini 등 LLM 프롬프트 추출기가 공유하는 시스템 지시문.
+ */
+public final class LlmPromptExtractionSystemText {
+
+    private LlmPromptExtractionSystemText() {
+    }
+
+    public static final String KOREAN_JSON_EXTRACTOR = """
+            당신은 여행 매칭용 정보 추출기다. 사용자 한국어 입력만 보고 아래 키를 가진 JSON 객체 하나만 출력한다. 설명·마크다운·코드펜스 금지.
+            키: region, travelStyle, budgetLevel, budgetMinWon, budgetMaxWon, budgetScope, strictBudget, companionType,
+            activityTags, requiredActivityTags, niceToHaveActivityTags, preferredLanguages, requiredLanguages, niceToHaveLanguages,
+            allowAdjacentRegion, headcount, durationDays, excludedActivityTags, excludedRegions, excludedTravelStyles, excludedLanguages, softPenaltyActivityTags,
+            guideBullets, specialRequests.
+            guideBullets는 가이드에게 보여줄 짧은 한국어 반말 불릿(한 줄당 한 가지). specialRequests는 따로 전달해야 할 문단이 있을 때만(없으면 null).
+            모르면 null. 배열은 JSON 배열(빈 배열 가능). region은 한국어 지역명이면 그대로(예: 제주, 서울, 부산). 숫자는 정수.
+            연락처·이메일·SNS·상세 주소는 넣지 말 것.
+            """;
+}

--- a/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
@@ -133,7 +133,9 @@ public class PromptRecommendationService {
             Integer resolvedTopN = (topN == null || topN <= 0)
                     ? AiRecommendationTuning.DEFAULT_TOP_N
                     : topN;
-            GuideRecommendRequest parsed = parsePromptToRequest(prompt, resolvedTopN, guideCandidates);
+            ParsedPrompt parsedPrompt = parsePromptToRequest(prompt, resolvedTopN, guideCandidates);
+            GuideRecommendRequest parsed = parsedPrompt.request();
+            LlmParseTrace llmParseTrace = parsedPrompt.llmTrace();
 
             // 2) 지역이 없으면 추천 품질이 크게 떨어지기 때문에 여기서 바로 short-circuit 한다.
             // 대신 빈 응답만 보내지 않고 conceptSummary / keywords / matchRequestDraft는 같이 만들어
@@ -153,7 +155,8 @@ public class PromptRecommendationService {
                         true,
                         false,
                         poolSize(parsed.getGuideCandidates()),
-                        0
+                        0,
+                        llmParseTrace
                 );
                 metrics.recordNoRegionShortCircuit();
                 metrics.recordOutcome("no_region");
@@ -271,7 +274,8 @@ public class PromptRecommendationService {
                     false,
                     expansion.expansionUsed(),
                     poolSize(expansion.candidates()),
-                    expansion.exactCount()
+                    expansion.exactCount(),
+                    llmParseTrace
             );
 
             // 11) 최종 응답을 만든다.
@@ -803,7 +807,8 @@ public class PromptRecommendationService {
             boolean noRegionShortCircuit,
             boolean regionExpansionUsed,
             int effectivePoolSize,
-            int expansionExactCount
+            int expansionExactCount,
+            LlmParseTrace llmParseTrace
     ) {
         try {
             // 추천 품질 이슈가 생겼을 때 promptHash, 후보 수, fallback 단계, Top1 reason code 등으로
@@ -815,7 +820,7 @@ public class PromptRecommendationService {
             String top1ReasonCodes = summarizeTopReasonCodes(finalBase);
             Long top1GuideId = topGuideId(finalBase);
 
-            log.info("[AI_RECOMMEND] policyVer={} promptHash={} topN={} candidates={} policy={{noRegionShortCircuit={},regionExpansion={},effectivePool={},expansionExact={}}} keywords={{region={},style={},budget={},companion={},headcount={},durationDays={},tags={},excluded={},softPenalty={},langs={}}} base={{count={},topScore={}}} final={{count={},topScore={},top1GuideId={},top1ReasonCodes={}}} fallback={{used={},stage={}}}",
+            log.info("[AI_RECOMMEND] policyVer={} promptHash={} topN={} candidates={} policy={{noRegionShortCircuit={},regionExpansion={},effectivePool={},expansionExact={}}} keywords={{region={},style={},budget={},companion={},headcount={},durationDays={},tags={},excluded={},softPenalty={},langs={}}} base={{count={},topScore={}}} final={{count={},topScore={},top1GuideId={},top1ReasonCodes={}}} fallback={{used={},stage={}}} llmParse={{cfgProvider={},extractorBean={},outcome={}}}",
                     AiRecommendationTuning.POLICY_VERSION,
                     promptHash,
                     request == null ? null : request.getTopN(),
@@ -841,21 +846,46 @@ public class PromptRecommendationService {
                     top1GuideId,
                     top1ReasonCodes,
                     fallback != null && fallback.attemptedRelaxChain(),
-                    fallback == null ? null : fallback.winningRelaxStage()
+                    fallback == null ? null : fallback.winningRelaxStage(),
+                    llmParseTrace == null ? null : llmParseTrace.cfgProvider(),
+                    llmParseTrace == null ? null : llmParseTrace.extractorBeanClass(),
+                    llmParseTrace == null ? null : llmParseTrace.outcome()
             );
         } catch (Exception e) {
             log.debug("[AI_RECOMMEND] logging skipped: {}", e.toString());
         }
     }
 
-    private GuideRecommendRequest parsePromptToRequest(
+    private record ParsedPrompt(GuideRecommendRequest request, LlmParseTrace llmTrace) {}
+
+    /**
+     * @param cfgProvider      {@code localguest.ai.llm-provider} 정규화 값(로그용)
+     * @param extractorBeanClass 주입된 {@link LlmPromptExtractor} 구현 단순 클래스명, 없으면 {@code none}
+     * @param outcome          {@code SKIP_DISABLED} | {@code SKIP_NO_BEAN} | {@code LLM_SUCCESS} | {@code LLM_EMPTY} | {@code LLM_ERROR}
+     */
+    private record LlmParseTrace(String cfgProvider, String extractorBeanClass, String outcome) {}
+
+    private ParsedPrompt parsePromptToRequest(
             String prompt,
             int resolvedTopN,
             List<GuideRecommendRequest.GuideCandidateDto> guideCandidates
     ) {
-        if (!Boolean.TRUE.equals(aiProperties.isLlmPromptExtractionEnabled()) || llmPromptExtractor == null) {
-            return promptParser.parse(prompt, resolvedTopN, guideCandidates);
+        String cfgProvider = normalizeCfgLlmProvider(aiProperties.getLlmProvider());
+        String extractorBean = llmPromptExtractor == null ? "none" : llmPromptExtractor.getClass().getSimpleName();
+
+        if (!Boolean.TRUE.equals(aiProperties.isLlmPromptExtractionEnabled())) {
+            return new ParsedPrompt(
+                    promptParser.parse(prompt, resolvedTopN, guideCandidates),
+                    new LlmParseTrace(cfgProvider, extractorBean, "SKIP_DISABLED")
+            );
         }
+        if (llmPromptExtractor == null) {
+            return new ParsedPrompt(
+                    promptParser.parse(prompt, resolvedTopN, guideCandidates),
+                    new LlmParseTrace(cfgProvider, "none", "SKIP_NO_BEAN")
+            );
+        }
+
         String llmPrompt = truncateForLlm(prompt);
         long t0 = System.nanoTime();
         try {
@@ -863,15 +893,29 @@ public class PromptRecommendationService {
                     llmPromptExtractor.tryExtract(llmPrompt, resolvedTopN, guideCandidates);
             long elapsed = System.nanoTime() - t0;
             if (llm.isPresent()) {
-                metrics.recordLlmPromptExtraction("success", elapsed, POLICY_VERSION);
-                return llm.get();
+                metrics.recordLlmPromptExtraction("success", elapsed, POLICY_VERSION, cfgProvider);
+                return new ParsedPrompt(llm.get(), new LlmParseTrace(cfgProvider, extractorBean, "LLM_SUCCESS"));
             }
-            metrics.recordLlmPromptExtraction("empty", elapsed, POLICY_VERSION);
+            metrics.recordLlmPromptExtraction("empty", elapsed, POLICY_VERSION, cfgProvider);
+            return new ParsedPrompt(
+                    promptParser.parse(prompt, resolvedTopN, guideCandidates),
+                    new LlmParseTrace(cfgProvider, extractorBean, "LLM_EMPTY")
+            );
         } catch (Exception e) {
-            metrics.recordLlmPromptExtraction("error", System.nanoTime() - t0, POLICY_VERSION);
+            metrics.recordLlmPromptExtraction("error", System.nanoTime() - t0, POLICY_VERSION, cfgProvider);
             log.warn("[AI_PROMPT] LLM 추출 실패, 룰 파서로 폴백: {}", e.toString());
+            return new ParsedPrompt(
+                    promptParser.parse(prompt, resolvedTopN, guideCandidates),
+                    new LlmParseTrace(cfgProvider, extractorBean, "LLM_ERROR")
+            );
         }
-        return promptParser.parse(prompt, resolvedTopN, guideCandidates);
+    }
+
+    private static String normalizeCfgLlmProvider(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return "unknown";
+        }
+        return raw.trim().toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/backend/module-ai/src/main/java/com/team6/module/ai/spi/LlmPromptExtractor.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/spi/LlmPromptExtractor.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 
 /**
  * 자연어 프롬프트를 {@link GuideRecommendRequest}로 바꾸는 LLM 기반 추출기 SPI.
- * <p>구현체는 {@code module-openai} 등에서 제공하며, 비어 있으면({@link Optional#empty()}) 호출부가
+ * <p>구현체는 {@code module-openai}·{@code module-gemini} 등에서 제공하며, 비어 있으면({@link Optional#empty()}) 호출부가
  * 룰 기반 {@link com.team6.module.ai.parser.PromptParser}로 폴백한다.
  */
 @FunctionalInterface

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationMetrics.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/AiRecommendationMetrics.java
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit;
  *   <li>{@code .debiased_click_used(policy_version=...,used=true|false)} — 디바이어스 클릭 신호 사용 여부(가이드별)</li>
  *   <li>{@code .negative_filter(reason=region|style|language,policy_version=...)} — 부정 의도로 제외된 후보 수</li>
  *   <li>{@code .budget_range_match(result=match|miss,policy_version=...)} — 범위 예산 매칭 분기(비교 가능 후보에 한함)</li>
- *   <li>{@code .llm_prompt_extraction(result=success|empty|error,policy_version=...)} — LLM 프롬프트 추출 시도 결과</li>
+ *   <li>{@code .llm_prompt_extraction(result=success|empty|error,policy_version=...,llm_provider=openai|gemini|unknown)} — LLM 프롬프트 추출 시도 결과</li>
  * </ul>
  * <b>Timer / Summary</b> (태그 {@code policy_version} 권장)
  * <ul>
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeUnit;
  *   <li>{@code .effective_pool_size} — 확장 후 후보 풀 크기</li>
  *   <li>{@code .feedback_penalty_magnitude} — 후보별 피드백 감점 절댓값(룰 점수에서 깎인 양, 단위: 점)</li>
  *   <li>{@code .diversity_penalty_magnitude} — Top-N에서 2번째 슬롯부터 선택 시 적용된 유사도×λ 패널티(점수 스케일)</li>
- *   <li>{@code .llm_prompt_extraction_latency} — LLM 추출 호출 지연(성공·empty·error 모두 기록)</li>
+ *   <li>{@code .llm_prompt_extraction_latency} — LLM 추출 호출 지연(카운터와 동일 태그: {@code policy_version}, {@code result}, {@code llm_provider})</li>
  * </ul>
  */
 @Component
@@ -216,13 +216,28 @@ public class AiRecommendationMetrics {
      * @param result {@code success}(비어 있지 않은 요청), {@code empty}(Optional.empty로 룰 파서 폴백),
      *               {@code error}(예외 후 룰 파서 폴백)
      * @param nanos  LLM 호출 구간 소요 시간
+     * @param llmProvider {@code localguest.ai.llm-provider}에 대응하는 태그 값({@code openai}, {@code gemini}, 그 외는 {@code unknown})
      */
-    public void recordLlmPromptExtraction(String result, long nanos, String policyVersion) {
+    public void recordLlmPromptExtraction(String result, long nanos, String policyVersion, String llmProvider) {
         String pv = policyVersion == null ? "unknown" : policyVersion;
         String r = result == null || result.isBlank() ? "unknown" : result;
-        registry.counter(PREFIX + ".llm_prompt_extraction", Tags.of("policy_version", pv, "result", r))
-                .increment();
-        registry.timer(PREFIX + ".llm_prompt_extraction_latency", Tags.of("policy_version", pv))
-                .record(Math.max(0L, nanos), TimeUnit.NANOSECONDS);
+        String prov = sanitizeLlmProviderTag(llmProvider);
+        Tags tags = Tags.of("policy_version", pv, "result", r, "llm_provider", prov);
+        registry.counter(PREFIX + ".llm_prompt_extraction", tags).increment();
+        registry.timer(PREFIX + ".llm_prompt_extraction_latency", tags).record(Math.max(0L, nanos), TimeUnit.NANOSECONDS);
+    }
+
+    private static String sanitizeLlmProviderTag(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return "unknown";
+        }
+        String s = raw.trim().toLowerCase();
+        if ("openai".equals(s)) {
+            return "openai";
+        }
+        if ("gemini".equals(s)) {
+            return "gemini";
+        }
+        return "unknown";
     }
 }

--- a/backend/module-ai/src/test/java/com/team6/module/ai/llm/LlmCopyPiiMaskerTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/llm/LlmCopyPiiMaskerTest.java
@@ -1,4 +1,4 @@
-package com.team6.module.openai.prompt;
+package com.team6.module.ai.llm;
 
 import org.junit.jupiter.api.Test;
 

--- a/backend/module-ai/src/test/java/com/team6/module/ai/support/AiRecommendationMetricsTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/support/AiRecommendationMetricsTest.java
@@ -84,11 +84,11 @@ class AiRecommendationMetricsTest {
 
     @Test
     void llm_prompt_extraction_should_record_counter_and_timer() {
-        metrics.recordLlmPromptExtraction("success", 500_000, "pv");
+        metrics.recordLlmPromptExtraction("success", 500_000, "pv", "gemini");
 
         assertThat(registry.counter("localguest.ai.recommend.llm_prompt_extraction",
-                "policy_version", "pv", "result", "success").count()).isEqualTo(1);
+                "policy_version", "pv", "result", "success", "llm_provider", "gemini").count()).isEqualTo(1);
         assertThat(registry.timer("localguest.ai.recommend.llm_prompt_extraction_latency",
-                "policy_version", "pv").count()).isEqualTo(1);
+                "policy_version", "pv", "result", "success", "llm_provider", "gemini").count()).isEqualTo(1);
     }
 }

--- a/backend/module-gemini/build.gradle
+++ b/backend/module-gemini/build.gradle
@@ -1,0 +1,19 @@
+/**
+ * Google AI Studio(Gemini) REST API로 {@link com.team6.module.ai.spi.LlmPromptExtractor}를 제공한다.
+ * <p>Spring AI Vertex 모듈 대신 API 키만으로 부팅 가능한 최소 RestClient 구현을 쓴다.
+ */
+dependencies {
+    implementation project(':module-ai')
+
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter'
+
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+bootJar { enabled = false }
+jar { enabled = true }

--- a/backend/module-gemini/src/main/java/com/team6/module/gemini/config/LocalGuestGeminiConfiguration.java
+++ b/backend/module-gemini/src/main/java/com/team6/module/gemini/config/LocalGuestGeminiConfiguration.java
@@ -1,0 +1,65 @@
+package com.team6.module.gemini.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team6.module.ai.spi.LlmPromptExtractor;
+import com.team6.module.gemini.prompt.GeminiLlmPromptExtractor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Gemini(Generative Language API) 클라이언트. {@code localguest.gemini.enabled=true} 일 때만 빈을 등록한다.
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnProperty(prefix = "localguest.gemini", name = "enabled", havingValue = "true", matchIfMissing = false)
+public class LocalGuestGeminiConfiguration {
+
+    @Bean
+    public RestClient geminiGenerativeLanguageRestClient(RestClient.Builder restClientBuilder) {
+        return restClientBuilder
+                .baseUrl("https://generativelanguage.googleapis.com")
+                .build();
+    }
+
+    @Bean
+    @Conditional(OnGeminiLlmExtractionProperties.class)
+    public LlmPromptExtractor geminiLlmPromptExtractor(
+            RestClient geminiGenerativeLanguageRestClient,
+            ObjectMapper objectMapper,
+            LocalGuestGeminiProperties props,
+            Environment env
+    ) {
+        String key = resolveApiKey(props, env);
+        if (!StringUtils.hasText(key)) {
+            throw new IllegalStateException(
+                    "localguest.gemini.enabled=true 이고 localguest.ai.llm-provider=gemini 인데 API 키가 없습니다. "
+                            + "localguest.gemini.api-key, GEMINI_API_KEY, GOOGLE_API_KEY 중 하나를 설정하세요."
+            );
+        }
+        return new GeminiLlmPromptExtractor(
+                geminiGenerativeLanguageRestClient,
+                objectMapper,
+                props.getModel(),
+                key.trim()
+        );
+    }
+
+    private static String resolveApiKey(LocalGuestGeminiProperties props, Environment env) {
+        if (StringUtils.hasText(props.getApiKey())) {
+            return props.getApiKey().trim();
+        }
+        String g1 = env.getProperty("GEMINI_API_KEY");
+        if (StringUtils.hasText(g1)) {
+            return g1.trim();
+        }
+        String g2 = env.getProperty("GOOGLE_API_KEY");
+        if (StringUtils.hasText(g2)) {
+            return g2.trim();
+        }
+        return "";
+    }
+}

--- a/backend/module-gemini/src/main/java/com/team6/module/gemini/config/LocalGuestGeminiProperties.java
+++ b/backend/module-gemini/src/main/java/com/team6/module/gemini/config/LocalGuestGeminiProperties.java
@@ -1,0 +1,28 @@
+package com.team6.module.gemini.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Google Generative Language API(Gemini, AI Studio API 키) 설정({@code localguest.gemini.*}).
+ * <p>키는 {@code localguest.gemini.api-key}, 환경 변수 {@code GEMINI_API_KEY} 또는 {@code GOOGLE_API_KEY} 순으로 해석한다.
+ */
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "localguest.gemini")
+public class LocalGuestGeminiProperties {
+
+    /**
+     * {@code true}일 때만 Gemini {@link org.springframework.web.client.RestClient}·추출기 빈을 등록한다.
+     */
+    private boolean enabled = false;
+
+    /** 비어 있지 않으면 최우선으로 사용하는 API 키(로컬 전용). */
+    private String apiKey = "";
+
+    /**
+     * {@code v1beta/models/{model}:generateContent} 에 쓰는 모델 id(예: gemini-2.0-flash, gemini-1.5-flash).
+     */
+    private String model = "gemini-2.0-flash";
+}

--- a/backend/module-gemini/src/main/java/com/team6/module/gemini/config/LocalGuestGeminiPropertiesBootstrapConfiguration.java
+++ b/backend/module-gemini/src/main/java/com/team6/module/gemini/config/LocalGuestGeminiPropertiesBootstrapConfiguration.java
@@ -1,0 +1,12 @@
+package com.team6.module.gemini.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * {@link LocalGuestGeminiProperties}를 항상 바인딩한다(기본 {@code enabled=false}).
+ */
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(LocalGuestGeminiProperties.class)
+public class LocalGuestGeminiPropertiesBootstrapConfiguration {
+}

--- a/backend/module-gemini/src/main/java/com/team6/module/gemini/config/OnGeminiLlmExtractionProperties.java
+++ b/backend/module-gemini/src/main/java/com/team6/module/gemini/config/OnGeminiLlmExtractionProperties.java
@@ -1,0 +1,20 @@
+package com.team6.module.gemini.config;
+
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+/**
+ * {@code localguest.ai.llm-prompt-extraction-enabled=true} 이고 {@code localguest.ai.llm-provider=gemini}일 때만 참.
+ */
+public final class OnGeminiLlmExtractionProperties implements Condition {
+
+    @Override
+    public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+        var env = context.getEnvironment();
+        if (!Boolean.parseBoolean(env.getProperty("localguest.ai.llm-prompt-extraction-enabled", "false"))) {
+            return false;
+        }
+        return "gemini".equalsIgnoreCase(env.getProperty("localguest.ai.llm-provider", "openai"));
+    }
+}

--- a/backend/module-gemini/src/main/java/com/team6/module/gemini/prompt/GeminiLlmPromptExtractor.java
+++ b/backend/module-gemini/src/main/java/com/team6/module/gemini/prompt/GeminiLlmPromptExtractor.java
@@ -1,0 +1,140 @@
+package com.team6.module.gemini.prompt;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.team6.module.ai.dto.request.GuideRecommendRequest;
+import com.team6.module.ai.llm.LlmGuideRecommendJson;
+import com.team6.module.ai.llm.LlmGuideRecommendMapper;
+import com.team6.module.ai.llm.LlmPromptExtractionSystemText;
+import com.team6.module.ai.spi.LlmPromptExtractor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientResponseException;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Google AI Studio API 키로 {@code generateContent}를 호출해 프롬프트를 구조화한다.
+ * <p>후보 목록·{@code topN}은 호출 인자를 그대로 쓴다.
+ */
+public final class GeminiLlmPromptExtractor implements LlmPromptExtractor {
+
+    private static final Logger log = LoggerFactory.getLogger(GeminiLlmPromptExtractor.class);
+
+    private final RestClient restClient;
+    private final ObjectMapper objectMapper;
+    private final String model;
+    private final String apiKey;
+
+    public GeminiLlmPromptExtractor(
+            RestClient restClient,
+            ObjectMapper objectMapper,
+            String model,
+            String apiKey
+    ) {
+        this.restClient = restClient;
+        this.objectMapper = objectMapper;
+        this.model = model;
+        this.apiKey = apiKey;
+    }
+
+    @Override
+    public Optional<GuideRecommendRequest> tryExtract(
+            String prompt,
+            int topN,
+            List<GuideRecommendRequest.GuideCandidateDto> guideCandidates
+    ) {
+        if (!StringUtils.hasText(prompt)) {
+            return Optional.empty();
+        }
+        try {
+            ObjectNode body = objectMapper.createObjectNode();
+            ArrayNode contents = body.putArray("contents");
+            ObjectNode userTurn = contents.addObject();
+            ArrayNode userParts = userTurn.putArray("parts");
+            userParts.addObject().put("text", prompt.trim());
+
+            ObjectNode systemInstruction = body.putObject("systemInstruction");
+            ArrayNode sysParts = systemInstruction.putArray("parts");
+            sysParts.addObject().put("text", LlmPromptExtractionSystemText.KOREAN_JSON_EXTRACTOR.trim());
+
+            ObjectNode generationConfig = body.putObject("generationConfig");
+            generationConfig.put("responseMimeType", "application/json");
+            generationConfig.put("temperature", 0.2);
+
+            String payload = objectMapper.writeValueAsString(body);
+            String rawJson = restClient.post()
+                    .uri(uriBuilder -> uriBuilder
+                            .path("/v1beta/models/{model}:generateContent")
+                            .queryParam("key", apiKey)
+                            .build(model))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(payload)
+                    .retrieve()
+                    .body(String.class);
+
+            if (!StringUtils.hasText(rawJson)) {
+                log.warn("[GEMINI_PROMPT] 빈 응답, 룰 파서 폴백");
+                return Optional.empty();
+            }
+            JsonNode root = objectMapper.readTree(rawJson);
+            if (root.hasNonNull("error")) {
+                log.warn("[GEMINI_PROMPT] API 오류, 룰 파서 폴백: {}", root.get("error"));
+                return Optional.empty();
+            }
+            JsonNode candidates = root.path("candidates");
+            if (!candidates.isArray() || candidates.isEmpty()) {
+                log.warn("[GEMINI_PROMPT] candidates 없음, 룰 파서 폴백");
+                return Optional.empty();
+            }
+            JsonNode parts = candidates.get(0).path("content").path("parts");
+            if (!parts.isArray() || parts.isEmpty()) {
+                log.warn("[GEMINI_PROMPT] parts 없음, 룰 파서 폴백");
+                return Optional.empty();
+            }
+            String text = parts.get(0).path("text").asText("");
+            String json = stripJsonFence(text);
+            if (!StringUtils.hasText(json)) {
+                log.warn("[GEMINI_PROMPT] 본문 JSON 비어 있음, 룰 파서 폴백");
+                return Optional.empty();
+            }
+            LlmGuideRecommendJson parsed = objectMapper.readValue(json, LlmGuideRecommendJson.class);
+            GuideRecommendRequest built = LlmGuideRecommendMapper.toRequest(parsed, topN, guideCandidates);
+            if (!StringUtils.hasText(built.getRegion())) {
+                log.warn("[GEMINI_PROMPT] LLM 결과에 region 없음, 룰 파서 폴백");
+                return Optional.empty();
+            }
+            return Optional.of(built);
+        } catch (RestClientResponseException e) {
+            log.warn("[GEMINI_PROMPT] HTTP 오류, 룰 파서 폴백: {} {}", e.getStatusCode().value(), e.getStatusText());
+            return Optional.empty();
+        } catch (Exception e) {
+            log.warn("[GEMINI_PROMPT] LLM 추출 실패, 룰 파서 폴백: {}", e.toString());
+            return Optional.empty();
+        }
+    }
+
+    private static String stripJsonFence(String text) {
+        if (text == null) {
+            return "";
+        }
+        String t = text.trim();
+        if (t.startsWith("```")) {
+            int firstNl = t.indexOf('\n');
+            if (firstNl > 0) {
+                t = t.substring(firstNl + 1);
+            }
+            int fence = t.lastIndexOf("```");
+            if (fence >= 0) {
+                t = t.substring(0, fence).trim();
+            }
+        }
+        return t.trim();
+    }
+}

--- a/backend/module-gemini/src/test/java/com/team6/module/gemini/prompt/GeminiLlmPromptExtractorTest.java
+++ b/backend/module-gemini/src/test/java/com/team6/module/gemini/prompt/GeminiLlmPromptExtractorTest.java
@@ -1,0 +1,60 @@
+package com.team6.module.gemini.prompt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team6.module.ai.dto.request.GuideRecommendRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+class GeminiLlmPromptExtractorTest {
+
+    private MockRestServiceServer server;
+    private RestClient restClient;
+
+    @BeforeEach
+    void setUp() {
+        RestClient.Builder builder = RestClient.builder().baseUrl("https://generativelanguage.googleapis.com");
+        server = MockRestServiceServer.bindTo(builder).ignoreExpectOrder(true).build();
+        restClient = builder.build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.verify();
+    }
+
+    @Test
+    void tryExtract_parsesGeminiEnvelope() {
+        server.expect(request -> {
+                    String p = request.getURI().getPath();
+                    if (!p.contains("generateContent")) {
+                        throw new AssertionError("unexpected path: " + p);
+                    }
+                    String q = request.getURI().getQuery();
+                    if (q == null || !q.contains("key=test-key")) {
+                        throw new AssertionError("unexpected query: " + q);
+                    }
+                })
+                .andRespond(withSuccess(
+                        "{\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"{\\\"region\\\":\\\"제주\\\",\\\"activityTags\\\":[\\\"맛집\\\"]}\"}]}}]}",
+                        MediaType.APPLICATION_JSON
+                ));
+
+        GeminiLlmPromptExtractor ext = new GeminiLlmPromptExtractor(restClient, new ObjectMapper(), "gemini-2.0-flash", "test-key");
+        Optional<GuideRecommendRequest> out = ext.tryExtract("제주", 3, List.of());
+
+        assertThat(out).isPresent();
+        assertThat(out.get().getRegion()).isEqualTo("제주");
+        assertThat(out.get().getActivityTags()).containsExactly("맛집");
+        assertThat(out.get().getTopN()).isEqualTo(3);
+    }
+}

--- a/backend/module-openai/src/main/java/com/team6/module/openai/config/LocalGuestOpenAiConfiguration.java
+++ b/backend/module-openai/src/main/java/com/team6/module/openai/config/LocalGuestOpenAiConfiguration.java
@@ -14,6 +14,7 @@ import org.springframework.ai.tool.execution.DefaultToolExecutionExceptionProces
 import org.springframework.ai.tool.resolution.StaticToolCallbackResolver;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.retry.support.RetryTemplate;
@@ -82,7 +83,7 @@ public class LocalGuestOpenAiConfiguration {
 
     @Bean
     @ConditionalOnBean(OpenAiChatModel.class)
-    @ConditionalOnProperty(prefix = "localguest.ai", name = "llm-prompt-extraction-enabled", havingValue = "true", matchIfMissing = false)
+    @Conditional(OnOpenAiLlmExtractionProperties.class)
     public LlmPromptExtractor llmPromptExtractor(OpenAiChatModel chatModel, ObjectMapper objectMapper) {
         return new OpenAiLlmPromptExtractor(chatModel, objectMapper);
     }

--- a/backend/module-openai/src/main/java/com/team6/module/openai/config/OnOpenAiLlmExtractionProperties.java
+++ b/backend/module-openai/src/main/java/com/team6/module/openai/config/OnOpenAiLlmExtractionProperties.java
@@ -1,0 +1,20 @@
+package com.team6.module.openai.config;
+
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+/**
+ * {@code localguest.ai.llm-prompt-extraction-enabled=true} 이고 {@code localguest.ai.llm-provider=openai}(기본)일 때만 참.
+ */
+public final class OnOpenAiLlmExtractionProperties implements Condition {
+
+    @Override
+    public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+        var env = context.getEnvironment();
+        if (!Boolean.parseBoolean(env.getProperty("localguest.ai.llm-prompt-extraction-enabled", "false"))) {
+            return false;
+        }
+        return "openai".equalsIgnoreCase(env.getProperty("localguest.ai.llm-provider", "openai"));
+    }
+}

--- a/backend/module-openai/src/main/java/com/team6/module/openai/prompt/OpenAiLlmPromptExtractor.java
+++ b/backend/module-openai/src/main/java/com/team6/module/openai/prompt/OpenAiLlmPromptExtractor.java
@@ -2,8 +2,12 @@ package com.team6.module.openai.prompt;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.team6.module.ai.dto.request.GuideRecommendRequest;
+import com.team6.module.ai.llm.LlmGuideRecommendJson;
+import com.team6.module.ai.llm.LlmGuideRecommendMapper;
+import com.team6.module.ai.llm.LlmPromptExtractionSystemText;
 import com.team6.module.ai.spi.LlmPromptExtractor;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.ai.chat.messages.UserMessage;
@@ -22,19 +26,9 @@ import java.util.Optional;
  * OpenAI(ChatModel)로 프롬프트를 구조화한 뒤 {@link GuideRecommendRequest}로 만든다.
  * <p>후보 목록·{@code topN}은 호출 인자를 그대로 쓰며, LLM 출력의 해당 필드는 무시한다.
  */
-@Slf4j
 public final class OpenAiLlmPromptExtractor implements LlmPromptExtractor {
 
-    private static final String SYSTEM_INSTRUCTION = """
-            당신은 여행 매칭용 정보 추출기다. 사용자 한국어 입력만 보고 아래 키를 가진 JSON 객체 하나만 출력한다. 설명·마크다운·코드펜스 금지.
-            키: region, travelStyle, budgetLevel, budgetMinWon, budgetMaxWon, budgetScope, strictBudget, companionType,
-            activityTags, requiredActivityTags, niceToHaveActivityTags, preferredLanguages, requiredLanguages, niceToHaveLanguages,
-            allowAdjacentRegion, headcount, durationDays, excludedActivityTags, excludedRegions, excludedTravelStyles, excludedLanguages, softPenaltyActivityTags,
-            guideBullets, specialRequests.
-            guideBullets는 가이드에게 보여줄 짧은 한국어 반말 불릿(한 줄당 한 가지). specialRequests는 따로 전달해야 할 문단이 있을 때만(없으면 null).
-            모르면 null. 배열은 JSON 배열(빈 배열 가능). region은 한국어 지역명이면 그대로(예: 제주, 서울, 부산). 숫자는 정수.
-            연락처·이메일·SNS·상세 주소는 넣지 말 것.
-            """;
+    private static final Logger log = LoggerFactory.getLogger(OpenAiLlmPromptExtractor.class);
 
     private final ChatModel chatModel;
     private final ObjectMapper objectMapper;
@@ -56,7 +50,10 @@ public final class OpenAiLlmPromptExtractor implements LlmPromptExtractor {
         try {
             OpenAiChatOptions opts = buildCallOptions();
             Prompt p = new Prompt(
-                    List.of(new SystemMessage(SYSTEM_INSTRUCTION), new UserMessage(prompt.trim())),
+                    List.of(
+                            new SystemMessage(LlmPromptExtractionSystemText.KOREAN_JSON_EXTRACTOR),
+                            new UserMessage(prompt.trim())
+                    ),
                     opts
             );
             ChatResponse response = chatModel.call(p);
@@ -67,7 +64,7 @@ public final class OpenAiLlmPromptExtractor implements LlmPromptExtractor {
                 return Optional.empty();
             }
             LlmGuideRecommendJson parsed = objectMapper.readValue(json, LlmGuideRecommendJson.class);
-            GuideRecommendRequest built = toGuideRequest(parsed, topN, guideCandidates);
+            GuideRecommendRequest built = LlmGuideRecommendMapper.toRequest(parsed, topN, guideCandidates);
             if (!StringUtils.hasText(built.getRegion())) {
                 log.warn("[OPEN_AI_PROMPT] LLM 결과에 region 없음, 룰 파서 폴백");
                 return Optional.empty();
@@ -103,70 +100,5 @@ public final class OpenAiLlmPromptExtractor implements LlmPromptExtractor {
             }
         }
         return t.trim();
-    }
-
-    private static GuideRecommendRequest toGuideRequest(
-            LlmGuideRecommendJson j,
-            int topN,
-            List<GuideRecommendRequest.GuideCandidateDto> guideCandidates
-    ) {
-        return GuideRecommendRequest.builder()
-                .region(trimToNull(j.getRegion()))
-                .travelStyle(trimToNull(j.getTravelStyle()))
-                .budgetLevel(trimToNull(j.getBudgetLevel()))
-                .budgetMinWon(j.getBudgetMinWon())
-                .budgetMaxWon(j.getBudgetMaxWon())
-                .budgetScope(trimToNull(j.getBudgetScope()))
-                .strictBudget(j.getStrictBudget())
-                .companionType(trimToNull(j.getCompanionType()))
-                .activityTags(copyList(j.getActivityTags()))
-                .requiredActivityTags(copyList(j.getRequiredActivityTags()))
-                .niceToHaveActivityTags(copyList(j.getNiceToHaveActivityTags()))
-                .preferredLanguages(copyList(j.getPreferredLanguages()))
-                .requiredLanguages(copyList(j.getRequiredLanguages()))
-                .niceToHaveLanguages(copyList(j.getNiceToHaveLanguages()))
-                .allowAdjacentRegion(j.getAllowAdjacentRegion())
-                .headcount(j.getHeadcount())
-                .durationDays(j.getDurationDays())
-                .excludedActivityTags(copyList(j.getExcludedActivityTags()))
-                .excludedRegions(copyList(j.getExcludedRegions()))
-                .excludedTravelStyles(copyList(j.getExcludedTravelStyles()))
-                .excludedLanguages(copyList(j.getExcludedLanguages()))
-                .softPenaltyActivityTags(copyList(j.getSoftPenaltyActivityTags()))
-                .llmGuideBullets(copyMaskedBulletList(j.getGuideBullets()))
-                .llmSpecialRequests(trimToNull(LlmCopyPiiMasker.mask(trimToNull(j.getSpecialRequests()))))
-                .topN(topN)
-                .guideCandidates(guideCandidates)
-                .build();
-    }
-
-    private static String trimToNull(String s) {
-        if (s == null) {
-            return null;
-        }
-        String t = s.trim();
-        return t.isEmpty() ? null : t;
-    }
-
-    private static List<String> copyMaskedBulletList(List<String> raw) {
-        if (raw == null || raw.isEmpty()) {
-            return null;
-        }
-        List<String> cleaned = raw.stream()
-                .map(s -> s == null ? "" : LlmCopyPiiMasker.mask(s.trim()))
-                .filter(StringUtils::hasText)
-                .toList();
-        return cleaned.isEmpty() ? null : List.copyOf(cleaned);
-    }
-
-    private static List<String> copyList(List<String> raw) {
-        if (raw == null || raw.isEmpty()) {
-            return null;
-        }
-        List<String> cleaned = raw.stream()
-                .map(s -> s == null ? "" : s.trim())
-                .filter(s -> !s.isEmpty())
-                .toList();
-        return cleaned.isEmpty() ? null : List.copyOf(cleaned);
     }
 }

--- a/backend/settings.gradle
+++ b/backend/settings.gradle
@@ -8,5 +8,6 @@ include 'module-ai'
 include 'module-ai-integration'
 
 include 'module-openai'
+include 'module-gemini'
 
 include 'module-common'


### PR DESCRIPTION
## 변경 범위
- `module-gemini` 추가: Gemini REST(`generateContent`)로 `LlmPromptExtractor` 구현
- `localguest.ai.llm-provider` (`openai` | `gemini`), `localguest.gemini.*` 설정
- OpenAI/Gemini 추출 빈은 각각 전용 `Condition`으로 등록(동일 프로퍼티 중복 `@ConditionalOnProperty` 회피)
- JSON/PII/시스템 프롬프트/매핑 공용화: `module-ai` `com.team6.module.ai.llm`
- **관측**: `[AI_RECOMMEND]` 로그에 `llmParse={{cfgProvider,extractorBean,outcome}}` 추가; Micrometer `llm_prompt_extraction`·`llm_prompt_extraction_latency`에 `llm_provider` 태그(`openai`|`gemini`|`unknown`)
- **부팅**: `[AI_LLM] startup ...` 한 줄(`LlmPromptExtractorStartupDiagnostics`)

## 스키마 영향
- 없음 (YAML/환경 변수만)

## 검증
```bash
cd backend && ./gradlew :module-ai:test :module-openai:test :module-gemini:test :api-server:compileJava
```

Closes #436