### PR TITLE
[Feat/fe#535] 매칭 요청 관리 '기타'를 '완료'로 변경

### DIFF
--- a/frontend/src/pages/GuideInboxPage.jsx
+++ b/frontend/src/pages/GuideInboxPage.jsx
@@ -238,7 +238,7 @@ export function GuideInboxPage() {
     if (extensionRows.length > 0) {
       mainSections.unshift({ key: 'EXTENSION', label: '연장 요청', statuses: [], rows: extensionRows })
     }
-    if (others.length > 0) mainSections.push({ key: 'OTHER', label: '기타', statuses: [], rows: others })
+    if (others.length > 0) mainSections.push({ key: 'OTHER', label: '완료', statuses: [], rows: others })
     if (rejectedSection?.rows.length) mainSections.push(rejectedSection)
     return mainSections
   }, [rows, extensionsByRequestId])


### PR DESCRIPTION
## 이슈
Closes #535

## 변경 사항
- 가이드 매칭 요청 관리(/guide/inbox) 섹션 라벨 **'기타' → '완료'**

## 검증
- `cd frontend && npm run build`

Made with [Cursor](https://cursor.com)