### PR TITLE
Feat/be#517: 페이징 API 추가

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,11 +6,6 @@
   <component name="ChangeListManager">
     <list default="true" id="84d1b3de-8103-452e-83cf-38ecd34993e7" name="Changes" comment="Feat/fe#453: redis, mongodb 분리">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/backend/api-server/build.gradle" beforeDir="false" afterPath="$PROJECT_DIR$/backend/api-server/build.gradle" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/backend/api-server/src/main/java/com/team6/apiserver/logging/MdcLoggingFilter.java" beforeDir="false" afterPath="$PROJECT_DIR$/backend/api-server/src/main/java/com/team6/apiserver/logging/MdcLoggingFilter.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/backend/api-server/src/main/resources/logback-spring.xml" beforeDir="false" afterPath="$PROJECT_DIR$/backend/api-server/src/main/resources/logback-spring.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/backend/build.gradle" beforeDir="false" afterPath="$PROJECT_DIR$/backend/build.gradle" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/backend/docs/BACKEND_MATCHING.md" beforeDir="false" afterPath="$PROJECT_DIR$/backend/docs/BACKEND_MATCHING.md" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -61,12 +56,12 @@
     &quot;assignee&quot;: &quot;jjang0617&quot;
   }
 }</component>
-  <component name="GithubPullRequestsUISettings"><![CDATA[{
-  "selectedUrlAndAccountId": {
-    "url": "https://github.com/changhyunmoon/LocalGuest.git",
-    "accountId": "183f6da5-454f-4b08-95a4-31032f49ef56"
+  <component name="GithubPullRequestsUISettings">{
+  &quot;selectedUrlAndAccountId&quot;: {
+    &quot;url&quot;: &quot;https://github.com/changhyunmoon/LocalGuest.git&quot;,
+    &quot;accountId&quot;: &quot;183f6da5-454f-4b08-95a4-31032f49ef56&quot;
   }
-}]]></component>
+}</component>
   <component name="KubernetesApiPersistence">{}</component>
   <component name="KubernetesApiProvider">{
   &quot;isMigrated&quot;: true
@@ -159,6 +154,7 @@
       <workItem from="1776780245318" duration="3710000" />
       <workItem from="1776940610378" duration="262000" />
       <workItem from="1776996988492" duration="2173000" />
+      <workItem from="1777040469806" duration="59000" />
     </task>
     <task id="LOCAL-00001" summary="Feat/be#417: 모니터링 배포 테스트">
       <option name="closed" value="true" />

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/controller/MatchRequestController.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/controller/MatchRequestController.java
@@ -13,6 +13,7 @@ import com.team6.domain.matching.service.MatchRequestService;
 import com.team6.domain.matching.support.MatchingAuthenticationSupport;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -49,6 +50,16 @@ public class MatchRequestController {
     public ResponseEntity<List<MatchRequestCreateResponse>> getGuestRequests() {
         Long guestId = matchingAuthenticationSupport.getCurrentGuestMemberId();
         return ResponseEntity.ok(matchRequestService.getGuestRequests(guestId));
+    }
+
+    /** 게스트 본인 매칭 요청 페이징 조회 (기존 /guest/list 하위호환 유지용 신규 경로). */
+    @GetMapping("/guest/list/paged")
+    public ResponseEntity<Page<MatchRequestCreateResponse>> getGuestRequestsPaged(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        Long guestId = matchingAuthenticationSupport.getCurrentGuestMemberId();
+        return ResponseEntity.ok(matchRequestService.getGuestRequestsPaged(guestId, page, size));
     }
 
     /** 가이드 본인 매칭 요청 목록 — 경로는 {@code /guide/list} (게스트 {@code /guest/list} 와 대칭). */

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/repository/MatchRequestRepository.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/repository/MatchRequestRepository.java
@@ -2,6 +2,8 @@ package com.team6.domain.matching.repository;
 
 import com.team6.domain.matching.entity.MatchRequest;
 import com.team6.domain.matching.entity.enums.MatchRequestStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,6 +15,9 @@ public interface MatchRequestRepository extends JpaRepository<MatchRequest, Long
 
     // 게스트 ID로 전체 매칭 요청 조회
     List<MatchRequest> findByGuestId(Long guestId);
+
+    // 게스트 ID로 페이징 조회
+    Page<MatchRequest> findByGuestId(Long guestId, Pageable pageable);
 
     // 가이드 ID로 전체 매칭 요청 조회
     List<MatchRequest> findByGuideId(Long guideId);

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/service/MatchRequestService.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/service/MatchRequestService.java
@@ -17,6 +17,10 @@ import com.team6.domain.matching.exception.MatchingException;
 import com.team6.domain.matching.repository.MatchRequestRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -79,6 +83,20 @@ public class MatchRequestService {
                 .peek(request -> syncTourProgress(request, today))
                 .map(MatchRequestCreateResponse::from)
                 .toList();
+    }
+
+    /** 게스트 본인 매칭 요청 페이징 조회 (안전한 전환을 위해 기존 전체 조회 API와 분리 제공) */
+    public Page<MatchRequestCreateResponse> getGuestRequestsPaged(Long guestId, int page, int size) {
+        int normalizedPage = Math.max(page, 0);
+        int normalizedSize = Math.min(Math.max(size, 1), 100);
+        Pageable pageable = PageRequest.of(normalizedPage, normalizedSize, Sort.by(Sort.Direction.DESC, "createdAt"));
+        LocalDate today = LocalDate.now();
+
+        return matchRequestRepository.findByGuestId(guestId, pageable)
+                .map(request -> {
+                    syncTourProgress(request, today);
+                    return MatchRequestCreateResponse.from(request);
+                });
     }
 
     // 가이드의 매칭 요청 목록 조회

--- a/stress-test/scripts/matching-guest-list-test.js‎
+++ b/stress-test/scripts/matching-guest-list-test.js‎
@@ -1,0 +1,38 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+const BASE = __ENV.BASE_URL || 'https://api.bam-match.com/api';
+const TOKEN = __ENV.TOKEN;
+
+export const options = {
+  stages: [
+    // 2분 동안 동시 사용자 50명까지 점진 증가
+    { duration: '2m', target: 50 },
+    // 다음 3분 동안 동시 사용자 100명까지 증가
+    { duration: '3m', target: 100 },
+    // 다음 3분 동안 동시 사용자 200명까지 증가(최대 부하)
+    { duration: '3m', target: 200 },
+    // 마지막 2분 동안 동시 사용자 0명으로 감소(정리 구간)
+    { duration: '2m', target: 0 },
+  ],
+  thresholds: {
+    http_req_failed: ['rate<0.05'],
+    http_req_duration: ['p(95)<1000'],
+  },
+};
+
+export default function () {
+  if (!TOKEN) {
+    throw new Error('TOKEN is required. Set env var TOKEN');
+  }
+
+  const res = http.get(`${BASE}/matching/requests/guest/list`, {
+    headers: { Authorization: `Bearer ${TOKEN}` },
+  });
+
+  check(res, {
+    'status is 200': (r) => r.status === 200,
+  });
+
+  sleep(1);
+}


### PR DESCRIPTION
# 🔗 이슈 번호
- Closes #517 

---

## 💡 주요 변경 사항
- 기존 API 유지: `GET /matching/requests/guest/list` (응답 타입 변경 없음)
- 신규 API 추가: `GET /matching/requests/guest/list/paged?page={page}&size={size}`
- Repository 확장: `findByGuestId(Long guestId, Pageable pageable)`
- Service 확장: `getGuestRequestsPaged(...)`
  - `page < 0` 방지
  - `size` 범위 제한(1~100)
  - 정렬 고정: `createdAt DESC`
- Controller에 페이징 엔드포인트 추가 및 인증 주체(guestId) 흐름 유지

---

## ⚠️ 주의 사항 / 질문
- 현재는 **guest/list만** 페이징 적용, `guide/list`는 후속 PR로 동일 패턴 적용 예정
- 신규 경로(`/paged`) 방식으로 배포해 하위호환을 유지함
- 프론트 전환 완료 후 기존 전체조회 API 유지/제거 정책 합의 필요
- 
---
