### PR TITLE
[Fix/fe#457] AI 일정 기반 연속 날짜 자동 선택

### DIFF
--- a/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
@@ -415,6 +415,9 @@ public class PromptRecommendationService {
     }
 
     private static String mergeNotice(String primary, String secondary) {
+        if (primary == null || primary.isBlank()) {
+            return (secondary == null || secondary.isBlank()) ? null : secondary;
+        }
         if (secondary == null || secondary.isBlank()) {
             return primary;
         }

--- a/backend/module-ai/src/test/java/com/team6/module/ai/service/PromptRecommendationServiceTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/service/PromptRecommendationServiceTest.java
@@ -144,6 +144,14 @@ class PromptRecommendationServiceTest {
     }
 
     @Test
+    void mergeNotice_should_not_prefix_null() throws Exception {
+        var method = PromptRecommendationService.class.getDeclaredMethod("mergeNotice", String.class, String.class);
+        method.setAccessible(true);
+
+        assertThat((String) method.invoke(null, null, "지역 외 조건 신호가 적어")).isEqualTo("지역 외 조건 신호가 적어");
+    }
+
+    @Test
     void recommendByPrompt_when_exact_region_sparse_should_expand_adjacent_and_notice() {
         PromptRecommendationService service = createService();
 

--- a/backend/module-domain/src/main/java/com/team6/domain/guide/service/GuideScheduleService.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/service/GuideScheduleService.java
@@ -22,7 +22,13 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * 가이드 스케줄 서비스 (F06-04)
@@ -35,6 +41,11 @@ public class GuideScheduleService {
     private final GuideScheduleRepository guideScheduleRepository;
     private final GuideProfileRepository guideProfileRepository;
     private final MatchRequestRepository matchRequestRepository;
+
+    private static final EnumSet<MatchRequestStatus> ACTIVE_MATCH_STATUSES =
+            EnumSet.of(MatchRequestStatus.PENDING, MatchRequestStatus.ACCEPTED, MatchRequestStatus.PAID, MatchRequestStatus.IN_PROGRESS);
+    private static final Pattern NIGHTS_DAYS = Pattern.compile("(\\d{1,2})\\s*박\\s*(\\d{1,2})\\s*일");
+    private static final Pattern DAYS_ONLY = Pattern.compile("(\\d{1,2})\\s*일\\s*일정");
 
     // 스케줄 등록 (F06-04)
     @Transactional
@@ -115,9 +126,100 @@ public class GuideScheduleService {
     // 스케줄 목록 조회 — 날짜 오름차순 (F06-04)
     @Transactional(readOnly = true)
     public List<GuideScheduleResponse> getSchedules(Long guideId) {
-        return guideScheduleRepository.findByGuideProfile_IdOrderByAvailableDateAsc(guideId).stream()
+        List<GuideScheduleResponse> base = guideScheduleRepository.findByGuideProfile_IdOrderByAvailableDateAsc(guideId).stream()
                 .map(GuideScheduleResponse::from)
                 .toList();
+
+        // 연속 일정(예: 1박2일/2박3일) 요청이 PENDING~IN_PROGRESS 상태일 때,
+        // 다른 사용자의 달력에서도 해당 기간이 예약 불가로 보이도록 "가상 PENDING" 엔트리를 덧붙인다.
+        Map<LocalDate, Long> reservedDateToRequestId = new LinkedHashMap<>();
+        for (MatchRequest mr : matchRequestRepository.findByGuideId(guideId)) {
+            if (mr == null || mr.getStatus() == null || !ACTIVE_MATCH_STATUSES.contains(mr.getStatus())) {
+                continue;
+            }
+            LocalDate start = mr.getDesiredDate();
+            if (start == null) {
+                continue;
+            }
+            int days = inferDurationDays(mr);
+            if (days <= 1) {
+                continue;
+            }
+            for (int i = 0; i < days; i++) {
+                reservedDateToRequestId.putIfAbsent(start.plusDays(i), mr.getId());
+            }
+        }
+
+        if (reservedDateToRequestId.isEmpty()) {
+            return base;
+        }
+
+        ArrayList<GuideScheduleResponse> out = new ArrayList<>(base);
+        for (Map.Entry<LocalDate, Long> e : reservedDateToRequestId.entrySet()) {
+            LocalDate d = e.getKey();
+            if (d == null) {
+                continue;
+            }
+            boolean alreadyReserved =
+                    base.stream().anyMatch(r ->
+                            d.equals(r.getAvailableDate())
+                                    && (r.getStatus() == GuideScheduleStatus.PENDING || r.getStatus() == GuideScheduleStatus.BOOKED)
+                    );
+            if (alreadyReserved) {
+                continue;
+            }
+            out.add(GuideScheduleResponse.builder()
+                    .scheduleId(null)
+                    .guideId(guideId)
+                    .availableDate(d)
+                    .startTime(null)
+                    .endTime(null)
+                    .status(GuideScheduleStatus.PENDING)
+                    .matchRequestId(e.getValue())
+                    .isPaid(false)
+                    .hasCourse(false)
+                    .createdAt(null)
+                    .updatedAt(null)
+                    .build());
+        }
+
+        out.sort(Comparator
+                .comparing(GuideScheduleResponse::getAvailableDate, Comparator.nullsLast(Comparator.naturalOrder()))
+                .thenComparing(GuideScheduleResponse::getStartTime, Comparator.nullsLast(Comparator.naturalOrder())));
+        return out;
+    }
+
+    private static int inferDurationDays(MatchRequest mr) {
+        String blob = ((mr.getConceptSummary() == null ? "" : mr.getConceptSummary()) + " " + (mr.getConcept() == null ? "" : mr.getConcept())).trim();
+        if (blob.isBlank()) {
+            return 1;
+        }
+        var m1 = NIGHTS_DAYS.matcher(blob);
+        if (m1.find()) {
+            int days = safeParseInt(m1.group(2));
+            return clampDays(days);
+        }
+        var m2 = DAYS_ONLY.matcher(blob);
+        if (m2.find()) {
+            int days = safeParseInt(m2.group(1));
+            return clampDays(days);
+        }
+        return 1;
+    }
+
+    private static int safeParseInt(String raw) {
+        try {
+            return Integer.parseInt(raw);
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+
+    private static int clampDays(int days) {
+        if (days <= 1) {
+            return 1;
+        }
+        return Math.min(14, days);
     }
 
     // 스케줄 상태 변경 (AVAILABLE ↔ BLOCKED) (F06-04)

--- a/frontend/src/pages/GuideCourseEditorPage.css
+++ b/frontend/src/pages/GuideCourseEditorPage.css
@@ -133,6 +133,19 @@
   word-break: break-word;
 }
 
+.gce-value--date-range {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  align-items: baseline;
+  word-break: keep-all;
+}
+
+.gce-date-range-sep {
+  color: #9ca3af;
+  font-weight: 800;
+}
+
 .gce-concept {
   margin: 0.65rem 0 0;
   padding-top: 0.65rem;

--- a/frontend/src/pages/GuideCourseEditorPage.jsx
+++ b/frontend/src/pages/GuideCourseEditorPage.jsx
@@ -73,7 +73,8 @@ function formatDesiredDateRange(start, days) {
     const yyyy = end.getFullYear()
     const mm = String(end.getMonth() + 1).padStart(2, '0')
     const dd = String(end.getDate()).padStart(2, '0')
-    return `${s} ~ ${yyyy}-${mm}-${dd}`
+    const endKey = `${yyyy}-${mm}-${dd}`
+    return { start: s, end: endKey }
   } catch {
     return s
   }
@@ -324,13 +325,23 @@ export function GuideCourseEditorPage() {
             </div>
             <div className="gce-guest-item">
               <span className="gce-label">희망 일정</span>
-              <span className="gce-value">
-                {formatDesiredDateRange(
+              {(() => {
+                const range = formatDesiredDateRange(
                   matchRow.desiredDate,
                   inferDurationDaysFromText(matchRow.conceptSummary) ??
                     inferDurationDaysFromText(matchRow.concept),
-                )}
-              </span>
+                )
+                if (range && typeof range === 'object') {
+                  return (
+                    <span className="gce-value gce-value--date-range">
+                      <span>{range.start}</span>
+                      <span className="gce-date-range-sep">~</span>
+                      <span>{range.end}</span>
+                    </span>
+                  )
+                }
+                return <span className="gce-value">{range}</span>
+              })()}
             </div>
             <div className="gce-guest-item">
               <span className="gce-label">목적지</span>

--- a/frontend/src/pages/GuideCourseEditorPage.jsx
+++ b/frontend/src/pages/GuideCourseEditorPage.jsx
@@ -44,6 +44,41 @@ function formatDesiredDate(d) {
   return String(d)
 }
 
+function inferDurationDaysFromText(text) {
+  if (!text) return null
+  const s = String(text)
+  const nightsDays = s.match(/(\d{1,2})\s*박\s*(\d{1,2})\s*일/)
+  if (nightsDays) {
+    const days = Number(nightsDays[2])
+    return Number.isFinite(days) && days > 0 ? days : null
+  }
+  const daysOnly = s.match(/(\d{1,2})\s*일\s*일정/)
+  if (daysOnly) {
+    const days = Number(daysOnly[1])
+    return Number.isFinite(days) && days > 0 ? days : null
+  }
+  return null
+}
+
+function formatDesiredDateRange(start, days) {
+  if (start == null || start === '') return '—'
+  const s = String(start)
+  const n = days != null ? Number(days) : NaN
+  if (!Number.isFinite(n) || n <= 1) return s
+  try {
+    const base = new Date(s)
+    if (Number.isNaN(base.getTime())) return s
+    const end = new Date(base)
+    end.setDate(end.getDate() + Math.floor(n) - 1)
+    const yyyy = end.getFullYear()
+    const mm = String(end.getMonth() + 1).padStart(2, '0')
+    const dd = String(end.getDate()).padStart(2, '0')
+    return `${s} ~ ${yyyy}-${mm}-${dd}`
+  } catch {
+    return s
+  }
+}
+
 function formatRequestedAt(iso) {
   if (iso == null || iso === '') return '—'
   try {
@@ -289,7 +324,13 @@ export function GuideCourseEditorPage() {
             </div>
             <div className="gce-guest-item">
               <span className="gce-label">희망 일정</span>
-              <span className="gce-value">{formatDesiredDate(matchRow.desiredDate)}</span>
+              <span className="gce-value">
+                {formatDesiredDateRange(
+                  matchRow.desiredDate,
+                  inferDurationDaysFromText(matchRow.conceptSummary) ??
+                    inferDurationDaysFromText(matchRow.concept),
+                )}
+              </span>
             </div>
             <div className="gce-guest-item">
               <span className="gce-label">목적지</span>

--- a/frontend/src/pages/GuideDetailPage.css
+++ b/frontend/src/pages/GuideDetailPage.css
@@ -854,3 +854,24 @@
     sans-serif;
   font-size: 0.8rem;
 }
+
+.gdp-match-cal--gss3 .gdp-match-day.is-range {
+  background: rgba(13, 148, 136, 0.12);
+}
+
+.gdp-match-cal--gss3 .gdp-match-day.is-range.is-selected,
+.gdp-match-cal--gss3 .gdp-match-day.is-range-start,
+.gdp-match-cal--gss3 .gdp-match-day.is-range-end {
+  background: #0d9488;
+  color: #fff;
+}
+
+.gdp-match-cal--gss3 .gdp-match-day.is-range-start {
+  border-top-left-radius: 999px;
+  border-bottom-left-radius: 999px;
+}
+
+.gdp-match-cal--gss3 .gdp-match-day.is-range-end {
+  border-top-right-radius: 999px;
+  border-bottom-right-radius: 999px;
+}

--- a/frontend/src/pages/GuideDetailPage.jsx
+++ b/frontend/src/pages/GuideDetailPage.jsx
@@ -195,6 +195,7 @@ export function GuideDetailPage() {
   const [aiBudgetMinWon, setAiBudgetMinWon] = useState(null)
   const [aiBudgetMaxWon, setAiBudgetMaxWon] = useState(null)
   const [aiHiddenConcept, setAiHiddenConcept] = useState(null)
+  const [aiDurationDays, setAiDurationDays] = useState(null)
 
   const [detail, setDetail] = useState(null)
   const [schedules, setSchedules] = useState([])
@@ -239,6 +240,7 @@ export function GuideDetailPage() {
       if (draft?.desiredBudget != null && draft.desiredBudget !== '') setAiDesiredBudget(Number(draft.desiredBudget))
       if (draft?.budgetMinWon != null && draft.budgetMinWon !== '') setAiBudgetMinWon(Number(draft.budgetMinWon))
       if (draft?.budgetMaxWon != null && draft.budgetMaxWon !== '') setAiBudgetMaxWon(Number(draft.budgetMaxWon))
+      if (draft?.durationDays != null && draft.durationDays !== '') setAiDurationDays(Number(draft.durationDays))
       if (draft?.budgetMinWon != null && draft.budgetMinWon !== '') setBudgetMinWonInput(String(Number(draft.budgetMinWon)))
       if (draft?.budgetMaxWon != null && draft.budgetMaxWon !== '') setBudgetMaxWonInput(String(Number(draft.budgetMaxWon)))
       if (draft?.concept) setAiHiddenConcept(String(draft.concept))
@@ -406,6 +408,38 @@ export function GuideDetailPage() {
     return set
   }, [schedules])
 
+  const effectiveDurationDays = useMemo(() => {
+    const n = aiDurationDays != null ? Number(aiDurationDays) : NaN
+    if (!Number.isFinite(n) || n <= 1) return 1
+    return Math.min(14, Math.max(1, Math.floor(n)))
+  }, [aiDurationDays])
+
+  const selectedRangeKeys = useMemo(() => {
+    if (!selectedDateKey) return []
+    if (effectiveDurationDays <= 1) return [selectedDateKey]
+    const out = []
+    const base = new Date(selectedDateKey)
+    if (Number.isNaN(base.getTime())) return [selectedDateKey]
+    for (let i = 0; i < effectiveDurationDays; i += 1) {
+      const d = new Date(base)
+      d.setDate(d.getDate() + i)
+      out.push(ymd(d))
+    }
+    return out
+  }, [effectiveDurationDays, selectedDateKey])
+
+  const isSelectedRangeValid = useMemo(() => {
+    if (!selectedDateKey) return true
+    if (selectedRangeKeys.length <= 1) return true
+    return selectedRangeKeys.every((k) => {
+      if (!k) return false
+      if (isPastDateKey(k)) return false
+      if (blockedDateSet.has(k)) return false
+      if (reservedDateSet.has(k)) return false
+      return true
+    })
+  }, [blockedDateSet, reservedDateSet, selectedDateKey, selectedRangeKeys])
+
   const availableByDate = useMemo(() => {
     /** @type {Map<string, any[]>} */
     const map = new Map()
@@ -518,6 +552,10 @@ export function GuideDetailPage() {
     }
     if (isPastDateKey(selectedDateKey)) {
       setSubmitErr('지난 날짜에는 요청할 수 없습니다.')
+      return
+    }
+    if (!isSelectedRangeValid) {
+      setSubmitErr(`선택한 시작일로 ${effectiveDurationDays}일 연속 일정이 어렵습니다. 다른 시작일을 선택해 주세요.`)
       return
     }
     if (blockedDateSet.has(selectedDateKey)) {
@@ -849,13 +887,37 @@ export function GuideDetailPage() {
                     const hasSchedule = availableByDate.has(key)
                     const selectable = inMonth && !isPast && !isBlocked && !isReserved
                     const selected = selectable && key === selectedDateKey
+                    const inRange = selectedRangeKeys.includes(key)
+                    const isRangeStart = inRange && key === selectedDateKey
+                    const isRangeEnd =
+                      inRange && selectedRangeKeys.length > 0 && key === selectedRangeKeys[selectedRangeKeys.length - 1]
                     return (
                       <button
                         key={cell.key}
                         type="button"
-                        className={`gdp-match-day${!inMonth ? ' is-out' : ''}${isPast ? ' is-past' : ''}${selectable ? ' is-on' : ''}${isBlocked ? ' is-blocked' : ''}${isReserved ? ' is-reserved' : ''}${selected ? ' is-selected' : ''}`}
+                        className={`gdp-match-day${!inMonth ? ' is-out' : ''}${isPast ? ' is-past' : ''}${selectable ? ' is-on' : ''}${isBlocked ? ' is-blocked' : ''}${isReserved ? ' is-reserved' : ''}${selected ? ' is-selected' : ''}${inRange ? ' is-range' : ''}${isRangeStart ? ' is-range-start' : ''}${isRangeEnd ? ' is-range-end' : ''}`}
                         disabled={!selectable}
                         onClick={() => {
+                          setSubmitErr('')
+                          if (effectiveDurationDays > 1) {
+                            const rangeKeys = []
+                            for (let i = 0; i < effectiveDurationDays; i += 1) {
+                              const d = new Date(cell.date)
+                              d.setDate(d.getDate() + i)
+                              rangeKeys.push(ymd(d))
+                            }
+                            const bad = rangeKeys.find((k) => {
+                              if (!k) return true
+                              if (isPastDateKey(k)) return true
+                              if (blockedDateSet.has(k)) return true
+                              if (reservedDateSet.has(k)) return true
+                              return false
+                            })
+                            if (bad) {
+                              setSubmitErr(`선택한 시작일로 ${effectiveDurationDays}일 연속 일정이 어렵습니다. 다른 시작일을 선택해 주세요.`)
+                              return
+                            }
+                          }
                           setSelectedDateKey(key)
                           const picks = availableByDate.get(key) ?? []
                           if (picks.length > 0) setSelectedScheduleId(Number(picks[0].scheduleId))
@@ -951,7 +1013,7 @@ export function GuideDetailPage() {
               <button
                 type="submit"
                 className="gdp-match-submit"
-                disabled={submitting || !selectedDateKey || blockedDateSet.has(selectedDateKey) || reservedDateSet.has(selectedDateKey)}
+                disabled={submitting || !selectedDateKey || !isSelectedRangeValid || blockedDateSet.has(selectedDateKey) || reservedDateSet.has(selectedDateKey)}
               >
                 {submitting ? '요청 전송 중…' : '매칭 요청 보내기 ✈️'}
               </button>

--- a/frontend/src/pages/GuideMypagePages.css
+++ b/frontend/src/pages/GuideMypagePages.css
@@ -3515,12 +3515,13 @@
 
 /* 연속 PENDING(같은 매칭 요청) — 범위처럼 연결 */
 .gss3-cal-grid .gss3-day--pending.gss3-day--range {
-  background: rgba(250, 204, 21, 0.22);
+  background: transparent;
+  border-color: transparent;
 }
 
 .gss3-cal-grid .gss3-day--pending.gss3-day--range-start,
 .gss3-cal-grid .gss3-day--pending.gss3-day--range-end {
-  background: #fffbeb;
+  background: transparent;
 }
 
 .gss3-cal-grid .gss3-day--pending.gss3-day--range-start {
@@ -3531,6 +3532,35 @@
 .gss3-cal-grid .gss3-day--pending.gss3-day--range-end {
   border-top-right-radius: 999px;
   border-bottom-right-radius: 999px;
+}
+
+.gss3-cal-grid .gss3-day--pending.gss3-day--range::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 6px;
+  bottom: 6px;
+  background: rgba(250, 204, 21, 0.22);
+  z-index: 0;
+}
+
+.gss3-cal-grid .gss3-day--pending.gss3-day--range-start::before {
+  left: 6px;
+  border-top-left-radius: 999px;
+  border-bottom-left-radius: 999px;
+}
+
+.gss3-cal-grid .gss3-day--pending.gss3-day--range-end::before {
+  right: 6px;
+  border-top-right-radius: 999px;
+  border-bottom-right-radius: 999px;
+}
+
+.gss3-cal-grid .gss3-day--pending.gss3-day--range-start.gss3-day--range-end::before {
+  left: 6px;
+  right: 6px;
+  border-radius: 999px;
 }
 
 .gss3-cal-grid .gss3-day--blocked {

--- a/frontend/src/pages/GuideMypagePages.css
+++ b/frontend/src/pages/GuideMypagePages.css
@@ -3503,64 +3503,15 @@
 }
 
 .gss3-cal-grid .gss3-day--pending {
-  background: #fffbeb;
-  border-color: #fde68a;
+  /* 수락 대기도 "예약된 날"로 인지되게 booked 톤에 맞춤 */
+  background: #ecfdf5;
+  border-color: #a7f3d0;
   box-shadow: none;
 }
 
 .gss3-cal-grid .gss3-day--pending .gss3-day-num {
-  color: #92400e;
+  color: #065f46;
   font-weight: 700;
-}
-
-/* 연속 PENDING(같은 매칭 요청) — 범위처럼 연결 */
-.gss3-cal-grid .gss3-day--pending.gss3-day--range {
-  background: transparent;
-  border-color: transparent;
-}
-
-.gss3-cal-grid .gss3-day--pending.gss3-day--range-start,
-.gss3-cal-grid .gss3-day--pending.gss3-day--range-end {
-  background: transparent;
-}
-
-.gss3-cal-grid .gss3-day--pending.gss3-day--range-start {
-  border-top-left-radius: 999px;
-  border-bottom-left-radius: 999px;
-}
-
-.gss3-cal-grid .gss3-day--pending.gss3-day--range-end {
-  border-top-right-radius: 999px;
-  border-bottom-right-radius: 999px;
-}
-
-.gss3-cal-grid .gss3-day--pending.gss3-day--range::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  right: 0;
-  top: 6px;
-  bottom: 6px;
-  background: rgba(250, 204, 21, 0.22);
-  z-index: 0;
-}
-
-.gss3-cal-grid .gss3-day--pending.gss3-day--range-start::before {
-  left: 6px;
-  border-top-left-radius: 999px;
-  border-bottom-left-radius: 999px;
-}
-
-.gss3-cal-grid .gss3-day--pending.gss3-day--range-end::before {
-  right: 6px;
-  border-top-right-radius: 999px;
-  border-bottom-right-radius: 999px;
-}
-
-.gss3-cal-grid .gss3-day--pending.gss3-day--range-start.gss3-day--range-end::before {
-  left: 6px;
-  right: 6px;
-  border-radius: 999px;
 }
 
 .gss3-cal-grid .gss3-day--blocked {

--- a/frontend/src/pages/GuideMypagePages.css
+++ b/frontend/src/pages/GuideMypagePages.css
@@ -3513,6 +3513,26 @@
   font-weight: 700;
 }
 
+/* 연속 PENDING(같은 매칭 요청) — 범위처럼 연결 */
+.gss3-cal-grid .gss3-day--pending.gss3-day--range {
+  background: rgba(250, 204, 21, 0.22);
+}
+
+.gss3-cal-grid .gss3-day--pending.gss3-day--range-start,
+.gss3-cal-grid .gss3-day--pending.gss3-day--range-end {
+  background: #fffbeb;
+}
+
+.gss3-cal-grid .gss3-day--pending.gss3-day--range-start {
+  border-top-left-radius: 999px;
+  border-bottom-left-radius: 999px;
+}
+
+.gss3-cal-grid .gss3-day--pending.gss3-day--range-end {
+  border-top-right-radius: 999px;
+  border-bottom-right-radius: 999px;
+}
+
 .gss3-cal-grid .gss3-day--blocked {
   background: #f8fafc;
   border-color: #e5e7eb;

--- a/frontend/src/pages/GuideScheduleSection.jsx
+++ b/frontend/src/pages/GuideScheduleSection.jsx
@@ -577,16 +577,7 @@ export function GuideScheduleSection({
             }
             if (isSelected && key != null) cls += ' gss3-day--selected'
 
-            if (key && cell.inMonth && !past && status === 'pending') {
-              const gid = pendingGroupByDate.get(key) ?? null
-              if (gid) {
-                const prev = pendingGroupByDate.get(addDaysKey(key, -1))
-                const next = pendingGroupByDate.get(addDaysKey(key, 1))
-                if (prev === gid || next === gid) cls += ' gss3-day--range'
-                if (prev !== gid) cls += ' gss3-day--range-start'
-                if (next !== gid) cls += ' gss3-day--range-end'
-              }
-            }
+            // 연속 일정이라도 캘린더는 "해당 날짜들이 예약(대기) 상태"임을 각 칸으로 명확히 보여준다.
 
             return (
               <button

--- a/frontend/src/pages/GuideScheduleSection.jsx
+++ b/frontend/src/pages/GuideScheduleSection.jsx
@@ -33,6 +33,18 @@ const WEEKDAYS = ['일', '월', '화', '수', '목', '금', '토']
 const WEEKDAYS_SHORT = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT']
 const MONTHS_KO = ['1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월', '9월', '10월', '11월', '12월']
 
+function addDaysKey(key, deltaDays) {
+  if (!key) return null
+  try {
+    const base = new Date(`${String(key)}T00:00:00`)
+    if (Number.isNaN(base.getTime())) return null
+    base.setDate(base.getDate() + Number(deltaDays || 0))
+    return ymd(base)
+  } catch {
+    return null
+  }
+}
+
 function getDayStatus(dayKey, scheduleByDate, blockedDates) {
   if (blockedDates.has(dayKey)) return 'blocked'
   const daySchedules = scheduleByDate.get(dayKey) ?? []
@@ -386,6 +398,19 @@ export function GuideScheduleSection({
     return map
   }, [schedules, pendingSchedules])
 
+  /** 같은 matchRequestId의 연속 PENDING을 캘린더에서 범위로 표시 */
+  const pendingGroupByDate = useMemo(() => {
+    const map = new Map()
+    for (const [dateKey, list] of scheduleByDate.entries()) {
+      if (!dateKey || !Array.isArray(list) || list.length === 0) continue
+      const pending = list.find((s) => String(s?.status ?? '').toUpperCase() === 'PENDING' && s?.matchRequestId != null)
+      if (pending?.matchRequestId != null) {
+        map.set(dateKey, String(pending.matchRequestId))
+      }
+    }
+    return map
+  }, [scheduleByDate])
+
   const monthKey = `${calendarMonth.getFullYear()}-${String(calendarMonth.getMonth() + 1).padStart(2, '0')}`
   const thisMonthBooked = mergedSchedules.filter((s) => s.availableDate?.startsWith(monthKey) && s.status === 'BOOKED').length
   const thisMonthPending = pendingSchedules.filter((s) => s.availableDate?.startsWith(monthKey)).length
@@ -541,6 +566,17 @@ export function GuideScheduleSection({
               else if (status === 'neutral') cls += ' gss3-day--neutral'
             }
             if (isSelected && key != null) cls += ' gss3-day--selected'
+
+            if (key && cell.inMonth && !past && status === 'pending') {
+              const gid = pendingGroupByDate.get(key) ?? null
+              if (gid) {
+                const prev = pendingGroupByDate.get(addDaysKey(key, -1))
+                const next = pendingGroupByDate.get(addDaysKey(key, 1))
+                if (prev === gid || next === gid) cls += ' gss3-day--range'
+                if (prev !== gid) cls += ' gss3-day--range-start'
+                if (next !== gid) cls += ' gss3-day--range-end'
+              }
+            }
 
             return (
               <button

--- a/frontend/src/pages/GuideScheduleSection.jsx
+++ b/frontend/src/pages/GuideScheduleSection.jsx
@@ -70,14 +70,24 @@ function calendarDayCaption(daySchedules, requestsByScheduleId) {
 
 function mergeSchedules(schedules, pendingSchedules) {
   const byId = new Map()
+  const extra = []
   for (const s of schedules) {
-    if (s?.scheduleId != null) byId.set(Number(s.scheduleId), s)
+    if (s?.scheduleId != null) {
+      byId.set(Number(s.scheduleId), s)
+      continue
+    }
+    // 백엔드가 연속 일정 차단을 위해 scheduleId 없는 가상 PENDING을 내려줄 수 있다.
+    // 이런 엔트리는 scheduleId로 dedupe가 불가능하므로 별도로 유지한다.
+    if (s?.availableDate && String(s?.status ?? '').toUpperCase() === 'PENDING') {
+      extra.push(s)
+    }
   }
   for (const s of pendingSchedules) {
     const id = Number(s.scheduleId)
     if (!Number.isNaN(id) && !byId.has(id)) byId.set(id, s)
   }
-  return [...byId.values()]
+  if (extra.length === 0) return [...byId.values()]
+  return [...byId.values(), ...extra]
 }
 
 function ScheduleDrawer({


### PR DESCRIPTION
## 변경 범위
- 가이드 상세 매칭 요청 달력에서 시작일 선택 시, AI 초안 `durationDays`만큼 연속 날짜를 자동 하이라이트
- 연속 기간 중 차단/예약/과거 날짜가 포함되면 안내하고 선택을 막음
- 서버 전송은 기존대로 시작일 1개(`desiredDate`) 유지(스키마 변경 없음)

## 스키마 영향
- 없음

## 검증
```bash
cd frontend && npm run build
```

Closes #457

Made with [Cursor](https://cursor.com)