### PR TITLE
[Feat/fe#473] 마이페이지 네비·다가오는 로컬 동행·일정 취소하기

### DIFF
--- a/backend/module-domain/src/main/java/com/team6/domain/matching/entity/MatchRequest.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/entity/MatchRequest.java
@@ -230,10 +230,11 @@ public class MatchRequest extends BaseTimeEntity {
         log.info("[F03-06] 게스트 제안 거절 — status=REJECTED, requestId={}", this.id);
     }
 
-    // 게스트 취소 처리 (F05-01)
+    // 게스트 취소 처리 (F05-01) — 가이드 응답 대기(PENDING)에서도 요청 철회 허용
     public void cancelByGuest(String reason) {
-        if (this.status != MatchRequestStatus.ACCEPTED &&
-                this.status != MatchRequestStatus.PAID) {
+        if (this.status != MatchRequestStatus.PENDING
+                && this.status != MatchRequestStatus.ACCEPTED
+                && this.status != MatchRequestStatus.PAID) {
             throw new MatchingException(MatchingErrorCode.MATCH_REQUEST_CANNOT_CANCEL);
         }
         this.status = MatchRequestStatus.CANCELLED;

--- a/frontend/src/layouts/AppLayout.jsx
+++ b/frontend/src/layouts/AppLayout.jsx
@@ -82,7 +82,7 @@ function AppLayoutInner() {
           )}
           {!isGuide && (
             <NavLink to="/mypage/itinerary" className={pillClass('shell-pill-link--cta')}>
-              다가오는 로컬 동행
+              예정된 로컬 만남
             </NavLink>
           )}
           {isGuide && (

--- a/frontend/src/layouts/AppLayout.jsx
+++ b/frontend/src/layouts/AppLayout.jsx
@@ -27,7 +27,6 @@ function AppLayoutInner() {
   const { isAuthenticated, email, isGuide, logout } = useAuth()
   const { pendingCount } = useGuidePendingRequests()
   const guideMypageActive = isGuide && pathname.startsWith('/guide/mypage')
-  const guestItineraryActive = !isGuide && pathname.startsWith('/mypage/itinerary')
   const matchComplete = isGuidesMatchCompletePath(pathname)
   const focusMode = pathname.startsWith('/auth/signup') || pathname.startsWith('/onboarding')
   const baseTitleRef = useRef(typeof document !== 'undefined' ? document.title : 'LocalGuest')
@@ -78,12 +77,12 @@ function AppLayoutInner() {
           </NavLink>
           {!isGuide && (
             <NavLink to="/mypage/scrapbook" className={pillClass()}>
-              나의 여행 기록
+              스크랩북
             </NavLink>
           )}
           {!isGuide && (
             <NavLink to="/mypage/itinerary" className={pillClass('shell-pill-link--cta')}>
-              앞으로의 여행 일정
+              다가오는 로컬 동행
             </NavLink>
           )}
           {isGuide && (
@@ -109,9 +108,7 @@ function AppLayoutInner() {
               <NavLink
                 to={isGuide ? '/guide/mypage/profile' : '/mypage'}
                 className={({ isActive }) => {
-                  const on = isGuide
-                    ? guideMypageActive || matchComplete
-                    : (isActive || matchComplete) && !guestItineraryActive
+                  const on = isGuide ? guideMypageActive || matchComplete : isActive || matchComplete
                   const parts = ['shell-btn', 'shell-btn--ghost']
                   if (on) parts.push('shell-btn--dark')
                   return parts.join(' ')

--- a/frontend/src/layouts/DashboardLayout.jsx
+++ b/frontend/src/layouts/DashboardLayout.jsx
@@ -8,8 +8,8 @@ import { getGuestDisplayName, loadTravelTags } from '../lib/guestMypagePrefs.js'
 import './DashboardLayout.css'
 
 const guestItems = [
-  { to: '/mypage/scrapbook', label: '📒 나의 여행 기록(스크랩북)' },
-  { to: '/mypage/itinerary', label: '📆 앞으로의 여행 일정' },
+  { to: '/mypage/scrapbook', label: '📒 스크랩북' },
+  { to: '/mypage/itinerary', label: '📆 다가오는 로컬 동행' },
   { to: '/mypage/payments', label: '💳 결제 내역' },
   { to: '/mypage/privacy', label: '⚙️ 개인정보 설정' },
   { to: '/mypage/tour', label: '🔁 투어 연장/환불 관리' },

--- a/frontend/src/layouts/DashboardLayout.jsx
+++ b/frontend/src/layouts/DashboardLayout.jsx
@@ -8,8 +8,8 @@ import { getGuestDisplayName, loadTravelTags } from '../lib/guestMypagePrefs.js'
 import './DashboardLayout.css'
 
 const guestItems = [
-  { to: '/mypage/scrapbook', label: '📒 스크랩북' },
-  { to: '/mypage/itinerary', label: '📆 다가오는 로컬 동행' },
+  { to: '/mypage/scrapbook', label: '📒 스크랩북 (나의 여행 기록)' },
+  { to: '/mypage/itinerary', label: '📆 예정된 로컬 만남' },
   { to: '/mypage/payments', label: '💳 결제 내역' },
   { to: '/mypage/privacy', label: '⚙️ 개인정보 설정' },
   { to: '/mypage/tour', label: '🔁 투어 연장/환불 관리' },

--- a/frontend/src/lib/matchingGuest.js
+++ b/frontend/src/lib/matchingGuest.js
@@ -137,6 +137,7 @@ export function latestCompletedPaymentPaidAtMs(payments, requestId) {
  */
 export function guestCanCancelByPolicy(row, paidAtMs) {
   const st = String(row?.status ?? '').toUpperCase()
+  if (st === 'PENDING') return true
   if (st === 'ACCEPTED') return true
   if (st !== 'PAID') return false
   if (paidAtMs == null) return false

--- a/frontend/src/pages/GuestUpcomingTripsPage.jsx
+++ b/frontend/src/pages/GuestUpcomingTripsPage.jsx
@@ -181,7 +181,7 @@ function groupRows(rows) {
     { key: 'inprogress', title: '진행 중인 여행', rows: inProgress },
     { key: 'dday', title: '오늘 출발 (D-Day)', rows: dday },
     { key: 'd1', title: '내일 출발 (D-1)', rows: d1 },
-    { key: 'upcoming', title: '다가오는 로컬 동행', rows: upcoming },
+    { key: 'upcoming', title: '예정된 로컬 만남', rows: upcoming },
   ].filter((section) => section.rows.length > 0)
 }
 

--- a/frontend/src/pages/GuestUpcomingTripsPage.jsx
+++ b/frontend/src/pages/GuestUpcomingTripsPage.jsx
@@ -42,6 +42,19 @@ function ddayLabel(days, status) {
   return `${Math.abs(days)}일 지남`
 }
 
+/**
+ * @param {{ status?: string }} row
+ * @param {number | null} _paidAtMs
+ * @param {boolean} canCancel
+ */
+function guestCancelDisabledTitle(row, _paidAtMs, canCancel) {
+  if (canCancel) return undefined
+  const st = String(row?.status ?? '').toUpperCase()
+  if (st === 'IN_PROGRESS') return '진행 중인 투어는 이 화면에서 취소할 수 없어요.'
+  if (st === 'PAID') return '예약 취소는 결제 완료 후 2시간 이내에만 가능해요.'
+  return '취소할 수 없는 상태예요.'
+}
+
 function statusText(status) {
   const s = String(status ?? '').toUpperCase()
   if (s === 'PENDING') return '요청 대기'
@@ -168,7 +181,7 @@ function groupRows(rows) {
     { key: 'inprogress', title: '진행 중인 여행', rows: inProgress },
     { key: 'dday', title: '오늘 출발 (D-Day)', rows: dday },
     { key: 'd1', title: '내일 출발 (D-1)', rows: d1 },
-    { key: 'upcoming', title: '다가오는 여행 일정', rows: upcoming },
+    { key: 'upcoming', title: '다가오는 로컬 동행', rows: upcoming },
   ].filter((section) => section.rows.length > 0)
 }
 
@@ -273,11 +286,11 @@ export function GuestUpcomingTripsPage() {
     const rid = Number(row.requestId)
     if (!Number.isFinite(rid) || rid <= 0) return
     const st = String(row.status ?? '').toUpperCase()
-    if (!(st === 'ACCEPTED' || st === 'PAID')) return
+    if (!(st === 'PENDING' || st === 'ACCEPTED' || st === 'PAID')) return
 
-    const reason = window.prompt('예약 취소 사유를 입력해 주세요.', '개인 사정으로 일정이 변경되었습니다.')
+    const reason = window.prompt('취소 사유를 입력해 주세요.', '개인 사정으로 일정이 변경되었습니다.')
     if (!reason || !String(reason).trim()) return
-    if (!window.confirm(`요청 #${rid} 예약을 취소할까요?`)) return
+    if (!window.confirm(`요청 #${rid}을(를) 취소할까요?`)) return
 
     setBusyId(rid)
     setToast('')
@@ -288,7 +301,7 @@ export function GuestUpcomingTripsPage() {
       })
       const text = await res.text()
       if (!res.ok) throw new Error(text || '취소 실패')
-      setToast('예약을 취소했습니다.')
+      setToast('취소했습니다.')
       await reload()
     } catch (e) {
       setToast(e instanceof Error ? e.message : '취소 실패')
@@ -333,6 +346,7 @@ export function GuestUpcomingTripsPage() {
                   const tripTitle = buildTripCardTitle(row, nick)
                   const paidAtMs = latestCompletedPaymentPaidAtMs(payments, row.requestId)
                   const canCancel = guestCanCancelByPolicy(row, paidAtMs)
+                  const cancelDisabledTitle = guestCancelDisabledTitle(row, paidAtMs, canCancel)
                   const cancelEnds =
                     String(row.status) === 'PAID' && paidAtMs != null
                       ? paidAtMs + GUEST_CANCEL_WINDOW_MS
@@ -363,16 +377,18 @@ export function GuestUpcomingTripsPage() {
                               {statusBadgeLabel(row.status)}
                             </span>
                             <div className="gut-card-actions">
-                              {canCancel && (
-                                <button
-                                  type="button"
-                                  className="gut-cancel"
-                                  disabled={busyId != null}
-                                  onClick={() => void cancelTrip(row)}
-                                >
-                                  {busyId === row.requestId ? '취소 중…' : '예약 취소'}
-                                </button>
-                              )}
+                              <button
+                                type="button"
+                                className="gut-cancel"
+                                disabled={busyId != null || !canCancel}
+                                title={cancelDisabledTitle}
+                                onClick={() => {
+                                  if (!canCancel) return
+                                  void cancelTrip(row)
+                                }}
+                              >
+                                {busyId === row.requestId ? '취소 중…' : '취소하기'}
+                              </button>
                               <button type="button" className="gut-open" onClick={() => openMatchScreen(row)}>
                                 일정 확인하기
                               </button>

--- a/frontend/src/pages/GuideMatchOptionsPage.jsx
+++ b/frontend/src/pages/GuideMatchOptionsPage.jsx
@@ -454,7 +454,7 @@ export function GuideMatchOptionsPage() {
           ← 가이드 프로필
         </Link>
         <Link to="/mypage/itinerary" className="gmo-back gmo-back--pill gmo-back--line">
-          앞으로의 여행 일정
+          다가오는 로컬 동행
         </Link>
       </div>
       <p className="gmo-kicker" role="text">

--- a/frontend/src/pages/GuideMatchOptionsPage.jsx
+++ b/frontend/src/pages/GuideMatchOptionsPage.jsx
@@ -454,7 +454,7 @@ export function GuideMatchOptionsPage() {
           ← 가이드 프로필
         </Link>
         <Link to="/mypage/itinerary" className="gmo-back gmo-back--pill gmo-back--line">
-          다가오는 로컬 동행
+          예정된 로컬 만남
         </Link>
       </div>
       <p className="gmo-kicker" role="text">

--- a/frontend/src/pages/MypageReviewsPage.jsx
+++ b/frontend/src/pages/MypageReviewsPage.jsx
@@ -88,7 +88,7 @@ export function MypageReviewsPage() {
       <h1>🌟 내 리뷰</h1>
       <p className="sub">
         내가 작성한 리뷰만 모아 보여 줍니다. 팀 정책상 <strong>작성 후 수정은 불가</strong>이며, 잘못 올린 경우{' '}
-        <strong>삭제</strong>만 가능합니다. 후기는 <strong>나의 여행 기록(스크랩북)</strong>에서만 작성할 수 있어요.
+        <strong>삭제</strong>만 가능합니다. 후기는 <strong>스크랩북</strong>에서만 작성할 수 있어요.
       </p>
 
       {actionErr && <p className="err">{actionErr}</p>}
@@ -97,7 +97,7 @@ export function MypageReviewsPage() {
 
       {!loading && !error && rows.length === 0 && (
         <PageEmpty title="작성한 리뷰가 없습니다">
-          나의 여행 기록(스크랩북)에서 후기를 남기면 여기에 표시됩니다.
+          스크랩북에서 후기를 남기면 여기에 표시됩니다.
         </PageEmpty>
       )}
 

--- a/frontend/src/pages/MypageScrapbookPage.jsx
+++ b/frontend/src/pages/MypageScrapbookPage.jsx
@@ -163,7 +163,7 @@ export function MypageScrapbookPage() {
 
   return (
     <div className="mp-member">
-      <h1>📒 나의 여행 기록 (스크랩북)</h1>
+      <h1>📒 스크랩북</h1>
       <p className="sub">투어가 완료된 매칭을 시간 순으로 모아 보여 줍니다.</p>
       {loading && <PageLoading />}
       {!loading && error && <PageError message={error} onRetry={() => void refetch()} />}


### PR DESCRIPTION
## 이슈
Closes #473

## 변경 요약
### 프론트
- 상단/사이드: **스크랩북**, **다가오는 로컬 동행** 명칭, **여행자 마이페이지** 버튼이 `/mypage/*`에서 활성 표시
- **다가오는 로컬 동행** 카드: **취소하기**를 **일정 확인하기** 왼쪽에 고정 배치. 취소 불가 시 비활성 + `title` 안내
- `guestCanCancelByPolicy`: `PENDING`(가이드 응답 대기)에서도 취소 가능하도록 정합

### 백엔드
- `MatchRequest.cancelByGuest`: `PENDING` 상태에서도 `CANCELLED` 전이 허용 (기존 서비스에서 스케줄 AVAILABLE 복구 호출 유지)

## 스키마
- 없음

## 검증
- `./gradlew :module-domain:compileJava`
- `cd frontend && npm run build`


Made with [Cursor](https://cursor.com)