### PR TITLE
[Fix/be#455] LLM 요약 불릿-문단 빈줄 제거

### DIFF
--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/ConceptSummaryGenerator.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/ConceptSummaryGenerator.java
@@ -105,7 +105,7 @@ public final class ConceptSummaryGenerator {
         }
         if (StringUtils.hasText(specialRequests)) {
             if (sb.length() > 0) {
-                sb.append("\n\n");
+                sb.append('\n');
             }
             sb.append(specialRequests.trim());
         }

--- a/backend/module-ai/src/test/java/com/team6/module/ai/support/ConceptSummaryGeneratorLlmTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/support/ConceptSummaryGeneratorLlmTest.java
@@ -18,7 +18,7 @@ class ConceptSummaryGeneratorLlmTest {
                 .llmSpecialRequests("애매한 일정 조정 가능해")
                 .build();
 
-        assertThat(ConceptSummaryGenerator.generate(req)).isEqualTo("• 맛집 위주\n\n애매한 일정 조정 가능해");
+        assertThat(ConceptSummaryGenerator.generate(req)).isEqualTo("• 맛집 위주\n애매한 일정 조정 가능해");
     }
 
     @Test


### PR DESCRIPTION
## 변경 범위
- LLM 요약(conceptSummary)에서 불릿과 요약 문장 사이 개행을 `\n\n` → `\n`으로 축소
  - `ConceptSummaryGenerator.formatLlmGuideCopy`
- 단위 테스트 갱신

## 스키마 영향
- 없음

## 검증
```bash
cd backend && ./gradlew :module-ai:test :api-server:compileJava
```

Closes #455

Made with [Cursor](https://cursor.com)