### PR TITLE
[Feat/be#498] AI 추천 속도 개선: rank 사용 시 LLM 파싱 fast-path

### DIFF
--- a/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
@@ -1131,7 +1131,7 @@ public class PromptRecommendationService {
     /**
      * @param cfgProvider      {@code localguest.ai.llm-provider} 정규화 값(로그용)
      * @param extractorBeanClass 주입된 {@link LlmPromptExtractor} 구현 단순 클래스명, 없으면 {@code none}
-     * @param outcome          {@code SKIP_DISABLED} | {@code SKIP_NO_BEAN} | {@code LLM_SUCCESS} | {@code LLM_EMPTY} | {@code LLM_ERROR}
+     * @param outcome          {@code SKIP_DISABLED} | {@code SKIP_NO_BEAN} | {@code SKIP_FASTPATH} | {@code LLM_SUCCESS} | {@code LLM_EMPTY} | {@code LLM_ERROR}
      */
     private record LlmParseTrace(String cfgProvider, String extractorBeanClass, String outcome) {}
 
@@ -1156,6 +1156,15 @@ public class PromptRecommendationService {
             );
         }
 
+        // 속도 최적화: rank LLM 경로를 쓰는 경우, 룰 파서가 충분히 신뢰할 만하면 LLM 파싱 호출을 생략한다.
+        GuideRecommendRequest ruleParsed = promptParser.parse(prompt, resolvedTopN, guideCandidates);
+        if (aiProperties.isLlmRankEnabled()
+                && notBlank(ruleParsed.getRegion())
+                && !"LOW".equals(computePromptParseConfidence(ruleParsed))) {
+            metrics.recordLlmPromptExtraction("skip_fastpath", 0L, POLICY_VERSION, cfgProvider);
+            return new ParsedPrompt(ruleParsed, new LlmParseTrace(cfgProvider, extractorBean, "SKIP_FASTPATH"));
+        }
+
         String llmPrompt = truncateForLlm(prompt);
         long t0 = System.nanoTime();
         try {
@@ -1168,14 +1177,14 @@ public class PromptRecommendationService {
             }
             metrics.recordLlmPromptExtraction("empty", elapsed, POLICY_VERSION, cfgProvider);
             return new ParsedPrompt(
-                    promptParser.parse(prompt, resolvedTopN, guideCandidates),
+                    ruleParsed,
                     new LlmParseTrace(cfgProvider, extractorBean, "LLM_EMPTY")
             );
         } catch (Exception e) {
             metrics.recordLlmPromptExtraction("error", System.nanoTime() - t0, POLICY_VERSION, cfgProvider);
             log.warn("[AI_PROMPT] LLM 추출 실패, 룰 파서로 폴백: {}", e.toString());
             return new ParsedPrompt(
-                    promptParser.parse(prompt, resolvedTopN, guideCandidates),
+                    ruleParsed,
                     new LlmParseTrace(cfgProvider, extractorBean, "LLM_ERROR")
             );
         }

--- a/backend/module-ai/src/test/java/com/team6/module/ai/service/PromptRecommendationServiceTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/service/PromptRecommendationServiceTest.java
@@ -34,6 +34,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -241,5 +242,63 @@ class PromptRecommendationServiceTest {
         ArgumentCaptor<String> promptSent = ArgumentCaptor.forClass(String.class);
         verify(extractor).tryExtract(promptSent.capture(), eq(2), any());
         assertThat(promptSent.getValue()).isEqualTo("제주도여");
+    }
+
+    @Test
+    void recommendByPrompt_whenLlmRankEnabled_skipsLlmPromptExtractionViaFastPath() {
+        LlmPromptExtractor extractor = mock(LlmPromptExtractor.class);
+
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        LocalGuestAiProperties aiProps = new LocalGuestAiProperties();
+        aiProps.setLlmPromptExtractionEnabled(true);
+        aiProps.setLlmRankEnabled(true);
+        ScoringPolicySnapshot scoring = ScoringPolicySnapshot.defaults();
+        AdjacentRegionProvider adjacent = new AdjacentRegionProvider(aiProps);
+        AiRecommendationMetrics metrics = new AiRecommendationMetrics(meterRegistry);
+        ScoreCalculator scoreCalculator = new ScoreCalculator(
+                new RegionMatchPolicy(adjacent, scoring),
+                new StyleMatchPolicy(scoring),
+                new BudgetMatchPolicy(scoring),
+                new ActivityMatchPolicy(scoring),
+                new LanguageMatchPolicy(scoring),
+                new FeedbackMatchPolicy(scoring),
+                new ComboMatchPolicy(scoring),
+                metrics
+        );
+        ReasonGenerator reasonGenerator = new ReasonGenerator(adjacent, scoring);
+        AiRecommendationService aiRecommendationService =
+                new AiRecommendationServiceImpl(
+                        new MatchingEngine(scoreCalculator, reasonGenerator, adjacent, DiversityRerankSnapshot.defaults(),
+                                metrics, scoring));
+
+        PromptRecommendationService service = new PromptRecommendationService(
+                new PromptParser(aiProps),
+                aiRecommendationService,
+                adjacent,
+                metrics,
+                scoring,
+                aiProps,
+                extractor,
+                null
+        );
+
+        // 룰 파서만으로도 region/confidence가 충분한 케이스: LLM extractor 호출 없이 진행해야 한다.
+        service.recommendByPrompt(
+                "강릉 바다 근처 감성 카페 투어 가이드 추천해요",
+                2,
+                List.of(
+                        GuideRecommendRequest.GuideCandidateDto.builder()
+                                .guideId(1L)
+                                .guideName("가")
+                                .region("강릉")
+                                .guideStyle("감성")
+                                .priceLevel("중간")
+                                .specialtyTags(List.of("카페"))
+                                .languages(List.of("한국어"))
+                                .build()
+                )
+        );
+
+        verifyNoInteractions(extractor);
     }
 }


### PR DESCRIPTION
## Summary
- `llm-rank-enabled=true`에서 룰 파서 결과가 충분히 신뢰 가능하면 LLM prompt extraction 호출을 생략해 평균 지연을 줄였습니다.
- 폴백/기존 동작은 유지하며, 필요한 케이스(지역 미확정/LOW confidence)에서는 기존대로 LLM 파싱을 실행합니다.

## 변경 범위
- `module-ai`
  - `PromptRecommendationService`: LLM 파싱 fast-path 추가
  - `PromptRecommendationServiceTest`: fast-path 동작 테스트 추가

## 스키마 영향
- 없음

## 검증
- `./gradlew :module-ai:test :module-openai:test`

Closes #498

Made with [Cursor](https://cursor.com)