### PR TITLE
[Fix/be#450] 매칭 요청 컨셉 중복 제거(LLM 요약)

### DIFF
--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/ConceptSummaryGenerator.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/ConceptSummaryGenerator.java
@@ -149,15 +149,6 @@ public final class ConceptSummaryGenerator {
         }
 
         String result = String.join(" / ", parts).trim();
-        if (hasLlmGuideCopy(req)) {
-            String llm = formatLlmGuideCopy(req.getLlmGuideBullets(), req.getLlmSpecialRequests());
-            if (StringUtils.hasText(llm)) {
-                if (StringUtils.hasText(result)) {
-                    return llm + "\n\n" + result;
-                }
-                return llm;
-            }
-        }
         return result.isBlank() ? null : result;
     }
 

--- a/backend/module-ai/src/test/java/com/team6/module/ai/support/ConceptSummaryGeneratorLlmTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/support/ConceptSummaryGeneratorLlmTest.java
@@ -22,7 +22,7 @@ class ConceptSummaryGeneratorLlmTest {
     }
 
     @Test
-    void generateMatchRequestConcept_prefixesLlmCopy() {
+    void generateMatchRequestConcept_doesNotDuplicateLlmCopy() {
         GuideRecommendRequest req = GuideRecommendRequest.builder()
                 .region("부산")
                 .llmGuideBullets(List.of("야경 좋아해"))
@@ -30,7 +30,7 @@ class ConceptSummaryGeneratorLlmTest {
                 .build();
 
         String concept = ConceptSummaryGenerator.generateMatchRequestConcept(req);
-        assertThat(concept).startsWith("• 야경 좋아해");
         assertThat(concept).contains("부산 여행");
+        assertThat(concept).doesNotContain("야경 좋아해");
     }
 }


### PR DESCRIPTION
## 변경 범위
- `matchRequestDraft.concept` 생성 시 LLM 불릿/요약을 다시 붙이지 않도록 수정
  - 요약은 `conceptSummary`에만 남기고, `concept`는 구조화된 컨셉(지역/일정/활동/예산 등)만 포함
- 단위 테스트 갱신

## 스키마 영향
- 없음

## 검증
```bash
cd backend && ./gradlew :module-ai:test :api-server:compileJava
```

Closes #450

Made with [Cursor](https://cursor.com)