### PR TITLE
[Feat/fe#543] 스크랩북 여행 지도 마커 지오코딩 안정화

### DIFF
--- a/frontend/src/pages/MypageScrapbookPage.jsx
+++ b/frontend/src/pages/MypageScrapbookPage.jsx
@@ -105,12 +105,15 @@ export function MypageScrapbookPage() {
         if (cancelled || !overviewMapRef.current) return
 
         const dests = [...new Set(rows.map((r) => String(r.destination ?? '').trim()).filter(Boolean))].slice(0, 15)
-        const hint = dests[0] ?? ''
+        const geoQueries = dests
+          .map((d) => d.split(/\s+/)[0]?.trim() ?? '')
+          .filter(Boolean)
+        const hint = geoQueries[0] ?? ''
         const points =
-          dests.length > 0
+          geoQueries.length > 0
             ? await Promise.all(
-                dests.map(async (d, idx) => {
-                  const p = await resolveLatLng(kakao, d, { regionHint: hint || d })
+                geoQueries.map(async (q, idx) => {
+                  const p = await resolveLatLng(kakao, q, { regionHint: hint || q })
                   return (
                     p ?? {
                       lat: DEFAULT_KOREA_CENTER.lat + idx * 0.04,


### PR DESCRIPTION
## 🔗 이슈 번호

Closes #543

## 💡 주요 변경 사항

- 스크랩북 여행 지도에서 `destination` 전체(예: "여수 카페투어")를 그대로 지오코딩하지 않고, 지도용으로는 **도시명(첫 단어)**만 사용해 마커 좌표를 안정화
- 마커 title/카드 표시는 기존 destination을 유지

## ⚠️ 주의 사항

- 좌표를 DB에 저장하는 방식이 아니므로, 장소 단위(세부 스팟) 고정 좌표가 필요하면 `course_detail`의 `lat,lng` 포맷을 추가로 활용하는 개선이 필요함

## ✅ 체크리스트

- [x] `npm run build` (frontend) 성공
- [x] 컨벤션에 맞게 커밋 메시지를 작성했는가?
- [x] `.gitignore`에 설정 파일(비밀·로컬 전용)이 잘 제외되었는가? — 해당 없음

Made with [Cursor](https://cursor.com)