### PR TITLE
[Feat/be#461] LLM 요약 품질 개선(few-shot·중복 제거)

### DIFF
--- a/backend/module-ai/src/main/java/com/team6/module/ai/llm/LlmPromptExtractionSystemText.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/llm/LlmPromptExtractionSystemText.java
@@ -20,5 +20,15 @@ public final class LlmPromptExtractionSystemText {
             사용자가 한 줄짜리 목적지만 말한 경우에만 specialRequests는 null로 둔다. 그 외에는 null 금지.
             그 밖의 필드는 알 수 없으면 null. 배열은 JSON 배열(빈 배열 가능). region은 한국어 지역명이면 그대로(예: 제주, 서울, 부산). 숫자는 정수.
             연락처·이메일·SNS·상세 주소·개인 식별 정보는 넣지 말 것.
+
+            출력 예시(형식 참고용, 반드시 JSON만 출력):
+            입력: "제주도 오름 투어 하고 싶고 반시계로 돌다가 마지막에 제주 가운데 산(이름 기억 안 남)에 가고 싶어. 2박 3일."
+            출력: {"region":"제주","durationDays":3,"activityTags":["오름 투어"],"guideBullets":["제주 반시계 방향으로 오름 투어","마지막에 한라산(추정) 방문"],"specialRequests":"2박 3일 동안 제주를 반시계 방향으로 돌며 오름을 방문하고 마지막에 한라산(추정)에 가고 싶어."}
+
+            입력: "부산 당일치기! 야경이랑 바다뷰 카페, 로컬 맛집 위주. 계단 많은 코스는 싫어."
+            출력: {"region":"부산","durationDays":1,"activityTags":["야경","바다뷰 카페","로컬 맛집"],"excludedActivityTags":["계단 많은 코스"],"guideBullets":["부산 당일치기 코스 원해","야경·바다뷰 카페·로컬 맛집 위주","계단 많은 코스는 피하고 싶어"],"specialRequests":"부산 당일치기로 야경과 바다뷰 카페, 로컬 맛집 위주로 돌고 계단 많은 코스는 피하고 싶어."}
+
+            입력: "서울 여행"
+            출력: {"region":"서울","guideBullets":[],"specialRequests":null}
             """;
 }

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/ConceptSummaryGenerator.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/ConceptSummaryGenerator.java
@@ -91,26 +91,66 @@ public final class ConceptSummaryGenerator {
      * LLM이 채운 불릿·특별 요청을 한 덩어리 요약 문자열로 만든다(가이드/응답 요약 공용).
      */
     public static String formatLlmGuideCopy(List<String> bullets, String specialRequests) {
+        String cleanedSpecial = normalizeGuideText(specialRequests);
+        List<String> cleanedBullets = normalizeBullets(bullets, cleanedSpecial);
+
         StringBuilder sb = new StringBuilder();
-        if (bullets != null) {
-            for (String b : bullets) {
-                if (b == null || b.isBlank()) {
-                    continue;
-                }
-                if (sb.length() > 0) {
-                    sb.append('\n');
-                }
-                sb.append("• ").append(b.trim());
-            }
-        }
-        if (StringUtils.hasText(specialRequests)) {
+        for (String b : cleanedBullets) {
             if (sb.length() > 0) {
                 sb.append('\n');
             }
-            sb.append(specialRequests.trim());
+            sb.append("• ").append(b);
+        }
+        if (StringUtils.hasText(cleanedSpecial)) {
+            if (sb.length() > 0) {
+                sb.append('\n');
+            }
+            sb.append(cleanedSpecial);
         }
         String out = sb.toString().trim();
         return out.isBlank() ? null : out;
+    }
+
+    private static String normalizeGuideText(String raw) {
+        if (!StringUtils.hasText(raw)) {
+            return null;
+        }
+        String s = raw.trim()
+                .replaceAll("[\\r\\t]+", " ")
+                .replaceAll(" +", " ")
+                .replaceAll("\\n{3,}", "\n\n")
+                .trim();
+        return s.isBlank() ? null : s;
+    }
+
+    private static List<String> normalizeBullets(List<String> raw, String specialRequests) {
+        if (raw == null || raw.isEmpty()) {
+            return List.of();
+        }
+        String special = specialRequests == null ? "" : specialRequests;
+        java.util.LinkedHashSet<String> set = new java.util.LinkedHashSet<>();
+        for (String b : raw) {
+            if (!StringUtils.hasText(b)) {
+                continue;
+            }
+            String t = b.trim()
+                    .replaceAll("^[-•\\s]+", "")
+                    .replaceAll("[\\r\\t]+", " ")
+                    .replaceAll(" +", " ")
+                    .trim();
+            if (!StringUtils.hasText(t)) {
+                continue;
+            }
+            // specialRequests에 그대로 포함된 불릿은 중복이므로 제거
+            if (StringUtils.hasText(special) && special.contains(t)) {
+                continue;
+            }
+            set.add(t);
+            if (set.size() >= 5) {
+                break;
+            }
+        }
+        return List.copyOf(set);
     }
 
     public static String generateMatchRequestConcept(GuideRecommendRequest req) {

--- a/backend/module-ai/src/test/java/com/team6/module/ai/support/ConceptSummaryGeneratorLlmTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/support/ConceptSummaryGeneratorLlmTest.java
@@ -33,4 +33,16 @@ class ConceptSummaryGeneratorLlmTest {
         assertThat(concept).contains("부산 여행");
         assertThat(concept).doesNotContain("야경 좋아해");
     }
+
+    @Test
+    void formatLlmGuideCopy_dedupes_bullets_against_specialRequests() {
+        String out = ConceptSummaryGenerator.formatLlmGuideCopy(
+                List.of("제주 반시계 방향으로 오름 투어", "마지막에 한라산(추정) 방문", "제주 반시계 방향으로 오름 투어"),
+                "2박 3일 동안 제주 반시계 방향으로 오름 투어를 하고 마지막에 한라산(추정)에 가고 싶어."
+        );
+
+        // specialRequests에 포함된 불릿은 제거되고, 중복 불릿도 제거된다.
+        assertThat(out).doesNotContain("• 제주 반시계 방향으로 오름 투어");
+        assertThat(out).contains("• 마지막에 한라산(추정) 방문");
+    }
 }


### PR DESCRIPTION
## 변경 범위
- `KOREAN_JSON_EXTRACTOR`에 few-shot 예시 3개 추가(불릿/요약 문장 형식 안정화)
- `ConceptSummaryGenerator.formatLlmGuideCopy`에서
  - 불릿 정규화(중복 제거/최대 5개/특수문자 제거)
  - `specialRequests` 공백·개행 정규화
  - `specialRequests`에 포함된 불릿은 중복 제거
- 단위 테스트 추가/보강

## 스키마 영향
- 없음

## 검증
```bash
cd backend && ./gradlew :module-ai:test
```

Closes #461

Made with [Cursor](https://cursor.com)