### PR TITLE
[Fix/fe#444] AI 검색 요약을 매칭 요청에 전달

### DIFF
--- a/frontend/src/pages/AiQuickSearchPage.jsx
+++ b/frontend/src/pages/AiQuickSearchPage.jsx
@@ -266,8 +266,24 @@ export function AiQuickSearchPage() {
   const persistMatchDraftForGuide = useCallback(
     (guideId) => {
       try {
-        const draft = result?.matchRequestDraft ?? null
-        if (!draft || !guideId) return
+        if (guideId == null || guideId === '') return
+
+        const draft =
+          result?.matchRequestDraft != null && typeof result.matchRequestDraft === 'object'
+            ? { ...result.matchRequestDraft }
+            : {}
+
+        const topSummary = typeof result?.conceptSummary === 'string' ? String(result.conceptSummary).trim() : ''
+        if (topSummary && !String(draft.conceptSummary || '').trim()) {
+          draft.conceptSummary = topSummary
+        }
+        const region = result?.keywords?.region
+        if (region && !String(draft.destination || '').trim()) {
+          draft.destination = String(region).trim()
+        }
+
+        const hasPayload = Object.keys(draft).length > 0
+        if (!hasPayload) return
         sessionStorage.setItem(
           LS_AI_MATCH_DRAFT,
           JSON.stringify({

--- a/frontend/src/pages/GuideDetailPage.jsx
+++ b/frontend/src/pages/GuideDetailPage.jsx
@@ -231,7 +231,11 @@ export function GuideDetailPage() {
       const draft = snap?.matchRequestDraft ?? null
       if (!draft || typeof draft !== 'object') return
 
-      if (draft?.conceptSummary) setAiConceptSummary(String(draft.conceptSummary))
+      const summaryFromDraft =
+        (draft?.conceptSummary && String(draft.conceptSummary).trim()) ||
+        (draft?.concept && String(draft.concept).trim()) ||
+        ''
+      if (summaryFromDraft) setAiConceptSummary(summaryFromDraft)
       if (draft?.desiredBudget != null && draft.desiredBudget !== '') setAiDesiredBudget(Number(draft.desiredBudget))
       if (draft?.budgetMinWon != null && draft.budgetMinWon !== '') setAiBudgetMinWon(Number(draft.budgetMinWon))
       if (draft?.budgetMaxWon != null && draft.budgetMaxWon !== '') setAiBudgetMaxWon(Number(draft.budgetMaxWon))


### PR DESCRIPTION
## 변경 범위
- AI 검색 결과에서 가이드 상세로 이동할 때 `matchRequestDraft`가 비어도 `conceptSummary`/지역을 포함해 sessionStorage에 저장
- 가이드 상세에서 draft의 `conceptSummary`가 없으면 `concept`로 보조 채움

## 스키마 영향
- 없음

## 검증
```bash
cd frontend && npm run build
```

Closes #444

Made with [Cursor](https://cursor.com)