### PR TITLE
[Feat/fe#541] 예정된 로컬 만남 → 가이드 프로필 시 상단 네비 유지

### DIFF
--- a/frontend/src/layouts/AppLayout.jsx
+++ b/frontend/src/layouts/AppLayout.jsx
@@ -26,10 +26,22 @@ function isGuidesMatchFlowPath(pathname) {
   return /^\/guides\/[^/]+\/match(?:\/|$)/.test(pathname)
 }
 
+/**
+ * `/guides/...?nav=itinerary` — 예정된 로컬 만남에서 연 가이드 상세·피드 등.
+ * 상단 탭은 "예정된 로컬 만남"을 유지하고 AI 검색은 끈다.
+ */
+function isItineraryNavShell(pathname, search) {
+  if (new URLSearchParams(search).get('nav') !== 'itinerary') return false
+  if (pathname === '/guides') return false
+  if (pathname.startsWith('/guides/') && !pathname.includes('/match')) return true
+  return false
+}
+
 /** 가이드 목록·상세 등 `/guides*` 는 메뉴에서 빠졌지만, 상단에서는 AI 검색 흐름으로 간주해 같은 탭을 켠다. */
-function isAiSearchShellActive(pathname, matchComplete, matchFlow) {
+function isAiSearchShellActive(pathname, search, matchComplete, matchFlow) {
   if (matchComplete) return false
   if (matchFlow) return false
+  if (isItineraryNavShell(pathname, search)) return false
   if (pathname === '/ai-search' || pathname.startsWith('/ai-search/')) return true
   if (pathname === '/guides' || pathname.startsWith('/guides/')) return true
   return false
@@ -43,6 +55,7 @@ function AppLayoutInner() {
   const guideMypageActive = isGuide && pathname.startsWith('/guide/mypage')
   const matchComplete = isGuidesMatchCompletePath(pathname)
   const matchFlow = isGuidesMatchFlowPath(pathname)
+  const shellItinerary = matchComplete || matchFlow || isItineraryNavShell(pathname, search)
   const focusMode = pathname.startsWith('/auth/signup') || pathname.startsWith('/onboarding')
   const baseTitleRef = useRef(typeof document !== 'undefined' ? document.title : 'LocalGuest')
 
@@ -76,7 +89,7 @@ function AppLayoutInner() {
           <NavLink
             to="/ai-search"
             className={({ isActive }) => {
-              const on = (isActive || isAiSearchShellActive(pathname, matchComplete, matchFlow)) && !matchComplete && !matchFlow
+              const on = (isActive || isAiSearchShellActive(pathname, search, matchComplete, matchFlow)) && !shellItinerary
               const parts = ['shell-pill-link', 'shell-pill-link--spark']
               if (on) parts.push('is-on')
               return parts.join(' ')
@@ -96,7 +109,7 @@ function AppLayoutInner() {
             <NavLink
               to="/mypage/itinerary"
               className={({ isActive }) => {
-                const on = isActive || matchComplete || matchFlow
+                const on = isActive || shellItinerary
                 const parts = ['shell-pill-link', 'shell-pill-link--cta']
                 if (on) parts.push('is-on')
                 return parts.join(' ')
@@ -128,7 +141,7 @@ function AppLayoutInner() {
               <NavLink
                 to={isGuide ? '/guide/mypage/profile' : '/mypage'}
                 className={({ isActive }) => {
-                  const on = isGuide ? guideMypageActive || matchComplete : isActive || matchComplete || matchFlow
+                  const on = isGuide ? guideMypageActive || matchComplete : isActive || shellItinerary
                   const parts = ['shell-btn', 'shell-btn--ghost']
                   if (on) parts.push('shell-btn--dark')
                   return parts.join(' ')

--- a/frontend/src/pages/GuestUpcomingTripsPage.jsx
+++ b/frontend/src/pages/GuestUpcomingTripsPage.jsx
@@ -279,12 +279,17 @@ export function GuestUpcomingTripsPage() {
       if (st === 'PAID' || st === 'IN_PROGRESS') {
         const qs = new URLSearchParams()
         qs.set('requestId', String(row.requestId))
+        qs.set('nav', 'itinerary')
         const pid = paymentIdByRequest[row.requestId]
         if (pid != null) qs.set('paymentId', String(pid))
         navigate(`/guides/${row.guideId}/match/complete?${qs.toString()}`)
         return
       }
-      navigate(`/guides/${row.guideId}/match`, { state: { requestId: row.requestId } })
+      navigate({
+        pathname: `/guides/${row.guideId}/match`,
+        search: 'nav=itinerary',
+        state: { requestId: row.requestId },
+      })
     },
     [navigate, paymentIdByRequest],
   )

--- a/frontend/src/pages/GuideDetailPage.jsx
+++ b/frontend/src/pages/GuideDetailPage.jsx
@@ -188,6 +188,8 @@ export function GuideDetailPage() {
   const location = useLocation()
   const navigate = useNavigate()
   const { isAuthenticated, isGuide } = useAuth()
+  const itineraryNav = new URLSearchParams(location.search).get('nav') === 'itinerary'
+  const itineraryQs = itineraryNav ? '?nav=itinerary' : ''
   const fromMatchedCourse = location.state?.fromMatchedCourse === true
   const hideMatchRequest = location.state?.hideMatchRequest === true
   const returnTo = typeof location.state?.returnTo === 'string' ? location.state.returnTo : ''
@@ -698,6 +700,10 @@ export function GuideDetailPage() {
             type="button"
             className="gdp-back-btn"
             onClick={() => {
+              if (itineraryNav) {
+                navigate('/mypage/itinerary')
+                return
+              }
               if (returnTo) {
                 navigate(returnTo)
                 return
@@ -800,7 +806,7 @@ export function GuideDetailPage() {
           </h2>
           <div className="gdp-feeds">
             {feeds.map((f) => {
-              const href = `/guides/${guideId}/feeds/${f.feedId}`
+              const href = `/guides/${guideId}/feeds/${f.feedId}${itineraryQs}`
               const bg = feedPrimaryImage(f)
               return (
                 <Link key={f.feedId} to={href} className="gdp-feed-card">
@@ -1126,7 +1132,7 @@ export function GuideDetailPage() {
         <LoginModal
           open={loginModalOpen}
           onClose={() => setLoginModalOpen(false)}
-          returnTo={`/guides/${guideId}#match-request`}
+          returnTo={`/guides/${guideId}${itineraryQs}#match-request`}
           hint="로그인 후 이 가이드에게 매칭 요청을 보낼 수 있어요."
           preferredRole="GUEST"
         />

--- a/frontend/src/pages/GuideFeedTourPage.jsx
+++ b/frontend/src/pages/GuideFeedTourPage.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { Link, useNavigate, useParams } from 'react-router-dom'
+import { Link, useLocation, useNavigate, useParams } from 'react-router-dom'
 
 import { PageEmpty, PageError, PageLoading } from '../components/PageStates.jsx'
 import { ReviewCarousel } from '../components/ReviewCarousel.jsx'
@@ -42,6 +42,9 @@ async function fetchJson(path, { skipAuth = true } = {}) {
 export function GuideFeedTourPage() {
   const { guideId, feedId } = useParams()
   const navigate = useNavigate()
+  const location = useLocation()
+  const itineraryNav = new URLSearchParams(location.search).get('nav') === 'itinerary'
+  const itineraryQs = itineraryNav ? '?nav=itinerary' : ''
   const { isAuthenticated } = useAuth()
   const [detail, setDetail] = useState(null)
   const [reviews, setReviews] = useState([])
@@ -143,8 +146,15 @@ export function GuideFeedTourPage() {
   const rc = profile?.reviewCount != null ? profile.reviewCount : 0
 
   const goBack = () => {
-    if (window.history.length > 1) navigate(-1)
-    else navigate('/ai-search')
+    if (window.history.length > 1) {
+      navigate(-1)
+      return
+    }
+    if (itineraryNav && guideId) {
+      navigate(`/guides/${guideId}${itineraryQs}`)
+      return
+    }
+    navigate('/ai-search')
   }
 
   if (loading) {
@@ -176,7 +186,7 @@ export function GuideFeedTourPage() {
         </button>
         <PageEmpty title="이 피드를 찾을 수 없습니다">
           삭제되었거나 주소가 바뀌었을 수 있어요.{' '}
-          <Link to={`/guides/${guideId}`}>가이드 프로필</Link>로 이동
+          <Link to={`/guides/${guideId}${itineraryQs}`}>가이드 프로필</Link>로 이동
         </PageEmpty>
       </div>
     )
@@ -204,7 +214,7 @@ export function GuideFeedTourPage() {
           {otherFeeds.map((f, i) => (
             <Link
               key={f.feedId}
-              to={`/guides/${guideId}/feeds/${f.feedId}`}
+              to={`/guides/${guideId}/feeds/${f.feedId}${itineraryQs}`}
               className={`gft-polaroid gft-polaroid--sm ${i === 0 ? 'gft-polaroid--tilt-l' : 'gft-polaroid--tilt-r'}`}
             >
               <span className={`gft-tape ${i === 0 ? 'gft-tape--g' : 'gft-tape--b'}`} aria-hidden />
@@ -277,12 +287,12 @@ export function GuideFeedTourPage() {
 
       <div className="gft-actions">
         <Link
-          to={isAuthenticated ? `/guides/${guideId}#match-request` : '/auth/login'}
+          to={isAuthenticated ? `/guides/${guideId}${itineraryQs}#match-request` : '/auth/login'}
           state={
             isAuthenticated
               ? { hint: '아래로 스크롤되면「매칭 요청 보내기」로 일정을 등록할 수 있어요.' }
               : {
-                  returnTo: `/guides/${guideId}#match-request`,
+                  returnTo: `/guides/${guideId}${itineraryQs}#match-request`,
                   hint: '로그인 후 달력이 있는 매칭 요청 섹션으로 이동해 이어갈 수 있어요.',
                 }
           }

--- a/frontend/src/pages/GuideMatchOptionsPage.jsx
+++ b/frontend/src/pages/GuideMatchOptionsPage.jsx
@@ -450,7 +450,7 @@ export function GuideMatchOptionsPage() {
   return (
     <div className="gmo">
       <div className="gmo-topbar">
-        <Link to={`/guides/${guideId}`} className="gmo-back gmo-back--pill">
+        <Link to={`/guides/${guideId}?nav=itinerary`} className="gmo-back gmo-back--pill">
           ← 가이드 프로필
         </Link>
         <Link to="/mypage/itinerary" className="gmo-back gmo-back--pill gmo-back--line">
@@ -697,7 +697,7 @@ export function GuideMatchOptionsPage() {
               ) : (
                 <div className="gmo-profile-dialog-feeds">
                   {modalFeeds.map((f) => {
-                    const href = `/guides/${guideId}/feeds/${f.feedId}`
+                    const href = `/guides/${guideId}/feeds/${f.feedId}?nav=itinerary`
                     const bg = feedPrimaryImage(f)
                     return (
                       <Link key={f.feedId} to={href} className="gmo-profile-dialog-feed" onClick={() => setProfileModalOpen(false)}>
@@ -732,7 +732,7 @@ export function GuideMatchOptionsPage() {
             </section>
 
             <p className="gmo-profile-dialog-footer">
-              <Link to={`/guides/${guideId}`} onClick={() => setProfileModalOpen(false)}>
+              <Link to={`/guides/${guideId}?nav=itinerary`} onClick={() => setProfileModalOpen(false)}>
                 전체 프로필 페이지로 이동 →
               </Link>
             </p>

--- a/frontend/src/pages/GuideMatchedCoursePage.jsx
+++ b/frontend/src/pages/GuideMatchedCoursePage.jsx
@@ -61,6 +61,8 @@ export function GuideMatchedCoursePage() {
 
   const requestId = searchParams.get('requestId')
   const paymentId = searchParams.get('paymentId')
+  const itineraryNav = searchParams.get('nav') === 'itinerary'
+  const guideProfileHref = itineraryNav ? `/guides/${guideId}?nav=itinerary` : `/guides/${guideId}`
 
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
@@ -253,7 +255,7 @@ export function GuideMatchedCoursePage() {
 
       {/* 가이드 프로필 헤더 (기존 유지) */}
       <Link
-        to={`/guides/${guideId}`}
+        to={guideProfileHref}
         state={{
           fromMatchedCourse: true,
           hideMatchRequest: true,


### PR DESCRIPTION
## 🔗 이슈 번호

Closes #541

## 💡 주요 변경 사항

- `?nav=itinerary` 쿼리로 **예정된 로컬 만남** 흐름임을 표시
- `AppLayout`: 해당 쿼리가 있고 경로가 `/guides/...` (단, `/match` 구간 제외)이면 **AI 검색** 탭 대신 **예정된 로컬 만남** 탭 활성
- 매칭 옵션·매칭 완료·일정 목록에서 가이드 상세/피드 링크에 쿼리 전달, 가이드 상세 `← 목록`은 `/mypage/itinerary`로 복귀

## ⚠️ 주의 사항

- AI 검색에서 연 `/guides/:id` 는 기존처럼 쿼리 없음 → AI 검색 탭 유지

## ✅ 체크리스트

- [x] `npm run build` (frontend) 성공
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [x] 해당 없음(.gitignore)

Made with [Cursor](https://cursor.com)