### PR TITLE
[Feat/be#484] 상단 메뉴: 가이드 탭 제거·/guides* 에서 AI 검색 활성

### DIFF
--- a/backend/module-domain/src/main/java/com/team6/domain/guide/service/GuideFeedService.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/guide/service/GuideFeedService.java
@@ -56,6 +56,10 @@ public class GuideFeedService {
 
         // imageUrls 우선, 없으면 imageUrl 단일 값 사용
         String imageUrl = joinImageUrls(request.getImageUrls(), request.getImageUrl());
+        // 요청에 빈 imageUrls 가 오면 이미지 전부 제거(join 만으로는 null 이 되어 기존 이미지가 유지됨)
+        if (request.getImageUrls() != null && request.getImageUrls().isEmpty()) {
+            imageUrl = "";
+        }
 
         // 피드 내용 수정
         feed.update(request.getContent(), imageUrl);

--- a/frontend/src/layouts/AppLayout.css
+++ b/frontend/src/layouts/AppLayout.css
@@ -134,7 +134,7 @@
   background: #edf2f7;
 }
 
-/* 활성 탭: 홈·가이드·메시지·AI 검색·마이페이지 동일 회색 (매칭 요청만 별색) */
+/* 활성 탭: 홈·메시지·AI 검색·마이페이지 동일 회색 (매칭 요청만 별색). /guides* 는 AI 검색 탭 활성으로 표시 */
 .shell-pill-link.is-on:not(.shell-pill-link--guide) {
   background: #10b981;
   color: #ffffff;

--- a/frontend/src/layouts/AppLayout.jsx
+++ b/frontend/src/layouts/AppLayout.jsx
@@ -16,9 +16,17 @@ function pillClass(...extra) {
   }
 }
 
-/** `/guides/:id/match/complete` — 일정·매칭 완료 흐름이므로 상단은 마이페이지 탭을 켠다(가이드 탭은 끔). */
+/** `/guides/:id/match/complete` — 일정·매칭 완료 흐름이므로 상단은 마이페이지 탭을 켠다(AI 검색 탭은 끔). */
 function isGuidesMatchCompletePath(pathname) {
   return /^\/guides\/[^/]+\/match\/complete(?:\/|$)/.test(pathname)
+}
+
+/** 가이드 목록·상세 등 `/guides*` 는 메뉴에서 빠졌지만, 상단에서는 AI 검색 흐름으로 간주해 같은 탭을 켠다. */
+function isAiSearchShellActive(pathname, matchComplete) {
+  if (matchComplete) return false
+  if (pathname === '/ai-search' || pathname.startsWith('/ai-search/')) return true
+  if (pathname === '/guides' || pathname.startsWith('/guides/')) return true
+  return false
 }
 
 function AppLayoutInner() {
@@ -59,17 +67,14 @@ function AppLayoutInner() {
             홈
           </NavLink>
           <NavLink
-            to="/guides"
+            to="/ai-search"
             className={({ isActive }) => {
-              const on = isActive && !matchComplete
-              const parts = ['shell-pill-link']
+              const on = (isActive || isAiSearchShellActive(pathname, matchComplete)) && !matchComplete
+              const parts = ['shell-pill-link', 'shell-pill-link--spark']
               if (on) parts.push('is-on')
               return parts.join(' ')
             }}
           >
-            가이드
-          </NavLink>
-          <NavLink to="/ai-search" className={pillClass('shell-pill-link--spark')}>
             AI 검색
           </NavLink>
           <NavLink to="/messages" className={pillClass()}>

--- a/frontend/src/pages/GuideFeedSchedulePage.jsx
+++ b/frontend/src/pages/GuideFeedSchedulePage.jsx
@@ -20,6 +20,25 @@ function parseFeedHeading(content) {
   return { title, body: body || String(content).trim() }
 }
 
+/** 등록 시 본문 맨 끝 한 줄 `#태그1 #태그2` 형태를 역파싱한다. */
+function parseFeedForEdit(content) {
+  const raw = String(content ?? '').replace(/\r\n/g, '\n').trimEnd()
+  if (!raw) return { title: '', body: '', tags: [] }
+  const lines = raw.split('\n')
+  const title = (lines[0] ?? '').trim()
+  if (lines.length <= 1) return { title, body: '', tags: [] }
+  const lastLine = (lines[lines.length - 1] ?? '').trim()
+  const tagLinePattern = /^(#\S+(?:\s+#\S+)*)$/
+  let tags = []
+  let end = lines.length - 1
+  if (tagLinePattern.test(lastLine)) {
+    tags = lastLine.split(/\s+/).map((t) => t.replace(/^#/, '').trim()).filter(Boolean)
+    end = lines.length - 2
+  }
+  const body = lines.slice(1, end + 1).join('\n').trim()
+  return { title, body, tags }
+}
+
 function isInstagramUrl(url) {
   return typeof url === 'string' && url.includes('instagram.com')
 }
@@ -126,7 +145,20 @@ export function GuideFeedSchedulePage() {
   const mainFileInputRef = useRef(null)
   const feedImagesRef = useRef([])
   const dragIdx = useRef(null)
+  const editDragIdx = useRef(null)
+  const editFileInputRef = useRef(null)
   const currentTab = searchParams.get('tab') === 'schedule' ? 'schedule' : 'feed'
+
+  const [feedModalFeed, setFeedModalFeed] = useState(null)
+  const [editFeedTitle, setEditFeedTitle] = useState('')
+  const [editFeedBody, setEditFeedBody] = useState('')
+  const [editFeedTags, setEditFeedTags] = useState([])
+  const [editFeedImages, setEditFeedImages] = useState([])
+  const [editFeedImageMode, setEditFeedImageMode] = useState('file')
+  const [editUrlInput, setEditUrlInput] = useState('')
+  const [editShowLocation, setEditShowLocation] = useState(false)
+  const [editLocationInput, setEditLocationInput] = useState('')
+  const [editFeedBusy, setEditFeedBusy] = useState(false)
 
   const revokePreviewUrl = useCallback((src) => {
     if (typeof src === 'string' && src.startsWith('blob:')) {
@@ -348,10 +380,178 @@ export function GuideFeedSchedulePage() {
         return
       }
       await reloadFeeds(guideId)
+      if (feedModalFeed && Number(feedModalFeed.feedId) === Number(feedId)) {
+        setFeedModalFeed(null)
+      }
     } catch {
       addToast('삭제 실패', 'error')
     } finally {
       setBusy(false)
+    }
+  }
+
+  const closeFeedModal = useCallback(() => {
+    setEditFeedImages((prev) => {
+      prev.forEach((img) => {
+        if (typeof img?.src === 'string' && img.src.startsWith('blob:')) {
+          URL.revokeObjectURL(img.src)
+        }
+      })
+      return []
+    })
+    setFeedModalFeed(null)
+    setEditFeedTitle('')
+    setEditFeedBody('')
+    setEditFeedTags([])
+    setEditFeedImageMode('file')
+    setEditUrlInput('')
+    setEditShowLocation(false)
+    setEditLocationInput('')
+  }, [])
+
+  const openFeedModal = useCallback((f) => {
+    const { title, body, tags } = parseFeedForEdit(f.content ?? '')
+    const urls =
+      Array.isArray(f.imageUrls) && f.imageUrls.length > 0
+        ? f.imageUrls.map((u) => String(u).trim()).filter(Boolean)
+        : f.imageUrl
+          ? String(f.imageUrl)
+              .split(',')
+              .map((s) => s.trim())
+              .filter(Boolean)
+          : []
+    setFeedModalFeed(f)
+    setEditFeedTitle(title)
+    setEditFeedBody(body)
+    setEditFeedTags(tags)
+    setEditFeedImages(
+      urls.map((src, i) => ({
+        id: `edit-${f.feedId}-${i}-${Date.now()}`,
+        src,
+        file: null,
+      })),
+    )
+    setEditFeedImageMode('file')
+    setEditUrlInput('')
+    setEditShowLocation(tags.length > 0)
+    setEditLocationInput('')
+  }, [])
+
+  useEffect(() => {
+    if (!feedModalFeed) return
+    const onKey = (e) => {
+      if (e.key === 'Escape' && !editFeedBusy) closeFeedModal()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [feedModalFeed, editFeedBusy, closeFeedModal])
+
+  const removeEditFeedImage = (id) => {
+    setEditFeedImages((prev) => {
+      const target = prev.find((img) => img.id === id)
+      if (typeof target?.src === 'string' && target.src.startsWith('blob:')) {
+        URL.revokeObjectURL(target.src)
+      }
+      return prev.filter((img) => img.id !== id)
+    })
+  }
+
+  const onEditPickFiles = async (e) => {
+    const files = Array.from(e.target.files ?? [])
+    e.target.value = ''
+    if (!files.length) return
+    const remaining = 10 - editFeedImages.length
+    const toProcess = files.slice(0, remaining)
+    const oversized = toProcess.filter((f) => f.size > MAX_LOCAL_IMAGE_BYTES)
+    if (oversized.length) addToast(`${oversized.length}개 파일이 2MB를 초과해 제외됐습니다.`, 'error')
+    const valid = toProcess.filter((f) => f.size <= MAX_LOCAL_IMAGE_BYTES)
+    const newImgs = valid.map((file) => ({
+      id: Date.now() + Math.random(),
+      src: URL.createObjectURL(file),
+      file,
+    }))
+    setEditFeedImages((prev) => [...prev, ...newImgs].slice(0, 10))
+  }
+
+  const addEditUrlImage = () => {
+    const src = editUrlInput.trim()
+    if (!src || editFeedImages.length >= 10) return
+    setEditFeedImages((prev) => [...prev, { id: Date.now() + Math.random(), src, file: null }])
+    setEditUrlInput('')
+  }
+
+  const reorderEditFeedImages = (dropIdx) => {
+    if (editDragIdx.current === null || editDragIdx.current === dropIdx) return
+    setEditFeedImages((prev) => {
+      const next = [...prev]
+      const [moved] = next.splice(editDragIdx.current, 1)
+      next.splice(dropIdx, 0, moved)
+      return next
+    })
+    editDragIdx.current = null
+  }
+
+  const addEditLocationTag = (raw) => {
+    const tag = raw.trim().replace(/^#/, '')
+    if (!tag || editFeedTags.includes(tag)) return
+    setEditFeedTags((prev) => [...prev, tag])
+    setEditLocationInput('')
+  }
+
+  const removeEditLocationTag = (tag) => {
+    setEditFeedTags((prev) => prev.filter((t) => t !== tag))
+  }
+
+  const saveFeedEdit = async () => {
+    if (!guideId || !feedModalFeed || !editFeedTitle.trim()) return
+    setEditFeedBusy(true)
+    try {
+      const uploadedImageUrls = []
+      for (const img of editFeedImages) {
+        if (img?.file) {
+          const formData = new FormData()
+          formData.append('file', img.file)
+          formData.append('folder', 'guide-feed')
+          const uploadRes = await apiRequest('/files/upload', { method: 'POST', body: formData })
+          const uploadText = await uploadRes.text()
+          if (!uploadRes.ok) {
+            addToast(await readJsonError(uploadRes, uploadText), 'error')
+            setEditFeedBusy(false)
+            return
+          }
+          const uploadJson = uploadText ? JSON.parse(uploadText) : {}
+          const uploadedUrl = String(uploadJson?.url ?? '').trim()
+          if (!uploadedUrl) {
+            addToast('이미지 업로드 URL을 받지 못했습니다.', 'error')
+            setEditFeedBusy(false)
+            return
+          }
+          uploadedImageUrls.push(uploadedUrl)
+          continue
+        }
+        const src = String(img?.src ?? '').trim()
+        if (!src || src.startsWith('blob:') || src.startsWith('data:')) continue
+        uploadedImageUrls.push(src)
+      }
+      const tagLine = editFeedTags.length > 0 ? '\n' + editFeedTags.map((t) => `#${t}`).join(' ') : ''
+      const content = (editFeedTitle.trim() + '\n' + editFeedBody.trim() + tagLine).trim()
+      const res = await apiRequest(`/guides/${guideId}/feeds/${feedModalFeed.feedId}`, {
+        method: 'PUT',
+        json: { content, imageUrls: uploadedImageUrls.length > 0 ? uploadedImageUrls : [] },
+      })
+      const text = await res.text()
+      if (!res.ok) {
+        addToast(await readJsonError(res, text), 'error')
+        return
+      }
+      addToast('피드를 저장했습니다.')
+      closeFeedModal()
+      await reloadFeeds(guideId)
+    } catch (e) {
+      console.error('[saveFeedEdit]', e)
+      addToast('저장에 실패했습니다.', 'error')
+    } finally {
+      setEditFeedBusy(false)
     }
   }
 
@@ -550,6 +750,180 @@ export function GuideFeedSchedulePage() {
     <div className="g-panel">
       {loadError && <p className="g-error">{loadError}</p>}
       <Toast toasts={toasts} />
+      {feedModalFeed &&
+        typeof document !== 'undefined' &&
+        createPortal(
+          <div
+            className="gfd-overlay"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="gfd-feed-modal-title"
+            onClick={(e) => {
+              if (e.target === e.currentTarget && !editFeedBusy) closeFeedModal()
+            }}
+          >
+            <div className="gfd-sheet" onClick={(e) => e.stopPropagation()}>
+              <div className="gfd-head">
+                <h3 id="gfd-feed-modal-title">피드 상세 · 수정</h3>
+                <button type="button" className="gfd-close" aria-label="닫기" disabled={editFeedBusy} onClick={() => closeFeedModal()}>
+                  ×
+                </button>
+              </div>
+              <p className="gfd-lead">본인 피드만 수정할 수 있어요. 저장 시 즉시 반영됩니다.</p>
+
+              <div className="gfd-mode-tabs">
+                {[
+                  { key: 'file', label: '파일 업로드' },
+                  { key: 'url', label: 'URL 입력' },
+                ].map(({ key, label }) => (
+                  <button
+                    key={key}
+                    type="button"
+                    className={`gfi-mode-tab ${editFeedImageMode === key ? 'is-on' : ''}`}
+                    onClick={() => setEditFeedImageMode(key)}
+                    disabled={editFeedBusy}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+
+              {editFeedImageMode === 'file' && editFeedImages.length < 10 && (
+                <div className="gfi-file-row">
+                  <button type="button" className="gm-btn gm-btn--ghost" onClick={() => editFileInputRef.current?.click()} disabled={editFeedBusy}>
+                    {editFeedImages.length === 0 ? '파일 선택' : `+ 추가 (${editFeedImages.length}/10)`}
+                  </button>
+                  <input
+                    ref={editFileInputRef}
+                    type="file"
+                    accept="image/*"
+                    multiple
+                    style={{ display: 'none' }}
+                    onChange={(e) => void onEditPickFiles(e)}
+                  />
+                </div>
+              )}
+
+              {editFeedImageMode === 'url' && (
+                <div className="gfi-file-row" style={{ gap: '0.5rem' }}>
+                  <input
+                    className="gfi-text-input"
+                    placeholder="https://…"
+                    value={editUrlInput}
+                    onChange={(e) => setEditUrlInput(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault()
+                        addEditUrlImage()
+                      }
+                    }}
+                    disabled={editFeedBusy}
+                  />
+                  <button type="button" className="gm-btn gm-btn--ghost" onClick={addEditUrlImage} disabled={!editUrlInput.trim() || editFeedImages.length >= 10 || editFeedBusy}>
+                    추가
+                  </button>
+                </div>
+              )}
+
+              {editFeedImages.length > 0 ? (
+                <div className="gfi-thumb-grid gfd-thumb-grid">
+                  {editFeedImages.map((img, idx) => (
+                    <div
+                      key={img.id}
+                      className="gfi-thumb-item"
+                      draggable
+                      onDragStart={() => { editDragIdx.current = idx }}
+                      onDragOver={(e) => e.preventDefault()}
+                      onDrop={() => reorderEditFeedImages(idx)}
+                    >
+                      <img src={img.src} alt="" />
+                      {idx === 0 && <span className="gfi-thumb-badge">대표</span>}
+                      <button
+                        type="button"
+                        className="gfi-thumb-del"
+                        onClick={() => removeEditFeedImage(img.id)}
+                        aria-label="이미지 삭제"
+                        disabled={editFeedBusy}
+                      >
+                        ×
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="gfi-preview gfd-preview">
+                  <span className="gfi-preview-empty">이미지 없음 — 추가해 주세요</span>
+                </div>
+              )}
+
+              <div className="gfs-content-wrap gfd-fields">
+                <input
+                  type="text"
+                  className="gfi-title-input"
+                  placeholder="제목"
+                  value={editFeedTitle}
+                  onChange={(e) => setEditFeedTitle(e.target.value)}
+                  maxLength={100}
+                  disabled={editFeedBusy}
+                />
+                <textarea
+                  className="gfs-content"
+                  rows={5}
+                  maxLength={1000}
+                  placeholder="본문"
+                  value={editFeedBody}
+                  onChange={(e) => setEditFeedBody(e.target.value)}
+                  disabled={editFeedBusy}
+                />
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                  <button type="button" className="gfs-tag-hint-btn" onClick={() => setEditShowLocation((v) => !v)} disabled={editFeedBusy}>
+                    📍 장소 태그 {editShowLocation ? '닫기' : '추가'}
+                  </button>
+                  <span className="gfi-char-count">{editFeedBody.length} / 1000</span>
+                </div>
+                {editShowLocation && (
+                  <div style={{ marginTop: '0.5rem' }}>
+                    <input
+                      className="gi-tag-input"
+                      placeholder="장소명 입력 후 Enter"
+                      value={editLocationInput}
+                      onChange={(e) => setEditLocationInput(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                          e.preventDefault()
+                          addEditLocationTag(editLocationInput)
+                        }
+                      }}
+                      disabled={editFeedBusy}
+                    />
+                    {editFeedTags.length > 0 && (
+                      <div className="gi-tag-list" style={{ marginTop: '0.4rem' }}>
+                        {editFeedTags.map((tag) => (
+                          <span key={tag} className="gi-tag">
+                            #{tag}
+                            <button type="button" className="gi-tag-del" onClick={() => removeEditLocationTag(tag)} aria-label={`${tag} 삭제`} disabled={editFeedBusy}>
+                              ×
+                            </button>
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+
+              <div className="gfd-actions">
+                <button type="button" className="gm-btn gm-btn--ghost" onClick={() => closeFeedModal()} disabled={editFeedBusy}>
+                  취소
+                </button>
+                <button type="button" className="gfs-upload-btn" onClick={() => void saveFeedEdit()} disabled={editFeedBusy || !editFeedTitle.trim()}>
+                  {editFeedBusy ? '저장 중…' : '저장'}
+                </button>
+              </div>
+            </div>
+          </div>,
+          document.body,
+        )}
       {currentTab === 'feed' ? (
         <section className="gfs-feed">
           <header className="gfs-feed-head">
@@ -716,18 +1090,20 @@ export function GuideFeedSchedulePage() {
               const dateStr = f.createdAt ? String(f.createdAt).slice(0, 10).replace(/-/g, '.') : null
               return (
                 <li key={f.feedId} className="gfi-feed-card">
-                  <div className="gfi-feed-thumb">
-                    {(() => {
-                      const thumb = f.imageUrls?.[0] ?? f.imageUrl ?? null
-                      if (!thumb) return <div className="gfi-thumb-empty" />
-                      if (isInstagramUrl(thumb)) return <span className="gfi-thumb-insta">📷</span>
-                      return <img src={thumb} alt="" />
-                    })()}
-                  </div>
-                  <div style={{ flex: 1, minWidth: 0 }}>
-                    <p className="gfi-feed-title">{title}</p>
-                    {dateStr && <p className="gfi-feed-date">{dateStr}</p>}
-                  </div>
+                  <button type="button" className="gfi-feed-card-main" onClick={() => openFeedModal(f)} disabled={busy}>
+                    <div className="gfi-feed-thumb">
+                      {(() => {
+                        const thumb = f.imageUrls?.[0] ?? f.imageUrl ?? null
+                        if (!thumb) return <div className="gfi-thumb-empty" />
+                        if (isInstagramUrl(thumb)) return <span className="gfi-thumb-insta">📷</span>
+                        return <img src={thumb} alt="" />
+                      })()}
+                    </div>
+                    <div className="gfi-feed-card-text">
+                      <p className="gfi-feed-title">{title}</p>
+                      {dateStr && <p className="gfi-feed-date">{dateStr}</p>}
+                    </div>
+                  </button>
                   <button type="button" className="gm-danger" onClick={() => void removeFeed(f.feedId)} disabled={busy}>
                     삭제
                   </button>

--- a/frontend/src/pages/GuideMypagePages.css
+++ b/frontend/src/pages/GuideMypagePages.css
@@ -536,6 +536,130 @@
   border: 1px solid #e8eaed;
 }
 
+.gfi-feed-card-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0;
+  margin: 0;
+  border: none;
+  background: transparent;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  border-radius: 8px;
+  color: inherit;
+}
+
+.gfi-feed-card-main:hover:not(:disabled) {
+  background: rgba(99, 102, 241, 0.06);
+}
+
+.gfi-feed-card-main:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.gfi-feed-card-text {
+  flex: 1;
+  min-width: 0;
+}
+
+/* 피드 상세·수정 모달 */
+.gfd-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10050;
+  background: rgba(15, 23, 42, 0.45);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 1.25rem 0.75rem;
+  overflow: auto;
+}
+
+.gfd-sheet {
+  width: min(560px, 100%);
+  margin: 2vh auto;
+  background: #fffef8;
+  border: 1px solid #e5e7eb;
+  border-radius: 16px;
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.18);
+  padding: 1rem 1.1rem 1.15rem;
+}
+
+.gfd-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.gfd-head h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 800;
+  color: #1f2328;
+}
+
+.gfd-close {
+  flex-shrink: 0;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 999px;
+  background: #f3f4f6;
+  color: #374151;
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.gfd-close:hover:not(:disabled) {
+  background: #e5e7eb;
+}
+
+.gfd-close:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.gfd-lead {
+  margin: 0.45rem 0 0.85rem;
+  font-size: 0.8rem;
+  color: #6b7280;
+  line-height: 1.45;
+}
+
+.gfd-mode-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-bottom: 0.5rem;
+}
+
+.gfd-thumb-grid {
+  margin-top: 0.35rem;
+}
+
+.gfd-preview {
+  margin-top: 0.35rem;
+}
+
+.gfd-fields {
+  margin-top: 0.85rem;
+}
+
+.gfd-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 1rem;
+  flex-wrap: wrap;
+}
+
 .gfi-feed-thumb {
   width: 2.5rem;
   height: 2.5rem;


### PR DESCRIPTION
## 변경 범위
### 상단 내비 (#484)
- **가이드** 메뉴 제거, `/guides*`·`/ai-search` 에서 **AI 검색** 탭 활성.
- `/guides/:id/match/complete` 에서는 **여행자 마이페이지**만 활성.

### 가이드 피드 등록 (#484 추가)
- 피드 목록 행 클릭 시 **상세·수정 모달**(제목·본문·장소 태그·이미지 URL/파일, 순서 변경·삭제).
- `PUT /guides/{guideId}/feeds/{feedId}` 로 저장.
- **빈 `imageUrls`** 로 수정 시 이미지 전부 제거되도록 `GuideFeedService` 보강.

## 스키마 / API
- 기존 피드 수정 API 활용. DTO 계약 변경 없음.

## 검증
- `./gradlew :module-domain:compileJava`
- `npm run build` (frontend)

Closes #484