### PR TITLE
[Feat/fe#482] 스크랩북 갤러리 → 여행기 상세 이동

### DIFF
--- a/frontend/src/pages/MypageMemberPages.css
+++ b/frontend/src/pages/MypageMemberPages.css
@@ -574,6 +574,17 @@ button.mp-thumb--match:focus-visible {
   color: #374151;
 }
 
+a.mp-polaroid.mp-polaroid--scrap-link {
+  text-decoration: none;
+  color: inherit;
+  display: block;
+}
+
+a.mp-polaroid.mp-polaroid--scrap-link:focus-visible {
+  outline: 2px solid #0f766e;
+  outline-offset: 3px;
+}
+
 .mp-pay-wrap {
   width: 100%;
   overflow-x: auto;

--- a/frontend/src/pages/MypageScrapbookPage.jsx
+++ b/frontend/src/pages/MypageScrapbookPage.jsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { PageEmpty, PageError, PageLoading } from '../components/PageStates.jsx'
 import { apiRequest } from '../api/client.js'
 import { DEFAULT_KOREA_CENTER, resolveLatLng } from '../lib/kakaoGeocode.js'
@@ -248,11 +248,20 @@ export function MypageScrapbookPage() {
             <>
               <h2 style={{ margin: '1.5rem 0 0.75rem', fontSize: '0.95rem', fontWeight: 800 }}>지난 여행 갤러리</h2>
               <div className="mp-gallery">
-                {rows.slice(0, 6).map((r, i) => (
-                  <div key={`g-${r.requestId}`} className="mp-polaroid" style={{ transform: `rotate(${i % 2 === 0 ? -2 : 2}deg)` }}>
-                    {r.destination}
-                  </div>
-                ))}
+                {rows.slice(0, 6).map((r, i) => {
+                  const label = String(r.destination ?? '').trim() || '여행 기록'
+                  return (
+                    <Link
+                      key={`g-${r.requestId}`}
+                      to={`/mypage/scrapbook/${r.requestId}`}
+                      className="mp-polaroid mp-polaroid--scrap-link"
+                      style={{ transform: `rotate(${i % 2 === 0 ? -2 : 2}deg)` }}
+                      aria-label={`${label} 여행기 상세 보기`}
+                    >
+                      {label}
+                    </Link>
+                  )
+                })}
               </div>
             </>
           )}


### PR DESCRIPTION
## 변경 범위
- 스크랩북 목록 **지난 여행 갤러리** 폴라로이드를 `Link`로 바꿔, 클릭 시 `/mypage/scrapbook/:requestId` 티켓 상세로 이동합니다.
- 표시 텍스트는 기존과 동일하게 `destination`(없으면 `여행 기록`)입니다.
- 링크 스타일·포커스 링용 CSS 소량 추가.

## 스키마 / API
- 없음 (프론트만).

## 검증
- `npm run build` (frontend) 통과

Closes #482

Made with [Cursor](https://cursor.com)