### PR TITLE
[Feat/be#448] LLM specialRequests 가이드용 요약 강화

### DIFF
--- a/backend/module-ai/src/main/java/com/team6/module/ai/llm/LlmGuideRecommendJson.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/llm/LlmGuideRecommendJson.java
@@ -38,6 +38,6 @@ public class LlmGuideRecommendJson {
     private List<String> softPenaltyActivityTags;
     /** 가이드에게 보여줄 짧은 불릿(반말 한 줄씩). */
     private List<String> guideBullets;
-    /** 특별 요청 등 문단으로 전달할 내용. */
+    /** 가이드에게 보여줄 서술형 요약(한두 문장). LLM 시스템 프롬프트에서 우선 채우도록 유도한다. */
     private String specialRequests;
 }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/llm/LlmGuideRecommendMapper.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/llm/LlmGuideRecommendMapper.java
@@ -10,6 +10,9 @@ import java.util.List;
  */
 public final class LlmGuideRecommendMapper {
 
+    /** DB·가이드 UI 과다 길이 방지(매칭 요약 등과 합쳐져도 TEXT 범위 내). */
+    private static final int MAX_SPECIAL_REQUESTS_CHARS = 500;
+
     private LlmGuideRecommendMapper() {
     }
 
@@ -42,7 +45,7 @@ public final class LlmGuideRecommendMapper {
                 .excludedLanguages(copyList(j.getExcludedLanguages()))
                 .softPenaltyActivityTags(copyList(j.getSoftPenaltyActivityTags()))
                 .llmGuideBullets(copyMaskedBulletList(j.getGuideBullets()))
-                .llmSpecialRequests(trimToNull(LlmCopyPiiMasker.mask(trimToNull(j.getSpecialRequests()))))
+                .llmSpecialRequests(limitSpecialRequests(trimToNull(LlmCopyPiiMasker.mask(trimToNull(j.getSpecialRequests())))))
                 .topN(topN)
                 .guideCandidates(guideCandidates)
                 .build();
@@ -54,6 +57,17 @@ public final class LlmGuideRecommendMapper {
         }
         String t = s.trim();
         return t.isEmpty() ? null : t;
+    }
+
+    private static String limitSpecialRequests(String s) {
+        if (s == null) {
+            return null;
+        }
+        if (s.length() <= MAX_SPECIAL_REQUESTS_CHARS) {
+            return s;
+        }
+        String cut = s.substring(0, MAX_SPECIAL_REQUESTS_CHARS).trim();
+        return cut.isEmpty() ? null : cut;
     }
 
     private static List<String> copyMaskedBulletList(List<String> raw) {

--- a/backend/module-ai/src/main/java/com/team6/module/ai/llm/LlmPromptExtractionSystemText.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/llm/LlmPromptExtractionSystemText.java
@@ -14,8 +14,11 @@ public final class LlmPromptExtractionSystemText {
             activityTags, requiredActivityTags, niceToHaveActivityTags, preferredLanguages, requiredLanguages, niceToHaveLanguages,
             allowAdjacentRegion, headcount, durationDays, excludedActivityTags, excludedRegions, excludedTravelStyles, excludedLanguages, softPenaltyActivityTags,
             guideBullets, specialRequests.
-            guideBullets는 가이드에게 보여줄 짧은 한국어 반말 불릿(한 줄당 한 가지). specialRequests는 따로 전달해야 할 문단이 있을 때만(없으면 null).
-            모르면 null. 배열은 JSON 배열(빈 배열 가능). region은 한국어 지역명이면 그대로(예: 제주, 서울, 부산). 숫자는 정수.
-            연락처·이메일·SNS·상세 주소는 넣지 말 것.
+            guideBullets: 가이드가 스캔하기 좋은 짧은 한국어 불릿 2~5개(한 줄당 한 가지, 반말·구어 OK). 핵심만. 없으면 [].
+            specialRequests: 가이드에게 그대로 보여줄 **한국어 요약 문장**(권장 1문장, 길어도 공백 포함 220자 이내). 사용자가 동선·순서·방문지·느낌을 말로 풀었으면 **반드시** 여기에 압축한다.
+            요약에는 이동 방향(예: 반시계), 랜드마크(오름·한라산 등), 일정 감이 드는 표현을 넣는다. "가운데 산 이름이 기억 안 난다"처럼 막연하면 문맥상 제주 한가운데 산이면 **한라산**으로 정리해도 된다. 확신 없으면 "한라산(추정)"처럼 짧게 표시.
+            사용자가 한 줄짜리 목적지만 말한 경우에만 specialRequests는 null로 둔다. 그 외에는 null 금지.
+            그 밖의 필드는 알 수 없으면 null. 배열은 JSON 배열(빈 배열 가능). region은 한국어 지역명이면 그대로(예: 제주, 서울, 부산). 숫자는 정수.
+            연락처·이메일·SNS·상세 주소·개인 식별 정보는 넣지 말 것.
             """;
 }

--- a/backend/module-ai/src/test/java/com/team6/module/ai/llm/LlmGuideRecommendMapperTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/llm/LlmGuideRecommendMapperTest.java
@@ -1,0 +1,23 @@
+package com.team6.module.ai.llm;
+
+import com.team6.module.ai.dto.request.GuideRecommendRequest;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LlmGuideRecommendMapperTest {
+
+    @Test
+    void toRequest_truncates_specialRequests_over500() {
+        String longText = "가".repeat(520);
+        LlmGuideRecommendJson j = new LlmGuideRecommendJson();
+        j.setRegion("제주");
+        j.setSpecialRequests(longText);
+
+        GuideRecommendRequest r = LlmGuideRecommendMapper.toRequest(j, 3, List.of());
+
+        assertThat(r.getLlmSpecialRequests()).hasSize(500);
+    }
+}

--- a/backend/module-ai/src/test/java/com/team6/module/ai/llm/LlmPromptExtractionSystemTextTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/llm/LlmPromptExtractionSystemTextTest.java
@@ -1,0 +1,17 @@
+package com.team6.module.ai.llm;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LlmPromptExtractionSystemTextTest {
+
+    @Test
+    void koreanJsonExtractor_requiresGuideFacingSummary() {
+        String t = LlmPromptExtractionSystemText.KOREAN_JSON_EXTRACTOR;
+        assertThat(t).contains("specialRequests");
+        assertThat(t).contains("guideBullets");
+        assertThat(t).contains("220");
+        assertThat(t).contains("한라산");
+    }
+}


### PR DESCRIPTION
## 변경 범위
- LLM 프롬프트 추출 시스템 지시문에서 `specialRequests`를 가이드용 요약 1문장(권장, 220자 이내)로 강하게 유도
- 동선/방문지(오름·한라산 등) 중심 압축, 불확실 시 `(추정)` 표기 허용
- `specialRequests`는 PII 마스킹 후 500자 상한 적용
- 단위 테스트 추가

## 스키마 영향
- 없음

## 검증
```bash
cd backend && ./gradlew :module-ai:test
```

Closes #448

Made with [Cursor](https://cursor.com)