### PR TITLE
Feat/be#521: guest list 조회 DTO Projection 적용 및 표준화 성능 재실험

### DIFF
--- a/backend/module-domain/src/main/java/com/team6/domain/matching/controller/MatchRequestController.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/controller/MatchRequestController.java
@@ -76,6 +76,19 @@ public class MatchRequestController {
         return ResponseEntity.ok(matchRequestService.getGuestRequestsSlice(guestId, page, size));
     }
 
+    /**
+     * 게스트 본인 매칭 요청 Slice 조회 (DTO projection).
+     * 기존 API 동작은 유지하고, 성능 비교를 위한 별도 경로를 제공한다.
+     */
+    @GetMapping("/guest/list/slice-projected")
+    public ResponseEntity<Slice<MatchRequestCreateResponse>> getGuestRequestsSliceProjected(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        Long guestId = matchingAuthenticationSupport.getCurrentGuestMemberId();
+        return ResponseEntity.ok(matchRequestService.getGuestRequestsSliceProjected(guestId, page, size));
+    }
+
     /** 가이드 본인 매칭 요청 목록 — 경로는 {@code /guide/list} (게스트 {@code /guest/list} 와 대칭). */
     @GetMapping("/guide/list")
     public ResponseEntity<List<MatchRequestCreateResponse>> getGuideRequests() {

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/dto/response/MatchRequestCreateResponse.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/dto/response/MatchRequestCreateResponse.java
@@ -54,4 +54,24 @@ public class MatchRequestCreateResponse {
                 .createdAt(entity.getCreatedAt())
                 .build();
     }
+
+    public static MatchRequestCreateResponse fromProjection(MatchRequestListProjection projection) {
+        return MatchRequestCreateResponse.builder()
+                .requestId(projection.getRequestId())
+                .guestId(projection.getGuestId())
+                .guideId(projection.getGuideId())
+                .guideScheduleId(projection.getGuideScheduleId())
+                .destination(projection.getDestination())
+                .concept(projection.getConcept())
+                .conceptSummary(projection.getConceptSummary())
+                .desiredDate(projection.getDesiredDate())
+                .desiredBudget(projection.getDesiredBudget())
+                .budgetMinWon(projection.getBudgetMinWon())
+                .budgetMaxWon(projection.getBudgetMaxWon())
+                .proposedSchedule(projection.getProposedSchedule())
+                .proposeMessage(projection.getProposeMessage())
+                .status(projection.getStatus() == null ? null : projection.getStatus().name())
+                .createdAt(projection.getCreatedAt())
+                .build();
+    }
 }

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/dto/response/MatchRequestListProjection.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/dto/response/MatchRequestListProjection.java
@@ -1,0 +1,28 @@
+package com.team6.domain.matching.dto.response;
+
+import com.team6.domain.matching.entity.enums.MatchRequestStatus;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * 목록 조회 성능 최적화를 위한 read-only projection.
+ * 필요한 컬럼만 선택해 엔티티 전체 로딩 비용을 줄인다.
+ */
+public interface MatchRequestListProjection {
+    Long getRequestId();
+    Long getGuestId();
+    Long getGuideId();
+    Long getGuideScheduleId();
+    String getDestination();
+    String getConcept();
+    String getConceptSummary();
+    LocalDate getDesiredDate();
+    Integer getDesiredBudget();
+    Integer getBudgetMinWon();
+    Integer getBudgetMaxWon();
+    String getProposedSchedule();
+    String getProposeMessage();
+    MatchRequestStatus getStatus();
+    LocalDateTime getCreatedAt();
+}

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/repository/MatchRequestRepository.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/repository/MatchRequestRepository.java
@@ -1,6 +1,7 @@
 package com.team6.domain.matching.repository;
 
 import com.team6.domain.matching.entity.MatchRequest;
+import com.team6.domain.matching.dto.response.MatchRequestListProjection;
 import com.team6.domain.matching.entity.enums.MatchRequestStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -22,6 +23,30 @@ public interface MatchRequestRepository extends JpaRepository<MatchRequest, Long
 
     // 게스트 ID로 Slice 기반 페이징 조회 (COUNT 쿼리 회피용)
     Slice<MatchRequest> findSliceByGuestId(Long guestId, Pageable pageable);
+
+    // 게스트 ID로 DTO projection + Slice 조회 (필요 컬럼만 선택)
+    @Query("""
+            SELECT
+              mr.id AS requestId,
+              mr.guestId AS guestId,
+              mr.guideId AS guideId,
+              mr.guideScheduleId AS guideScheduleId,
+              mr.destination AS destination,
+              mr.concept AS concept,
+              mr.conceptSummary AS conceptSummary,
+              mr.desiredDate AS desiredDate,
+              mr.desiredBudget AS desiredBudget,
+              mr.budgetMinWon AS budgetMinWon,
+              mr.budgetMaxWon AS budgetMaxWon,
+              mr.proposedSchedule AS proposedSchedule,
+              mr.proposeMessage AS proposeMessage,
+              mr.status AS status,
+              mr.createdAt AS createdAt
+            FROM MatchRequest mr
+            WHERE mr.guestId = :guestId
+            ORDER BY mr.createdAt DESC
+            """)
+    Slice<MatchRequestListProjection> findGuestListProjectionSliceByGuestId(@Param("guestId") Long guestId, Pageable pageable);
 
     // 가이드 ID로 전체 매칭 요청 조회
     List<MatchRequest> findByGuideId(Long guideId);

--- a/backend/module-domain/src/main/java/com/team6/domain/matching/service/MatchRequestService.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/matching/service/MatchRequestService.java
@@ -11,6 +11,7 @@ import com.team6.domain.matching.dto.request.MatchRequestDeclineRequest;
 import com.team6.domain.matching.dto.request.MatchRequestProposeRequest;
 import com.team6.domain.matching.dto.response.MatchRequestCreateResponse;
 import com.team6.domain.matching.dto.response.MatchRequestActionResponse;
+import com.team6.domain.matching.dto.response.MatchRequestListProjection;
 import com.team6.domain.matching.entity.MatchRequest;
 import com.team6.domain.matching.exception.MatchingErrorCode;
 import com.team6.domain.matching.exception.MatchingException;
@@ -116,6 +117,17 @@ public class MatchRequestService {
                     syncTourProgress(request, today);
                     return MatchRequestCreateResponse.from(request);
                 });
+    }
+
+    /** 게스트 본인 매칭 요청 Slice 조회 (DTO projection 적용). */
+    @Transactional(readOnly = true)
+    public Slice<MatchRequestCreateResponse> getGuestRequestsSliceProjected(Long guestId, int page, int size) {
+        int normalizedPage = Math.max(page, 0);
+        int normalizedSize = Math.min(Math.max(size, 1), 100);
+        Pageable pageable = PageRequest.of(normalizedPage, normalizedSize);
+
+        return matchRequestRepository.findGuestListProjectionSliceByGuestId(guestId, pageable)
+                .map(MatchRequestCreateResponse::fromProjection);
     }
 
     // 가이드의 매칭 요청 목록 조회

--- a/stress-test/scripts/matching-guest-list-rps-standardized-test.js
+++ b/stress-test/scripts/matching-guest-list-rps-standardized-test.js
@@ -1,0 +1,61 @@
+import http from 'k6/http';
+import { check } from 'k6';
+import { Counter, Rate } from 'k6/metrics';
+
+const BASE = __ENV.BASE_URL || 'https://api.bam-match.com/api';
+const TOKEN = __ENV.TOKEN;
+const ENDPOINT = __ENV.ENDPOINT || '/matching/requests/guest/list/slice-projected?page=0&size=20';
+const RATE = Number(__ENV.RATE || 160);
+const DURATION = __ENV.DURATION || '10m';
+
+const status2xx = new Counter('status_2xx');
+const status4xx = new Counter('status_4xx');
+const status5xx = new Counter('status_5xx');
+const status401 = new Counter('status_401');
+const status403 = new Counter('status_403');
+const status404 = new Counter('status_404');
+const status429 = new Counter('status_429');
+const okRate = new Rate('status_200_rate');
+
+export const options = {
+  scenarios: {
+    guest_list_fixed_rps_standardized: {
+      executor: 'constant-arrival-rate',
+      rate: RATE,
+      timeUnit: '1s',
+      duration: DURATION,
+      preAllocatedVUs: 120,
+      maxVUs: 500,
+    },
+  },
+  // 실험 재현성을 위해 핵심 통계값을 고정 출력한다.
+  summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(90)', 'p(95)', 'p(99)'],
+  thresholds: {
+    http_req_failed: ['rate<0.05'],
+    http_req_duration: ['p(95)<1000', 'p(99)<2000'],
+  },
+};
+
+export default function () {
+  if (!TOKEN) {
+    throw new Error('TOKEN is required. Set env var TOKEN');
+  }
+
+  const res = http.get(`${BASE}${ENDPOINT}`, {
+    headers: { Authorization: `Bearer ${TOKEN}` },
+    tags: { endpoint: ENDPOINT },
+  });
+
+  if (res.status >= 200 && res.status < 300) status2xx.add(1);
+  if (res.status >= 400 && res.status < 500) status4xx.add(1);
+  if (res.status >= 500) status5xx.add(1);
+  if (res.status === 401) status401.add(1);
+  if (res.status === 403) status403.add(1);
+  if (res.status === 404) status404.add(1);
+  if (res.status === 429) status429.add(1);
+  okRate.add(res.status === 200);
+
+  check(res, {
+    'status is 200': (r) => r.status === 200,
+  });
+}

--- a/stress-test/scripts/run-matching-guest-list-standardized-3x.sh
+++ b/stress-test/scripts/run-matching-guest-list-standardized-3x.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_NAME="${SCRIPT_NAME:-matching-guest-list-rps-standardized-test.js}"
+RATE="${RATE:-160}"
+DURATION="${DURATION:-10m}"
+ENDPOINT="${ENDPOINT:-/matching/requests/guest/list/slice-projected?page=0&size=20}"
+RUNS="${RUNS:-3}"
+
+if [[ -z "${TOKEN:-}" ]]; then
+  echo "TOKEN is required. Export TOKEN first."
+  exit 1
+fi
+
+if [[ -z "${BASE_URL:-}" ]]; then
+  echo "BASE_URL is required. Export BASE_URL first."
+  exit 1
+fi
+
+echo "== Standardized experiment =="
+echo "SCRIPT_NAME=${SCRIPT_NAME}"
+echo "RATE=${RATE}, DURATION=${DURATION}, ENDPOINT=${ENDPOINT}, RUNS=${RUNS}"
+echo
+
+for i in $(seq 1 "${RUNS}"); do
+  echo "---- Run ${i}/${RUNS} ----"
+  RATE="${RATE}" DURATION="${DURATION}" ENDPOINT="${ENDPOINT}" \
+    k6 run "${SCRIPT_NAME}" --summary-export "result-${i}.json"
+done
+
+python3 - <<'PY'
+import json
+import math
+import statistics
+
+runs = []
+i = 1
+while True:
+    name = f"result-{i}.json"
+    try:
+        with open(name, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except FileNotFoundError:
+        break
+    metrics = data.get("metrics", {})
+    duration = metrics.get("http_req_duration", {})
+    failed = metrics.get("http_req_failed", {})
+    dropped = metrics.get("dropped_iterations", {})
+    vus = metrics.get("vus_max", {})
+
+    run = {
+        "run": i,
+        "avg_ms": duration.get("avg"),
+        "p95_ms": duration.get("p(95)"),
+        "p99_ms": duration.get("p(99)"),
+        "failed_rate": failed.get("rate"),
+        "dropped": dropped.get("count", 0),
+        "max_vus": vus.get("max"),
+    }
+    runs.append(run)
+    i += 1
+
+if not runs:
+    print("No result-*.json files found.")
+    raise SystemExit(1)
+
+def mean_std(key):
+    vals = [r[key] for r in runs if r[key] is not None]
+    if not vals:
+        return None, None
+    mean = statistics.mean(vals)
+    std = statistics.pstdev(vals) if len(vals) > 1 else 0.0
+    return mean, std
+
+print("\n== Per-run metrics ==")
+for r in runs:
+    print(
+        f"run={r['run']}, avg={r['avg_ms']:.2f}ms, p95={r['p95_ms']:.2f}ms, "
+        f"p99={r['p99_ms']:.2f}ms, failed_rate={r['failed_rate']:.4f}, "
+        f"dropped={r['dropped']}, max_vus={r['max_vus']}"
+    )
+
+print("\n== Aggregated (mean ± std) ==")
+for key, label, scale in [
+    ("avg_ms", "avg_ms", 1.0),
+    ("p95_ms", "p95_ms", 1.0),
+    ("p99_ms", "p99_ms", 1.0),
+    ("failed_rate", "failed_rate", 1.0),
+    ("dropped", "dropped_iterations", 1.0),
+    ("max_vus", "max_vus", 1.0),
+]:
+    m, s = mean_std(key)
+    if m is None:
+        continue
+    print(f"{label}: {m*scale:.4f} ± {s*scale:.4f}")
+PY
+
+echo
+echo "Done. result-*.json files were generated."


### PR DESCRIPTION
# 🔗 이슈 번호
- Closes #521 

---
## 💡 주요 변경 사항
- 게스트 요청 목록 조회에 DTO Projection 적용
  - Projection 인터페이스 추가
  - Repository에 필요한 컬럼만 조회하는 Slice 쿼리 추가
  - Service/Controller에 projection 기반 조회 경로 추가
- 기존 API 하위호환 유지
  - 기존 `list`, `paged`, `slice` 경로 동작 변경 없음
  - 비교 실험용 `slice-projected` 경로 추가
- 성능 재실험 표준화 스크립트 추가
  - `matching-guest-list-rps-standardized-test.js`
  - `run-matching-guest-list-standardized-3x.sh` (3회 반복 + 평균/편차 집계)
---
## ⚠️ 주의 사항 / 질문
- 성능 비교 시 반드시 `BASE_URL`, `TOKEN`, `RATE`, `DURATION` 동일 조건 유지 필요
- endpoint만 교체해서 `page/slice/slice-projected` 순차 비교 권장
- `http_req_failed`가 높으면 latency 비교 왜곡 가능 (401/403/429/5xx 먼저 확인 필요)
---
## ✅ 체크리스트
- [x] 빌드가 정상적으로 되는가?
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [x] .gitignore에 설정 파일이 잘 포함되었는가? (application-local.yml 등)