### PR TITLE
Feat/fe#469 JWT 역할 불일치 시 홈으로 리다이렉트

### DIFF
--- a/frontend/src/components/ProtectedGuideRoute.jsx
+++ b/frontend/src/components/ProtectedGuideRoute.jsx
@@ -1,0 +1,22 @@
+import { Navigate, useLocation } from 'react-router-dom'
+
+import { useAuth } from '../context/useAuth.js'
+
+/**
+ * 로그인 + JWT 역할 GUIDE만 허용. 그 외는 홈으로 보냄(게스트가 가이드 URL에 남은 경우).
+ */
+export function ProtectedGuideRoute({ children }) {
+  const { isAuthenticated, isGuide } = useAuth()
+  const location = useLocation()
+
+  if (!isAuthenticated) {
+    const returnTo = `${location.pathname}${location.search}`
+    return <Navigate to="/auth/login" replace state={{ returnTo }} />
+  }
+
+  if (!isGuide) {
+    return <Navigate to="/" replace />
+  }
+
+  return children
+}

--- a/frontend/src/layouts/GuideDashboardLayout.jsx
+++ b/frontend/src/layouts/GuideDashboardLayout.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { Link, Navigate, NavLink, Outlet, useLocation } from 'react-router-dom'
+import { Link, NavLink, Outlet, useLocation } from 'react-router-dom'
 
 import { apiRequest } from '../api/client.js'
 import { useGuidePendingRequests } from '../context/GuidePendingRequestsProvider.jsx'
@@ -19,7 +19,7 @@ const NAV = [
 ]
 
 export function GuideDashboardLayout() {
-  const { email, logout, isGuide } = useAuth()
+  const { email, logout } = useAuth()
   const { pendingCount } = useGuidePendingRequests()
   const { pathname, search } = useLocation()
   const { guideId } = useResolvedGuideId()
@@ -58,10 +58,6 @@ export function GuideDashboardLayout() {
         .filter(Boolean),
     )].slice(0, 3)
   }, [guideStyleRaw])
-
-  if (!isGuide) {
-    return <Navigate to="/mypage" replace />
-  }
 
   return (
     <div className="g-dash">

--- a/frontend/src/layouts/MypageShell.jsx
+++ b/frontend/src/layouts/MypageShell.jsx
@@ -5,12 +5,12 @@ import { useAuth } from '../context/useAuth.js'
 import { DashboardLayout } from './DashboardLayout.jsx'
 
 /**
- * 여행자 전용 /mypage/* 트리. 가이드(GUIDE)는 가이드 대시보드로 보냅니다.
+ * 여행자 전용 /mypage/* 트리. 가이드(GUIDE)는 홈으로 보냅니다(JWT 역할과 경로 불일치 정리).
  */
 export function MypageShell() {
   const { isGuide } = useAuth()
   if (isGuide) {
-    return <Navigate to="/guide/mypage/profile" replace />
+    return <Navigate to="/" replace />
   }
   return (
     <DashboardLayout>

--- a/frontend/src/pages/GuideInboxPage.jsx
+++ b/frontend/src/pages/GuideInboxPage.jsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 
 import { apiRequest } from '../api/client.js'
 import { useGuidePendingRequests } from '../context/GuidePendingRequestsProvider.jsx'
@@ -290,21 +290,6 @@ export function GuideInboxPage() {
     navigate(`/guide/requests/${r.requestId}/course-editor?${params.toString()}`, {
       state: { schedule: schedulePayload, proposeAfterSave: true },
     })
-  }
-
-  if (!isGuide) {
-    return (
-      <div className="inbox">
-        <h1>매칭 요청</h1>
-        <p className="inbox-warn">
-          이 화면은 JWT 역할이 <strong>GUIDE</strong>일 때만 API가 허용합니다. 가이드 신청 직후라면{' '}
-          <strong>다시 로그인</strong>한 뒤 이용해 주세요.
-        </p>
-        <p>
-          <Link to="/auth/login">로그인</Link> · <Link to="/guide/register">가이드 신청</Link>
-        </p>
-      </div>
-    )
   }
 
   return (

--- a/frontend/src/routes/guideRoutes.jsx
+++ b/frontend/src/routes/guideRoutes.jsx
@@ -1,5 +1,6 @@
 import { Navigate } from 'react-router-dom'
 
+import { ProtectedGuideRoute } from '../components/ProtectedGuideRoute'
 import { ProtectedRoute } from '../components/ProtectedRoute'
 import { GuideDashboardLayout } from '../layouts/GuideDashboardLayout'
 import { GuideApplyPage } from '../pages/GuideApplyPage'
@@ -32,33 +33,33 @@ export const guideRoutes = [
   {
     path: 'guide/inbox',
     element: (
-      <ProtectedRoute>
+      <ProtectedGuideRoute>
         <GuideInboxPage />
-      </ProtectedRoute>
+      </ProtectedGuideRoute>
     ),
   },
   {
     path: 'guide/requests/:requestId/course-editor',
     element: (
-      <ProtectedRoute>
+      <ProtectedGuideRoute>
         <GuideCourseEditorPage />
-      </ProtectedRoute>
+      </ProtectedGuideRoute>
     ),
   },
   {
     path: 'guide/schedules/:scheduleId/course-editor',
     element: (
-      <ProtectedRoute>
+      <ProtectedGuideRoute>
         <GuideCourseEditorPage />
-      </ProtectedRoute>
+      </ProtectedGuideRoute>
     ),
   },
   {
     path: 'guide/mypage',
     element: (
-      <ProtectedRoute>
+      <ProtectedGuideRoute>
         <GuideDashboardLayout />
-      </ProtectedRoute>
+      </ProtectedGuideRoute>
     ),
     children: [
       { index: true, element: <Navigate to="profile" replace /> },


### PR DESCRIPTION
## 🔗 이슈 번호

Closes #469

## 💡 주요 변경 사항

- `ProtectedGuideRoute` 추가: 로그인 + JWT 역할 `GUIDE`일 때만 가이드 전용 라우트 진입, 아니면 `/`로 이동
- `/guide/inbox`, 코스 에디터, `/guide/mypage` 트리에 적용 (`/guide/register`, `/guide/apply`는 게스트 신청 흐름 유지)
- `/mypage/*`(`MypageShell`)에서 JWT가 `GUIDE`이면 `/`로 이동(기존 가이드 대시보드로내던 동작을 홈으로 통일)
- `GuideInboxPage`의 JWT 안내 UI 제거(라우트 가드로 처리)

## ⚠️ 주의 사항 / 질문

- 비로그인 사용자는 기존과 동일하게 `/auth/login`으로 보냅니다.

## 🗄️ 스키마 영향

- 없음

## ✅ 체크리스트

- [x] `cd frontend && npm run build`


Made with [Cursor](https://cursor.com)