### PR TITLE
[Feat/be#527] 배포 messages 오류: domain→chat 내부 호출 base URL 설정화

### DIFF
--- a/backend/module-domain/src/main/java/com/team6/domain/chat/controller/ChatOrchestrationController.java
+++ b/backend/module-domain/src/main/java/com/team6/domain/chat/controller/ChatOrchestrationController.java
@@ -6,12 +6,12 @@ import com.team6.domain.member.repository.MemberRepository;
 import com.team6.module.common.global.util.SecurityUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.server.ResponseStatusException;
-import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.util.*;
 import java.util.regex.Matcher;
@@ -31,6 +31,12 @@ public class ChatOrchestrationController {
     private final MemberRepository memberRepository;
     private final RestTemplate restTemplate = new RestTemplate();
 
+    @Value("${matching.chat.base-url:http://localhost:8080}")
+    private String chatBaseUrl;
+
+    @Value("${matching.chat.context-path:${server.servlet.context-path:/api}}")
+    private String chatContextPath;
+
     private static final Pattern DM_GUIDE_TITLE = Pattern.compile("^LG-DM-GUIDE-(\\d+)$");
 
     /**
@@ -43,7 +49,7 @@ public class ChatOrchestrationController {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Authorization 헤더가 없습니다.");
         }
 
-        String base = ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString();
+        String base = chatApiBase();
         Map<String, Object> raw = fetchRooms(base, auth);
         Object roomsObj = raw.get("rooms");
         if (!(roomsObj instanceof List<?> rooms)) {
@@ -97,7 +103,7 @@ public class ChatOrchestrationController {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Authorization 헤더가 없습니다.");
         }
 
-        String base = ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString();
+        String base = chatApiBase();
         Map<String, Object> existing = findRoomByTitle(base, auth, title);
         if (existing != null) {
             return ResponseEntity.ok(existing);
@@ -105,6 +111,18 @@ public class ChatOrchestrationController {
 
         Map<String, Object> created = createRoom(base, auth, title, List.of(guideEmail));
         return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    }
+
+    private String chatApiBase() {
+        String b = (chatBaseUrl == null ? "" : chatBaseUrl.trim()).replaceAll("/+$", "");
+        String ctx = chatContextPath == null ? "" : chatContextPath.trim();
+        if (ctx.isEmpty() || "/".equals(ctx)) {
+            return b;
+        }
+        if (!ctx.startsWith("/")) {
+            ctx = "/" + ctx;
+        }
+        return b + ctx.replaceAll("/+$", "");
     }
 
     private Map<String, Object> fetchRooms(String base, String auth) {


### PR DESCRIPTION
## 원인
- PR #294에서 `module-domain`의 `ChatOrchestrationController`가 `module-chat` REST(`/chat/rooms`)를 **HTTP로 내부 호출**하도록 추가되었습니다.
- 당시 구현은 `ServletUriComponentsBuilder.fromCurrentContextPath()`로 **현재 요청 기반 base URL**을 만들고 `base + /chat/rooms`를 호출했습니다.
- 배포 환경(리버스 프록시/HTTPS 종료/forwarded headers/컨텍스트패스 `/api`)에서는 이 base URL이 잘못 구성될 수 있어,
  내부 호출이 404/5xx/연결 실패로 이어지고 `/messages` 화면에서 `SERVER_ERROR`로 표출될 수 있습니다.

## 조치
- 내부 호출 base URL을 **요청 기반 → 설정 기반**으로 고정했습니다.
- 아래 설정으로 채팅 API 대상 URL을 구성합니다.
  - `matching.chat.base-url` (default: `http://localhost:8080`)
  - `matching.chat.context-path` (default: `${server.servlet.context-path:/api}`)
- 결과적으로 배포에서도 프록시/도메인/프로토콜에 흔들리지 않고 동일한 내부 호출 URL을 사용합니다.

## 운영 적용 방법
- 배포 환경의 설정(예: `application-prod.yml` 또는 환경변수)에 아래 값을 지정하세요.
  - 예시(같은 서버라면):
    - `matching.chat.base-url: https://bam-match.com`
    - `matching.chat.context-path: /api`

## 변경 범위
- `module-domain`
  - `ChatOrchestrationController`: chat 내부 호출 base URL 구성 방식 변경

## 스키마 영향
- 없음

## 검증
- `./gradlew :module-domain:compileJava :api-server:compileJava`

Closes #527

Made with [Cursor](https://cursor.com)