### PR TITLE
[Feat/be#539] 시드 SQL UTF-8(utf8mb4) 연결 고정

### DIFF
--- a/scripts/db/dummy/local_minimal_reset_seed.sql
+++ b/scripts/db/dummy/local_minimal_reset_seed.sql
@@ -17,10 +17,14 @@
 --   payment 970001~, chat 983001~, 기타 보조 ID 아래 참고
 -- · MongoDB(chat_message 등)는 이 스크립트로 지우지 않음.
 -- · MySQL 8.0+
+-- · 한글 깨짐 방지: 클라이언트가 UTF-8로 보내야 함. 아래 중 하나 필수.
+--     mysql --default-character-set=utf8mb4 -h... -uroot -p local_guide_db < 이파일
+--   (또는 mysql 프롬프트에서 먼저 SET NAMES utf8mb4; 후 SOURCE)
 -- =============================================================================
 
 USE local_guide_db;
 
+SET NAMES utf8mb4;
 SET FOREIGN_KEY_CHECKS = 0;
 
 TRUNCATE TABLE chat_participants;


### PR DESCRIPTION
## 🔗 이슈 번호

Closes #539

## 💡 주요 변경 사항

- `SET NAMES utf8mb4` 추가로 이후 INSERT 한글이 올바른 문자셋으로 저장되도록 함
- 주석에 `mysql --default-character-set=utf8mb4 ...` 실행 예시 추가

## ⚠️ 주의 사항

- 이미 깨진 데이터는 **시드를 utf8mb4로 다시 실행**하거나 해당 컬럼만 수정해야 함

## ✅ 체크리스트

- [x] 해당 없음(코드 빌드) — SQL만 변경
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [x] 해당 없음(.gitignore)

Made with [Cursor](https://cursor.com)