### PR TITLE
[Feat/fe#529] 피드 채팅 버튼 숨김 + AI 드래프트 뒤로가기 유지

### DIFF
--- a/frontend/src/pages/AiQuickSearchPage.jsx
+++ b/frontend/src/pages/AiQuickSearchPage.jsx
@@ -611,6 +611,7 @@ export function AiQuickSearchPage() {
                                     <span className="ais-polaroid-pin" aria-hidden />
                                     <Link
                                       to={`/guides/${g.guideId}`}
+                                      state={{ returnTo: '/ai-search' }}
                                       className="ais-polaroid-link"
                                       onClick={() => onClickGuideDetail(g.guideId, idx + 1)}
                                     >
@@ -696,6 +697,7 @@ export function AiQuickSearchPage() {
                                       <Link
                                         key={f.feedId}
                                         to={`/guides/${g.guideId}`}
+                                        state={{ returnTo: '/ai-search' }}
                                         className="ais-feed-thumb"
                                         title={f.content ? String(f.content).slice(0, 80) : '가이드 상세보기'}
                                         onClick={() => onClickGuideDetail(g.guideId, rank)}
@@ -710,6 +712,7 @@ export function AiQuickSearchPage() {
                                   ) : (
                                     <Link
                                       to={`/guides/${g.guideId}`}
+                                      state={{ returnTo: '/ai-search' }}
                                       className="ais-feed-empty"
                                       title="가이드 상세보기"
                                       onClick={() => onClickGuideDetail(g.guideId, rank)}

--- a/frontend/src/pages/GuideDetailPage.jsx
+++ b/frontend/src/pages/GuideDetailPage.jsx
@@ -694,7 +694,23 @@ export function GuideDetailPage() {
             ← 상세 코스로 돌아가기
           </button>
         ) : (
-          <Link to="/guides">← 목록</Link>
+          <button
+            type="button"
+            className="gdp-back-btn"
+            onClick={() => {
+              if (returnTo) {
+                navigate(returnTo)
+                return
+              }
+              if (window.history.length > 1) {
+                navigate(-1)
+                return
+              }
+              navigate('/guides')
+            }}
+          >
+            ← 목록
+          </button>
         )}
       </p>
 

--- a/frontend/src/pages/GuideDetailPage.jsx
+++ b/frontend/src/pages/GuideDetailPage.jsx
@@ -251,7 +251,8 @@ export function GuideDetailPage() {
       // 목적지는 사용자가 비워둔 경우에만 보조로 채운다.
       if (!destination.trim() && draft?.destination) setDestination(String(draft.destination).trim())
 
-      sessionStorage.removeItem('localguest_ai_match_draft_v1')
+      // 뒤로가기/피드 탐색 후 재진입 시에도 AI 예산·기간 힌트를 유지하기 위해
+      // 매칭 요청 성공 시점에만 정리한다.
     } catch {
       /* ignore */
     }
@@ -528,6 +529,11 @@ export function GuideDetailPage() {
       }
       const data = t ? JSON.parse(t) : {}
       const rid = data?.requestId
+      try {
+        sessionStorage.removeItem('localguest_ai_match_draft_v1')
+      } catch {
+        /* ignore */
+      }
       navigate('/mypage/itinerary', {
         replace: false,
         state: {

--- a/frontend/src/pages/GuideFeedTourPage.jsx
+++ b/frontend/src/pages/GuideFeedTourPage.jsx
@@ -182,9 +182,6 @@ export function GuideFeedTourPage() {
     )
   }
 
-  const chatTo = isAuthenticated ? '/messages' : '/auth/login'
-  const chatState = isAuthenticated ? undefined : { returnTo: `/guides/${guideId}/feeds/${feedId}`, hint: '채팅은 로그인 후 이용할 수 있어요.' }
-
   return (
     <div className="gft gft--journal">
       <button type="button" className="gft-back" onClick={() => goBack()}>
@@ -279,9 +276,6 @@ export function GuideFeedTourPage() {
       </div>
 
       <div className="gft-actions">
-        <Link to={chatTo} state={chatState} className="gft-btn gft-btn--line">
-          💬 1:1 채팅하기
-        </Link>
         <Link
           to={isAuthenticated ? `/guides/${guideId}#match-request` : '/auth/login'}
           state={


### PR DESCRIPTION
## 이슈
Closes #529

## 변경 사항
- 피드 상세(`GuideFeedTourPage`): 결제 전 흐름에서는 **1:1 채팅하기 버튼 제거**
- 가이드 상세(`GuideDetailPage`): AI 검색에서 저장된 `localguest_ai_match_draft_v1`를 **즉시 삭제하지 않고 유지**하여, 피드↔가이드 상세 이동/뒤로가기에도 예산·기간 힌트가 초기화되지 않음
  - 매칭 요청 성공(POST /matching/requests) 시점에만 드래프트 정리

## 검증
- `cd frontend && npm run build`

Made with [Cursor](https://cursor.com)