### PR TITLE
[Feat/be#513] 후보 풀 확장/필터 정교화(region/인접/excluded)

### DIFF
--- a/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
@@ -190,7 +190,8 @@ public class PromptRecommendationService {
                         parsed.getGuideCandidates(),
                         parsed.getRegion(),
                         adjacentRegionProvider::neighbors,
-                        Boolean.TRUE.equals(parsed.getAllowAdjacentRegion())
+                        Boolean.TRUE.equals(parsed.getAllowAdjacentRegion()),
+                        resolvedTopN
                 );
 
         // 4) 실제 점수 계산에 넣을 최종 요청 객체를 다시 만든다.
@@ -852,6 +853,90 @@ public class PromptRecommendationService {
                 || (req.getNiceToHaveActivityTags() != null && !req.getNiceToHaveActivityTags().isEmpty());
     }
 
+    /**
+     * LLM rank 품질 보호용: excludedActivityTags가 후보 카드 텍스트/태그에 강하게 드러나는 경우
+     * LLM에 넘길 풀에서 우선 제거한다(단, 전부 제거되면 원본 풀을 유지).
+     */
+    static List<GuideRecommendRequest.GuideCandidateDto> filterPoolByExcludedSignals(
+            List<String> excludedActivityTags,
+            List<GuideRecommendRequest.GuideCandidateDto> pool
+    ) {
+        if (pool == null || pool.isEmpty()) {
+            return List.of();
+        }
+        if (excludedActivityTags == null || excludedActivityTags.isEmpty()) {
+            return pool;
+        }
+        List<String> needles = excludedActivityTags.stream()
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(s -> !s.isBlank())
+                .filter(s -> s.length() >= 2)
+                .map(s -> s.toLowerCase(Locale.ROOT))
+                .distinct()
+                .toList();
+        if (needles.isEmpty()) {
+            return pool;
+        }
+
+        List<GuideRecommendRequest.GuideCandidateDto> kept = new ArrayList<>();
+        for (GuideRecommendRequest.GuideCandidateDto c : pool) {
+            if (c == null) continue;
+            if (!violatesExcludedSignals(needles, c)) {
+                kept.add(c);
+            }
+        }
+        return kept.isEmpty() ? pool : kept;
+    }
+
+    private static boolean violatesExcludedSignals(List<String> needlesLower, GuideRecommendRequest.GuideCandidateDto c) {
+        if (needlesLower == null || needlesLower.isEmpty() || c == null) {
+            return false;
+        }
+        String hay = buildCandidateTextHaystackLower(c);
+        if (hay.isEmpty()) {
+            return false;
+        }
+        for (String n : needlesLower) {
+            if (n == null || n.isBlank()) continue;
+            if (hay.contains(n)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String buildCandidateTextHaystackLower(GuideRecommendRequest.GuideCandidateDto c) {
+        StringBuilder sb = new StringBuilder();
+        appendIfPresent(sb, c.getGuideStyle());
+        appendIfPresent(sb, joinOrEmpty(c.getSpecialtyTags()));
+        appendIfPresent(sb, c.getLlmKeywordsSnippet());
+        appendIfPresent(sb, c.getLlmIntroSnippet());
+        if (c.getLlmFeedBodiesNewestFirst() != null) {
+            for (String s : c.getLlmFeedBodiesNewestFirst()) {
+                appendIfPresent(sb, s);
+            }
+        }
+        appendIfPresent(sb, c.getLlmDefaultCourseSnippet());
+        appendIfPresent(sb, c.getLlmCareerSnippet());
+        return sb.toString().toLowerCase(Locale.ROOT);
+    }
+
+    private static void appendIfPresent(StringBuilder sb, String text) {
+        if (sb == null) return;
+        if (text == null || text.isBlank()) return;
+        sb.append(' ').append(text.strip());
+    }
+
+    private static String joinOrEmpty(List<String> tags) {
+        if (tags == null || tags.isEmpty()) return "";
+        return tags.stream()
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(s -> !s.isBlank())
+                .collect(Collectors.joining(" "));
+    }
+
     private void logRecommendation(
             String prompt,
             GuideRecommendRequest request,
@@ -930,7 +1015,9 @@ public class PromptRecommendationService {
         if (pool == null || pool.isEmpty()) {
             return finalBase;
         }
-        int poolSize = pool.size();
+        List<GuideRecommendRequest.GuideCandidateDto> filteredPool =
+                filterPoolByExcludedSignals(scoringRequest.getExcludedActivityTags(), pool);
+        int poolSize = filteredPool.size();
         long t0 = System.nanoTime();
         try {
             GuideRecommendRequest fullReq = scoringRequest.toBuilder()
@@ -941,9 +1028,9 @@ public class PromptRecommendationService {
                 metrics.recordLlmGuideRank("empty_rule_full", System.nanoTime() - t0, POLICY_VERSION);
                 return finalBase;
             }
-            long seed = LlmRankCardComposer.stableSeed(prompt, pool);
+            long seed = LlmRankCardComposer.stableSeed(prompt, filteredPool);
             Optional<LlmGuideRankResult> ranked =
-                    llmGuideRanker.tryRank(truncateForLlm(prompt), pool, resolvedTopN, seed);
+                    llmGuideRanker.tryRank(truncateForLlm(prompt), filteredPool, resolvedTopN, seed);
             if (ranked.isEmpty()) {
                 metrics.recordLlmGuideRank("empty", System.nanoTime() - t0, POLICY_VERSION);
                 log.info("[AI_RANK] llmRank=empty policyVer={} topN={} poolSize={}", POLICY_VERSION, resolvedTopN, poolSize);

--- a/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/service/PromptRecommendationService.java
@@ -1036,7 +1036,13 @@ public class PromptRecommendationService {
                 log.info("[AI_RANK] llmRank=empty policyVer={} topN={} poolSize={}", POLICY_VERSION, resolvedTopN, poolSize);
                 return finalBase;
             }
-            GuideRecommendResponse merged = mergeLlmRankIntoResponse(fullRule, ranked.get(), resolvedTopN);
+            GuideRecommendResponse merged = mergeLlmRankIntoResponse(
+                    fullRule,
+                    ranked.get(),
+                    resolvedTopN,
+                    scoringRequest.getExcludedActivityTags(),
+                    filteredPool
+            );
             metrics.recordLlmGuideRank("success", System.nanoTime() - t0, POLICY_VERSION);
             log.info("[AI_RANK] llmRank=success policyVer={} topN={} poolSize={} orderedIds={}",
                     POLICY_VERSION,
@@ -1050,6 +1056,60 @@ public class PromptRecommendationService {
             log.warn("[AI_RANK] LLM 순위 적용 실패, 룰 결과 유지: {}", e.toString());
             return finalBase;
         }
+    }
+
+    private static GuideRecommendResponse mergeLlmRankIntoResponse(
+            GuideRecommendResponse fullRule,
+            LlmGuideRankResult rank,
+            int topN,
+            List<String> excludedActivityTags,
+            List<GuideRecommendRequest.GuideCandidateDto> pool
+    ) {
+        // 2단 필터: LLM이 실수로 제외 후보를 앞에 두더라도, 최종 TopN에서는 제외 위반 후보를 한 번 더 걸러낸다.
+        // 단, 너무 과하게 걸러 empty가 되면 원본 머지 결과를 유지한다.
+        GuideRecommendResponse baselineMerged = mergeLlmRankIntoResponse(fullRule, rank, topN);
+        if (excludedActivityTags == null || excludedActivityTags.isEmpty() || pool == null || pool.isEmpty()) {
+            return baselineMerged;
+        }
+
+        Map<Long, GuideRecommendRequest.GuideCandidateDto> candidateById = pool.stream()
+                .filter(Objects::nonNull)
+                .filter(c -> c.getGuideId() != null)
+                .collect(Collectors.toMap(GuideRecommendRequest.GuideCandidateDto::getGuideId, c -> c, (a, b) -> a));
+        List<String> needles = excludedActivityTags.stream()
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(s -> !s.isBlank())
+                .filter(s -> s.length() >= 2)
+                .map(s -> s.toLowerCase(Locale.ROOT))
+                .distinct()
+                .toList();
+        if (needles.isEmpty()) {
+            return baselineMerged;
+        }
+
+        List<GuideRecommendItem> src = baselineMerged.getRecommendations();
+        if (src == null || src.isEmpty()) {
+            return baselineMerged;
+        }
+        List<GuideRecommendItem> filtered = new ArrayList<>();
+        for (GuideRecommendItem it : src) {
+            if (filtered.size() >= topN) break;
+            if (it == null || it.getGuideId() == null) continue;
+            GuideRecommendRequest.GuideCandidateDto c = candidateById.get(it.getGuideId());
+            if (c != null && violatesExcludedSignals(needles, c)) {
+                continue;
+            }
+            filtered.add(it);
+        }
+        if (filtered.isEmpty()) {
+            return baselineMerged;
+        }
+        return GuideRecommendResponse.builder()
+                .policyVersion(POLICY_VERSION)
+                .totalCount(filtered.size())
+                .recommendations(filtered)
+                .build();
     }
 
     private static GuideRecommendResponse mergeLlmRankIntoResponse(

--- a/backend/module-ai/src/main/java/com/team6/module/ai/support/RegionCandidateExpansion.java
+++ b/backend/module-ai/src/main/java/com/team6/module/ai/support/RegionCandidateExpansion.java
@@ -50,6 +50,19 @@ public final class RegionCandidateExpansion {
             Function<String, Set<String>> adjacentNeighbors,
             boolean allowAdjacentEvenIfExactEnough
     ) {
+        return apply(all, region, adjacentNeighbors, allowAdjacentEvenIfExactEnough, AiRecommendationTuning.DEFAULT_TOP_N);
+    }
+
+    /**
+     * @param desiredTopN 추천에서 원하는 상위 개수. exact 후보가 이 값 이상이면 인접 확장을 피한다(희소할 때만 확장).
+     */
+    public static Result apply(
+            List<GuideRecommendRequest.GuideCandidateDto> all,
+            String region,
+            Function<String, Set<String>> adjacentNeighbors,
+            boolean allowAdjacentEvenIfExactEnough,
+            int desiredTopN
+    ) {
         List<GuideRecommendRequest.GuideCandidateDto> pool =
                 all == null ? List.of() : new ArrayList<>(all);
 
@@ -63,7 +76,9 @@ public final class RegionCandidateExpansion {
                 .filter(g -> regionEquals(g.getRegion(), r))
                 .collect(Collectors.toList());
 
-        if (!allowAdjacentEvenIfExactEnough && exact.size() >= AiRecommendationTuning.MIN_EXACT_REGION_CANDIDATES) {
+        int target = Math.max(1, desiredTopN);
+        int minExact = Math.min(target, Math.max(1, AiRecommendationTuning.MIN_EXACT_REGION_CANDIDATES));
+        if (!allowAdjacentEvenIfExactEnough && exact.size() >= minExact) {
             return new Result(exact, false, exact.size());
         }
 

--- a/backend/module-ai/src/test/java/com/team6/module/ai/service/PromptRecommendationServiceTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/service/PromptRecommendationServiceTest.java
@@ -314,4 +314,28 @@ class PromptRecommendationServiceTest {
                 "소개에 “조용히 걷는 산책 코스”가 있어 감성 일정에 잘 맞습니다. 술집 위주는 제외하고 구성하겠습니다."
         )).isNotNull();
     }
+
+    @Test
+    void applyLlmGuideRank_filters_out_candidates_matching_excluded_activity_tags() {
+        List<GuideRecommendRequest.GuideCandidateDto> candidates = List.of(
+                GuideRecommendRequest.GuideCandidateDto.builder()
+                        .guideId(1L).guideName("A").region("부산").guideStyle("감성").priceLevel("중간")
+                        .specialtyTags(List.of("바다"))
+                        .languages(List.of("한국어"))
+                        .llmIntroSnippet("조용한 산책 코스를 좋아해요")
+                        .build(),
+                GuideRecommendRequest.GuideCandidateDto.builder()
+                        .guideId(2L).guideName("B").region("부산").guideStyle("파티").priceLevel("중간")
+                        .specialtyTags(List.of("술집"))
+                        .languages(List.of("한국어"))
+                        .llmIntroSnippet("술집 투어를 자주 안내합니다")
+                        .build()
+        );
+
+        List<GuideRecommendRequest.GuideCandidateDto> filtered =
+                PromptRecommendationService.filterPoolByExcludedSignals(List.of("술집"), candidates);
+        assertThat(filtered.stream().map(GuideRecommendRequest.GuideCandidateDto::getGuideId).toList())
+                .contains(1L)
+                .doesNotContain(2L);
+    }
 }

--- a/backend/module-ai/src/test/java/com/team6/module/ai/support/RegionCandidateExpansionTest.java
+++ b/backend/module-ai/src/test/java/com/team6/module/ai/support/RegionCandidateExpansionTest.java
@@ -15,7 +15,7 @@ class RegionCandidateExpansionTest {
                 g(1L, "부산"),
                 g(2L, "부산")
         );
-        RegionCandidateExpansion.Result r = RegionCandidateExpansion.apply(pool, "부산");
+        RegionCandidateExpansion.Result r = RegionCandidateExpansion.apply(pool, "부산", AdjacentRegionMap::neighbors, false, 3);
         assertThat(r.candidates()).hasSize(2);
         assertThat(r.expansionUsed()).isFalse();
     }
@@ -26,7 +26,7 @@ class RegionCandidateExpansionTest {
                 g(1L, "제주특별자치도 제주시"),
                 g(2L, "제주")
         );
-        RegionCandidateExpansion.Result r = RegionCandidateExpansion.apply(pool, "제주");
+        RegionCandidateExpansion.Result r = RegionCandidateExpansion.apply(pool, "제주", AdjacentRegionMap::neighbors, false, 3);
         assertThat(r.candidates()).hasSize(2);
         assertThat(r.expansionUsed()).isFalse();
         assertThat(r.exactCount()).isEqualTo(2);
@@ -38,7 +38,7 @@ class RegionCandidateExpansionTest {
                 g(1L, "강릉"),
                 g(2L, "속초")
         );
-        RegionCandidateExpansion.Result r = RegionCandidateExpansion.apply(pool, "강릉");
+        RegionCandidateExpansion.Result r = RegionCandidateExpansion.apply(pool, "강릉", AdjacentRegionMap::neighbors, false, 3);
         assertThat(r.candidates()).hasSize(2);
         assertThat(r.expansionUsed()).isTrue();
     }
@@ -49,9 +49,22 @@ class RegionCandidateExpansionTest {
                 g(1L, "대구"),
                 g(2L, "구미")
         );
-        RegionCandidateExpansion.Result r = RegionCandidateExpansion.apply(pool, "대구");
+        RegionCandidateExpansion.Result r = RegionCandidateExpansion.apply(pool, "대구", AdjacentRegionMap::neighbors, false, 3);
         assertThat(r.candidates()).hasSize(2);
         assertThat(r.expansionUsed()).isTrue();
+    }
+
+    @Test
+    void apply_should_not_expand_when_exact_is_enough_for_topN() {
+        List<GuideRecommendRequest.GuideCandidateDto> pool = List.of(
+                g(1L, "부산"),
+                g(2L, "부산"),
+                g(3L, "울산")
+        );
+        RegionCandidateExpansion.Result r = RegionCandidateExpansion.apply(pool, "부산", AdjacentRegionMap::neighbors, false, 2);
+        assertThat(r.candidates()).hasSize(2);
+        assertThat(r.expansionUsed()).isFalse();
+        assertThat(r.exactCount()).isEqualTo(2);
     }
 
     private static GuideRecommendRequest.GuideCandidateDto g(long id, String region) {


### PR DESCRIPTION
## Summary
- 정확 지역 후보가 TopN 기준으로 충분하면 인접 지역 확장을 하지 않도록 조정했습니다.
- `excludedActivityTags`가 후보 카드(소개/키워드/피드/경력/태그 등)에 강하게 드러나면 LLM rank 입력 풀에서 우선 제거합니다(전부 제거되면 원본 유지).

## 변경 범위
- `module-ai`
  - `RegionCandidateExpansion`: TopN 기준 확장 판단 오버로드 추가
  - `PromptRecommendationService`: 인접 확장에 TopN 전달 + LLM rank 풀 excluded 하드 필터
  - tests: `RegionCandidateExpansionTest`, `PromptRecommendationServiceTest`

## 스키마 영향
- 없음

## 검증
- `./gradlew :module-ai:test :module-openai:test`

Closes #513

Made with [Cursor](https://cursor.com)